### PR TITLE
Escape left paren so it isn't interpreted as Markdown link url

### DIFF
--- a/_posts/2014-12-12-1.0-Timeline.md
+++ b/_posts/2014-12-12-1.0-Timeline.md
@@ -15,7 +15,7 @@ produce Rust 1.0.0 final at least two cycles afterwards**:
 * Rust 1.0.0 -- One or more six-week cycles later
 
 We talked before about [why Rust is reaching 1.0], and also about the
-[6-week train model] (with Nightly, Beta, and Stable channels) that will enable
+[6-week train model] \(with Nightly, Beta, and Stable channels) that will enable
 us to deliver stability without stagnation. This post finishes the story by
 laying out the transition to this new release model and the stability guarantees
 it provides.


### PR DESCRIPTION
Currently this link is broken because it's interpreting the parenthetical remark "(with Nightly, Beta, and Stable channels)" as a URL.