### PR TITLE
Add meta tags for twitter cards.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,5 @@ github_username:  rust-lang
 
 # Build settings
 markdown: kramdown
+
+root: http://blog.rust-lang.org

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,4 +8,15 @@
     <link rel="alternate" type="application/rss+xml" title="The Rust Programming Language Blog" href="http://blog.rust-lang.org/feed.xml" />
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@{{ site.twitter_username }}" />
+    <meta name="twitter:title" content="{{ page.title }}" />
+    {% if page.description %}
+    <meta name="twitter:description" content="{{ page.description }}" />
+    {% else %}
+    <meta name="twitter:description" content="{{ site.description }}" />
+    {% endif %}
+    <meta name="twitter:url" content="{{ site.root }}{{ page.url }}">
+
 </head>

--- a/_posts/2014-09-15-Rust-1.0.md
+++ b/_posts/2014-09-15-Rust-1.0.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Road to Rust 1.0"
 author: Niko Matsakis
+description: "Rust 1.0 is on its way! We have nailed down a concrete list of features and are hard at work on implementing them."
 ---
 
 Rust 1.0 is on its way! We have nailed down a concrete list of
@@ -170,4 +171,3 @@ it already has. I can't wait to see what comes out of it.
 [wc]: https://github.com/rust-lang/rfcs/pull/135
 [at]: https://github.com/rust-lang/rfcs/pull/195
 [gt]: https://github.com/rust-lang/rfcs/pull/230
-

--- a/_posts/2014-10-30-Stability.md
+++ b/_posts/2014-10-30-Stability.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Stability as a Deliverable"
 author: Aaron Turon and Niko Matsakis
+description: "The upcoming Rust 1.0 release means a lot, but most fundamentally it is a commitment to stability, alongside our long-running commitment to safety."
 ---
 
 The upcoming Rust 1.0 release means

--- a/_posts/2014-11-20-Cargo.md
+++ b/_posts/2014-11-20-Cargo.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Cargo: Rust's community crate host"
 author: Alex Crichton
+description: "Today it is my pleasure to announce that crates.io is online and ready for action."
 ---
 
 Today it is my pleasure to announce that [crates.io](https://crates.io/) is

--- a/_posts/2014-12-12-1.0-Timeline.md
+++ b/_posts/2014-12-12-1.0-Timeline.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Rust 1.0: Scheduling the trains"
 author: Aaron Turon
+description: "As 2014 is drawing to a close, it's time to begin the Rust 1.0 release cycle!"
 ---
 
 As 2014 is drawing to a close, it's time to begin the Rust 1.0 release cycle!

--- a/_posts/2014-12-12-Core-Team.md
+++ b/_posts/2014-12-12-Core-Team.md
@@ -2,6 +2,7 @@
 layout: post
 title: Yehuda Katz and Steve Klabnik are joining the Rust Core Team
 author: Niko Matsakis
+description: "I'm pleased to announce that Yehuda Katz and Steve Klabnik are joining the Rust core team."
 ---
 
 I'm pleased to announce that Yehuda Katz and Steve Klabnik are joining


### PR DESCRIPTION
These make blog.rust-lang.org links on twitter slightly fancier.

Once this is merged, someone with control of the @rustlang twitter account may have to go to https://cards-dev.twitter.com/validator and plug in a blog.rust-lang.org URL to activate it on the twitter end.

Post authors can optionally provide a `description` that will appear in such cards; if it's not provided the description will fall back to the generic "words from the Rust team".


E.g. the github info in https://twitter.com/steveklabnik/status/553346841270431745 is a twitter card.