### PR TITLE
Typo in code comment, mutes -> mutex

### DIFF
--- a/_posts/2015-04-10-Fearless-Concurrency.md
+++ b/_posts/2015-04-10-Fearless-Concurrency.md
@@ -341,7 +341,7 @@ Here is a simplified version (the [standard library's][mutex]
 is more ergonomic):
 
 ~~~~rust
-// create a new mutes
+// create a new mutex
 fn mutex<T: Send>(t: T) -> Mutex<T>;
 
 // acquire the lock


### PR DESCRIPTION
Fixes a typo in a code comment.