### PR TITLE
Replaced my private email with github email

### DIFF
--- a/_posts/2015-05-15-Rust-1.0.md
+++ b/_posts/2015-05-15-Rust-1.0.md
@@ -224,7 +224,7 @@ whom contributed changes since our previous release (the
 - `P1start <rewi-github@whanau.org>`
 - `Pascal Hertleif <killercup@gmail.com>`
 - `Paul Banks <banks@banksdesigns.co.uk>`
-- `Paul Faria <paul_faria@ultimatesoftware.com>`
+- `Paul Faria <Nashenas88@users.noreply.github.com>`
 - `Paul Quint <DrKwint@gmail.com>`
 - `Pete Hunt <petehunt@users.noreply.github.com>`
 - `Peter Marheine <peter@taricorp.net>`


### PR DESCRIPTION
The current email is my work email, and I've seen spam coming in through this. I'm switching it to my github private email