### PR TITLE
Enable SmartyPants for Better Typography

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,6 @@ github_username:  rust-lang
 highlighter: pygments
 markdown: redcarpet
 redcarpet:
-  extensions: ["with_toc_data"]
+  extensions: ["with_toc_data", "smart"]
 
 root: http://blog.rust-lang.org


### PR DESCRIPTION
Enables transforming things like "--" to "–" and "we'll" to "we’ll".