### PR TITLE
fix stmt_expr_attributes example

### DIFF
--- a/_posts/2016-11-10-Rust-1.13.md
+++ b/_posts/2016-11-10-Rust-1.13.md
@@ -249,7 +249,7 @@ let x: Tuple!(i32, i32) = (1, 2);
 
 ```rust
 // Apply a lint attribute to a single statement
-#[allow(uppercase_variable)]
+#[allow(non_snake_case)]
 let BAD_STYLE = List::new();
 ```
 


### PR DESCRIPTION
The example was using a bogus name for the lint.