### PR TITLE
Adding a post for the Underhanded Rust contest

### DIFF
--- a/_posts/2016-12-15-Underhanded-Rust.md
+++ b/_posts/2016-12-15-Underhanded-Rust.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: "Announcing the First Underhanded Rust Contest"
+author: The Rust Community Team
+---
+
+The [Rust Community Team](https://community.rs) is pleased to announce the
+first annual Underhanded Rust Contest, inspired by the [Underhanded
+C](http://www.underhanded-c.org/) and [Underhanded
+Crypto](https://underhandedcrypto.com/) contests. Our goal with
+[Rust](https://www.rust-lang.org/) is to make it easy to write trustworthy
+low-level software that is resistant to accidental security vulnerabilities,
+though less often challenged has been Rust's ability to protect against
+*deliberate* vulnerabilities in the face of scrutiny. This challenge is
+designed to put our language and [the broader Rust
+ecosystem](https://crates.io/) to the test, to help us learn where our blind
+spots are and what needs to be done to address them. In short, we want you to
+break our stuff using reasonable, easy-to-read code. Can you write 100% safe
+Rust that hides a logic bug, or hide an exploit in
+[unsafe](https://doc.rust-lang.org/book/unsafe.html) Rust that passes an audit?
+Now's your chance!
+
+For more details, see the announcement of the project at
+[underhanded.rs](https://underhanded.rs/blog/2016/12/14/underhanded-rust.en-US.html).

--- a/_posts/2016-12-15-Underhanded-Rust.md
+++ b/_posts/2016-12-15-Underhanded-Rust.md
@@ -9,8 +9,8 @@ first annual Underhanded Rust Contest, inspired by the [Underhanded
 C](http://www.underhanded-c.org/) and [Underhanded
 Crypto](https://underhandedcrypto.com/) contests. Our goal with
 [Rust](https://www.rust-lang.org/) is to make it easy to write trustworthy
-low-level software that is resistant to accidental security vulnerabilities,
-though less often challenged has been Rust's ability to protect against
+low-level software that is resistant to accidental security vulnerabilities.
+Less often challenged has been Rust's ability to protect against
 *deliberate* vulnerabilities in the face of scrutiny. This challenge is
 designed to put our language and [the broader Rust
 ecosystem](https://crates.io/) to the test, to help us learn where our blind


### PR DESCRIPTION
This adds a short page to link to the Underhanded Rust announcement on https://underhanded.rs being run by the community team. We hope to publicize this by 9am PST, so please let us know if there's anything we should change.

[rendered](https://github.com/erickt/blog.rust-lang.org/blob/gh-pages/_posts/2016-12-15-Underhanded-Rust.md)