### PR TITLE
rm clone_from_slice (not this release).

### DIFF
--- a/_posts/2016-04-14-Rust-1.8.md
+++ b/_posts/2016-04-14-Rust-1.8.md
@@ -95,8 +95,6 @@ language section.
 
 Other notable improvements include:
 
-* `<[T]>::clone_from_slice()`, an efficient way to copy the data from one slice
-  and put it into another slice.
 * Various convenience methods on `Ipv4Addr` and `Ipv6Addr`, such as `is_loopback()`,
   which returns `true` or `false` if the address is a loopback address according to
   RFC 6890.


### PR DESCRIPTION
clone_from_slice was 1.7 (and copy_from_slice will be in 1.9)