### PR TITLE
Fearless Concurrency Typo

### DIFF
--- a/_posts/2015-04-10-Fearless-Concurrency.md
+++ b/_posts/2015-04-10-Fearless-Concurrency.md
@@ -490,7 +490,7 @@ fn parent() {
 }
 ~~~~
 
-The child thread take a reference to `vec`, which in turn resides in
+The child thread takes a reference to `vec`, which in turn resides in
 the stack frame of `parent`. When `parent` exits, the stack frame is
 popped, but the child thread is none the wiser. Oops!
 


### PR DESCRIPTION
This 's' was lost, but now it's home again.