### PR TITLE
Remove e-mail addresses from old posts

### DIFF
--- a/_posts/2015-01-09-Rust-1.0-alpha.md
+++ b/_posts/2015-01-09-Rust-1.0-alpha.md
@@ -112,253 +112,253 @@ And, of course, we will continue to fix bugs and add polish throughout the alpha
 
 This alpha release could not have happened without the help of Rust's enthusiastic community. Thanks go to:
 
-* `Aaron Friel <mayreply@aaronfriel.com>`
-* `Aaron Liblong <liblonga@physics.utoronto.ca>`
-* `Aaron Turon <aturon@mozilla.com>`
-* `Aaron Weiss <aaronweiss74@gmail.com>`
-* `Adam Szkoda <adaszko@gmail.com>`
-* `Adolfo Ochagavía <aochagavia92@gmail.com>`
-* `Adrien Tétar <adri-from-59@hotmail.fr>`
-* `Aidan Cully <github@aidan.users.panix.com>`
-* `A.J. Gardner <mrhota@users.noreply.github.com>`
-* `Akos Kiss <akiss@inf.u-szeged.hu>`
-* `Aleksandr Koshlo <sash7ko@gmail.com>`
-* `Alexander Light <scialexlight@gmail.com>`
-* `Alex Crichton <alex@alexcrichton.com>`
-* `Alex Gaynor <alex.gaynor@gmail.com>`
-* `Alexis Beingessner <a.beingessner@gmail.com>`
-* `Alex Lyon <Arcterus@mail.com>`
-* `Alfie John <alfiej@fastmail.fm>`
-* `Andrea Canciani <ranma42@gmail.com>`
-* `Andrew Cann <shum@canndrew.org>`
-* `Andrew Paseltiner <apaseltiner@gmail.com>`
-* `Andrew Wagner <drewm1980@gmail.com>`
-* `areski <areski@gmail.com>`
-* `Ariel Ben-Yehuda <ariel.byd@gmail.com>`
-* `Artem <artemciy@gmail.com>`
-* `Arthur Liao <arthurtw8@gmail.com>`
-* `arturo <arturo@openframeworks.cc>`
-* `Austin Bonander <austin.bonander@gmail.com>`
-* `Barosl Lee <vcs@barosl.com>`
-* `Ben Foppa <benjamin.foppa@gmail.com>`
-* `Ben Gamari <bgamari.foss@gmail.com>`
-* `Ben S <ogham@bsago.me>`
-* `Bheesham Persaud <bheesham123@hotmail.com>`
-* `Björn Steinbrink <bsteinbr@gmail.com>`
-* `bluss <bluss>`
-* `Boris Egorov <egorov@linux.com>`
-* `bors <bors@rust-lang.org>`
-* `Brandon Sanderson <singingboyo@gmail.com>`
-* `Brendan Zabarauskas <bjzaba@yahoo.com.au>`
-* `Brian Anderson <banderson@mozilla.com>`
-* `Brian J Brennan <brianloveswords@gmail.com>`
-* `Brian Koropoff <bkoropoff@gmail.com>`
-* `Carol Nichols <cnichols@thinkthroughmath.com>`
-* `Chase Southwood <chase.southwood@gmail.com>`
-* `Chris Morgan <me@chrismorgan.info>`
-* `Chris Wong <lambda.fairy@gmail.com>`
-* `Clark Gaebel <cg.wowus.cg@gmail.com>`
-* `Cody P Schafer <dev@codyps.com>`
-* `Colin Sherratt <colin.sherratt@gmail.com>`
-* `Corey Farwell <coreyf@rwell.org>`
-* `Corey Ford <corey@coreyford.name>`
-* `Corey Richardson <corey@octayn.net>`
-* `crhino <piraino.chris@gmail.com>`
-* `Cristi Burcă <scribu@gmail.com>`
-* `Damien Radtke <dradtke@channeliq.com>`
-* `Dan Burkert <dan@danburkert.com>`
-* `dan@daramos.com <dan@daramos.com>`
-* `Daniel Hofstetter <daniel.hofstetter@42dh.com>`
-* `Daniel Micay <danielmicay@gmail.com>`
-* `Dan Luu <danluu@gmail.com>`
-* `David Creswick <dcrewi@gyrae.net>`
-* `Davis Silverman <sinistersnare@gmail.com>`
-* `Diego Giagio <diego@giagio.com>`
-* `Dirk Gadsden <dirk@esherido.com>`
-* `Dylan Ede <dylanede@googlemail.com>`
-* `Earl St Sauver <estsauver@gmail.com>`
-* `Eduard Burtescu <edy.burt@gmail.com>`
-* `Eduardo Bautista <me@eduardobautista.com>`
-* `elszben <notgonna@tellyou>`
-* `Eric Allen <ericpallen@gmail.com>`
-* `Eric Kidd <git@randomhacks.net>`
-* `Erick Tryzelaar <erick.tryzelaar@gmail.com>`
-* `Erwan <erwan.ricq@gmail.com>`
-* `Fabrice Desré <fabrice@desre.org>`
-* `FakeKane <andrewyli@gmail.com>`
-* `Falco Hirschenberger <falco.hirschenberger@gmail.com>`
-* `Felix Raimundo <felix.raimundo@telecom-paristech.fr>`
-* `Felix S. Klock II <pnkfelix@pnkfx.org>`
-* `Flavio Percoco <flaper87@gmail.com>`
-* `Florian Gilcher <florian.gilcher@asquera.de>`
-* `Florian Hahn <flo@fhahn.com>`
-* `Florian Wilkens <floya@live.de>`
-* `gamazeps <gamaz3ps@gmail.com>`
-* `Gil Cottle <rc@redtown.org>`
-* `Gleb Kozyrev <gleb@gkoz.com>`
-* `Graham Fawcett <graham.fawcett@gmail.com>`
-* `Guillaume Pinot <texitoi@texitoi.eu>`
-* `Huon Wilson <dbau.pp+github@gmail.com>`
-* `Ian Connolly <iconnolly@mozilla.com>`
-* `inrustwetrust <inrustwetrust@users.noreply.github.com>`
-* `Ivan Petkov <ivanppetkov@gmail.com>`
-* `Ivan Ukhov <ivan.ukhov@gmail.com>`
-* `Jacob Edelman <edelman.jd@gmail.com>`
-* `Jake Goulding <jake.goulding@gmail.com>`
-* `Jakub Bukaj <jakub@jakub.cc>`
-* `James Miller <james@aatch.net>`
-* `Jared Roesch <roeschinc@gmail.com>`
-* `Jarod Liu <liuyuanzhi@gmail.com>`
-* `Jashank Jeremy <jashank@rulingia.com>`
-* `Jauhien Piatlicki <jpiatlicki@zertisa.com>`
-* `jbranchaud <jbranchaud@gmail.com>`
-* `Jeff Parsons <jeffdougson@gmail.com>`
-* `Jelte Fennema <github-tech@jeltef.nl>`
-* `jfager <jfager@gmail.com>`
-* `Jim Apple <jbapple+rust@google.com>`
-* `jmu303 <muj@bc.edu>`
-* `Johannes Hoff <johshoff@gmail.com>`
-* `Johannes Muenzel <jmuenzel@gmail.com>`
-* `John Albietz <inthecloud247@gmail.com>`
-* `John Gallagher <jgallagher@bignerdranch.com>`
-* `John Kåre Alsaker <john.kare.alsaker@gmail.com>`
-* `John Kleint <jk@hinge.co>`
-* `Jonathan Reem <jonathan.reem@gmail.com>`
-* `Jonathan S <gereeter@gmail.com>`
-* `Jon Haddad <jon@jonhaddad.com>`
-* `JONNALAGADDA Srinivas <js@ojuslabs.com>`
-* `Joonas Javanainen <joonas.javanainen@gmail.com>`
-* `Jorge Aparicio <japaricious@gmail.com>`
-* `Joseph Crail <jbcrail@gmail.com>`
-* `Joseph Rushton Wakeling <joe@webdrake.net>`
-* `Josh Haberman <jhaberman@gmail.com>`
-* `Josh Stone <cuviper@gmail.com>`
-* `Joshua Yanovski <pythonesque@gmail.com>`
-* `jrincayc <jrincayc@users.noreply.github.com>`
-* `Julian Orth <ju.orth@gmail.com>`
-* `juxiliary <juxiliary@gmail.com>`
-* `jxv <joevargas@hush.com>`
-* `Kang Seonghoon <public+git@mearie.org>`
-* `Kasey Carrothers <kaseyc.808@gmail.com>`
-* `Keegan McAllister <kmcallister@mozilla.com>`
-* `Ken Tossell <ken@tossell.net>`
-* `Kevin Ballard <kevin@sb.org>`
-* `Kevin Mehall <km@kevinmehall.net>`
-* `Kevin Yap <me@kevinyap.ca>`
-* `klutzy <klutzytheklutzy@gmail.com>`
-* `kulakowski <george.kulakowski@gmail.com>`
-* `Laurence Tratt <laurie@tratt.net>`
-* `Liigo Zhuang <com.liigo@gmail.com>`
-* `Lionel Flandrin <lionel.flandrin@parrot.com>`
-* `Luke Metz <luke.metz@students.olin.edu>`
-* `Luqman Aden <me@luqman.ca>`
-* `Manish Goregaokar <manishsmail@gmail.com>`
-* `Markus Siemens <siemens1993@gmail.com>`
-* `Martin Pool <mbp@sourcefrog.net>`
-* `Marvin Löbel <loebel.marvin@gmail.com>`
-* `Matej Lach <matej.lach@gmail.com>`
-* `Mathieu Poumeyrol <kali@zoy.org>`
-* `Matt McPherrin <git@mcpherrin.ca>`
-* `Matt Murphy <matthew.john.murphy@gmail.com>`
-* `Matt Windsor <mattwindsor@btinternet.com>`
-* `Maxime Quandalle <maxime@quandalle.com>`
-* `Maximilian Haack <mxhaack@gmail.com>`
-* `Maya Nitu <maya_nitu@yahoo.com>`
-* `mchaput <matt@whoosh.ca>`
-* `mdinger <mdinger.bugzilla@gmail.com>`
-* `Michael Gehring <mg@ebfe.org>`
-* `Michael Neumann <mneumann@ntecs.de>`
-* `Michael Sproul <micsproul@gmail.com>`
-* `Michael Woerister <michaelwoerister@posteo>`
-* `Mike Dilger <mike@efx.co.nz>`
-* `Mike Pedersen <noctune9@gmail.com>`
-* `Mike Robinson <mikeprobinsonuk@gmail.com>`
-* `Ms2ger <ms2ger@gmail.com>`
-* `Mukilan Thiyagarajan <mukilanthiagarajan@gmail.com>`
-* `Murarth <murarth@gmail.com>`
-* `Nafis <nhoss2@gmail.com>`
-* `Nathan Zadoks <nathan@nathan7.eu>`
-* `Neil Pankey <npankey@gmail.com>`
-* `Nicholas Bishop <nicholasbishop@gmail.com>`
-* `Nick Cameron <ncameron@mozilla.com>`
-* `Nick Howell <howellnick@gmail.com>`
-* `Niels Egberts <git@nielsegberts.nl>`
-* `Niko Matsakis <niko@alum.mit.edu>`
-* `NODA, Kai <nodakai@gmail.com>`
-* `OGINO Masanori <masanori.ogino@gmail.com>`
-* `oli-obk <github6541940@oli-obk.de>`
-* `Oliver Schneider <oliver.schneider@kit.edu>`
-* `olivren <o.renaud@gmx.fr>`
-* `P1start <rewi-github@whanau.org>`
-* `Pascal Hertleif <killercup@gmail.com>`
-* `Patrick Walton <pcwalton@mimiga.net>`
-* `Paul Collier <paul@paulcollier.ca>`
-* `Pedro Larroy <pedro.larroy@here.com>`
-* `Peter Atashian <retep998@gmail.com>`
-* `Peter Elmers <peter.elmers@yahoo.com>`
-* `Phil Dawes <pdawes@drw.com>`
-* `Philip Munksgaard <pmunksgaard@gmail.com>`
-* `Philipp Gesang <phg42.2a@gmail.com>`
-* `Piotr Czarnecki <pioczarn@gmail.com>`
-* `Piotr Jawniak <sawyer47@gmail.com>`
-* `Piotr Szotkowski <chastell@chastell.net>`
-* `qwitwa <qwitwa@gmail.com>`
-* `Raphael Speyer <rspeyer@gmail.com>`
-* `Ray Clanan <rclanan@utopianconcept.com>`
-* `Richard Diamond <wichard@vitalitystudios.com>`
-* `Richo Healey <richo@psych0tik.net>`
-* `Ricky Taylor <rickytaylor26@gmail.com>`
-* `rjz <rj@rjzaworski.com>`
-* `Robin Gloster <robin@loc-com.de>`
-* `Robin Stocker <robin@nibor.org>`
-* `Rohit Joshi <rohit.c.joshi@gmail.com>`
-* `Rolf Timmermans <rolftimmermans@voormedia.com>`
-* `Rolf van de Krol <info@rolfvandekrol.nl>`
-* `Roy Crihfield <rscrihf@gmail.com>`
-* `Ruud van Asseldonk <dev@veniogames.com>`
-* `Sean Collins <sean@cllns.com>`
-* `Sean Gillespie <sean.william.g@gmail.com>`
-* `Sean Jensen-Grey <seanj@xyke.com>`
-* `Sean McArthur <sean.monstar@gmail.com>`
-* `Sean T Allen <sean@monkeysnatchbanana.com>`
-* `Seo Sanghyeon <sanxiyn@gmail.com>`
-* `Seth Pollack <sethpollack@users.noreply.github.com>`
-* `sheroze1123 <mss385@cornell.edu>`
-* `Simonas Kazlauskas <git@kazlauskas.me>`
-* `Simon Sapin <simon.sapin@exyr.org>`
-* `Simon Wollwage <mail.wollwage@gmail.com>`
-* `Son <leson.phung@gmail.com>`
-* `Stefan Bucur <stefan.bucur@epfl.ch>`
-* `Stepan Koltsov <stepan.koltsov@gmail.com>`
-* `Steve Klabnik <steve@steveklabnik.com>`
-* `Steven Fackler <sfackler@gmail.com>`
-* `Stuart Pernsteiner <stuart@pernsteiner.org>`
-* `Subhash Bhushan <subhash.bhushan@kaybus.com>`
-* `Tamir Duberstein <tamird@squareup.com>`
-* `Taylor Hutchison <seanthutchison@gmail.com>`
-* `th0114nd <th0114nd@gmail.com>`
-* `thiagopnts <thiagopnts@gmail.com>`
-* `Timon Rapp <timon@zaeda.net>`
-* `Titouan Vervack <tivervac@gmail.com>`
-* `Tobias Bucher <tobiasbucher5991@gmail.com>`
-* `Tom Jakubowski <tom@crystae.net>`
-* `tshakah <tshakah@gmail.com>`
-* `Tshepang Lekhonkhobe <tshepang@gmail.com>`
-* `Ulysse Carion <ulysse@ulysse.io>`
-* `Utkarsh Kukreti <utkarshkukreti@gmail.com>`
-* `Vadim Chugunov <vadimcn@gmail.com>`
-* `Vadim Petrochenkov <vadim.petrochenkov@gmail.com>`
-* `Valerii Hiora <valerii.hiora@gmail.com>`
-* `Victor Berger <victor.berger@m4x.org>`
-* `Victor van den Elzen <victor.vde@gmail.com>`
-* `Viktor Dahl <pazaconyoman@gmail.com>`
-* `ville-h <ville3.14159@gmail.com>`
-* `Vitali Haravy <HumaneProgrammer@gmail.com>`
-* `Vladimir Matveev <vladimir.matweev@gmail.com>`
-* `Vladimir Smola <smola.vladimir@gmail.com>`
-* `we <vadim.petrochenkov@gmail.com>`
-* `whataloadofwhat <unusualmoniker@gmail.com>`
-* `YawarRaza7349 <YawarRaza7349@gmail.com>`
-* `York Xiang <bombless@126.com>`
-* `Zbigniew Siciarz <zbigniew@siciarz.net>`
-* `Ziad Hatahet <hatahet@gmail.com>`
+* `Aaron Friel`
+* `Aaron Liblong`
+* `Aaron Turon`
+* `Aaron Weiss`
+* `Adam Szkoda`
+* `Adolfo Ochagavía`
+* `Adrien Tétar`
+* `Aidan Cully`
+* `A.J. Gardner`
+* `Akos Kiss`
+* `Aleksandr Koshlo`
+* `Alexander Light`
+* `Alex Crichton`
+* `Alex Gaynor`
+* `Alexis Beingessner`
+* `Alex Lyon`
+* `Alfie John`
+* `Andrea Canciani`
+* `Andrew Cann`
+* `Andrew Paseltiner`
+* `Andrew Wagner`
+* `areski`
+* `Ariel Ben-Yehuda`
+* `Artem`
+* `Arthur Liao`
+* `arturo`
+* `Austin Bonander`
+* `Barosl Lee`
+* `Ben Foppa`
+* `Ben Gamari`
+* `Ben S`
+* `Bheesham Persaud`
+* `Björn Steinbrink`
+* `bluss`
+* `Boris Egorov`
+* `bors`
+* `Brandon Sanderson`
+* `Brendan Zabarauskas`
+* `Brian Anderson`
+* `Brian J Brennan`
+* `Brian Koropoff`
+* `Carol Nichols`
+* `Chase Southwood`
+* `Chris Morgan`
+* `Chris Wong`
+* `Clark Gaebel`
+* `Cody P Schafer`
+* `Colin Sherratt`
+* `Corey Farwell`
+* `Corey Ford`
+* `Corey Richardson`
+* `crhino`
+* `Cristi Burcă`
+* `Damien Radtke`
+* `Dan Burkert`
+* `dan@daramos.com`
+* `Daniel Hofstetter`
+* `Daniel Micay`
+* `Dan Luu`
+* `David Creswick`
+* `Davis Silverman`
+* `Diego Giagio`
+* `Dirk Gadsden`
+* `Dylan Ede`
+* `Earl St Sauver`
+* `Eduard Burtescu`
+* `Eduardo Bautista`
+* `elszben`
+* `Eric Allen`
+* `Eric Kidd`
+* `Erick Tryzelaar`
+* `Erwan`
+* `Fabrice Desré`
+* `FakeKane`
+* `Falco Hirschenberger`
+* `Felix Raimundo`
+* `Felix S. Klock II`
+* `Flavio Percoco`
+* `Florian Gilcher`
+* `Florian Hahn`
+* `Florian Wilkens`
+* `gamazeps`
+* `Gil Cottle`
+* `Gleb Kozyrev`
+* `Graham Fawcett`
+* `Guillaume Pinot`
+* `Huon Wilson`
+* `Ian Connolly`
+* `inrustwetrust`
+* `Ivan Petkov`
+* `Ivan Ukhov`
+* `Jacob Edelman`
+* `Jake Goulding`
+* `Jakub Bukaj`
+* `James Miller`
+* `Jared Roesch`
+* `Jarod Liu`
+* `Jashank Jeremy`
+* `Jauhien Piatlicki`
+* `jbranchaud`
+* `Jeff Parsons`
+* `Jelte Fennema`
+* `jfager`
+* `Jim Apple`
+* `jmu303`
+* `Johannes Hoff`
+* `Johannes Muenzel`
+* `John Albietz`
+* `John Gallagher`
+* `John Kåre Alsaker`
+* `John Kleint`
+* `Jonathan Reem`
+* `Jonathan S`
+* `Jon Haddad`
+* `JONNALAGADDA Srinivas`
+* `Joonas Javanainen`
+* `Jorge Aparicio`
+* `Joseph Crail`
+* `Joseph Rushton Wakeling`
+* `Josh Haberman`
+* `Josh Stone`
+* `Joshua Yanovski`
+* `jrincayc`
+* `Julian Orth`
+* `juxiliary`
+* `jxv`
+* `Kang Seonghoon`
+* `Kasey Carrothers`
+* `Keegan McAllister`
+* `Ken Tossell`
+* `Kevin Ballard`
+* `Kevin Mehall`
+* `Kevin Yap`
+* `klutzy`
+* `kulakowski`
+* `Laurence Tratt`
+* `Liigo Zhuang`
+* `Lionel Flandrin`
+* `Luke Metz`
+* `Luqman Aden`
+* `Manish Goregaokar`
+* `Markus Siemens`
+* `Martin Pool`
+* `Marvin Löbel`
+* `Matej Lach`
+* `Mathieu Poumeyrol`
+* `Matt McPherrin`
+* `Matt Murphy`
+* `Matt Windsor`
+* `Maxime Quandalle`
+* `Maximilian Haack`
+* `Maya Nitu`
+* `mchaput`
+* `mdinger`
+* `Michael Gehring`
+* `Michael Neumann`
+* `Michael Sproul`
+* `Michael Woerister`
+* `Mike Dilger`
+* `Mike Pedersen`
+* `Mike Robinson`
+* `Ms2ger`
+* `Mukilan Thiyagarajan`
+* `Murarth`
+* `Nafis`
+* `Nathan Zadoks`
+* `Neil Pankey`
+* `Nicholas Bishop`
+* `Nick Cameron`
+* `Nick Howell`
+* `Niels Egberts`
+* `Niko Matsakis`
+* `NODA, Kai`
+* `OGINO Masanori`
+* `oli-obk`
+* `Oliver Schneider`
+* `olivren`
+* `P1start`
+* `Pascal Hertleif`
+* `Patrick Walton`
+* `Paul Collier`
+* `Pedro Larroy`
+* `Peter Atashian`
+* `Peter Elmers`
+* `Phil Dawes`
+* `Philip Munksgaard`
+* `Philipp Gesang`
+* `Piotr Czarnecki`
+* `Piotr Jawniak`
+* `Piotr Szotkowski`
+* `qwitwa`
+* `Raphael Speyer`
+* `Ray Clanan`
+* `Richard Diamond`
+* `Richo Healey`
+* `Ricky Taylor`
+* `rjz`
+* `Robin Gloster`
+* `Robin Stocker`
+* `Rohit Joshi`
+* `Rolf Timmermans`
+* `Rolf van de Krol`
+* `Roy Crihfield`
+* `Ruud van Asseldonk`
+* `Sean Collins`
+* `Sean Gillespie`
+* `Sean Jensen-Grey`
+* `Sean McArthur`
+* `Sean T Allen`
+* `Seo Sanghyeon`
+* `Seth Pollack`
+* `sheroze1123`
+* `Simonas Kazlauskas`
+* `Simon Sapin`
+* `Simon Wollwage`
+* `Son`
+* `Stefan Bucur`
+* `Stepan Koltsov`
+* `Steve Klabnik`
+* `Steven Fackler`
+* `Stuart Pernsteiner`
+* `Subhash Bhushan`
+* `Tamir Duberstein`
+* `Taylor Hutchison`
+* `th0114nd`
+* `thiagopnts`
+* `Timon Rapp`
+* `Titouan Vervack`
+* `Tobias Bucher`
+* `Tom Jakubowski`
+* `tshakah`
+* `Tshepang Lekhonkhobe`
+* `Ulysse Carion`
+* `Utkarsh Kukreti`
+* `Vadim Chugunov`
+* `Vadim Petrochenkov`
+* `Valerii Hiora`
+* `Victor Berger`
+* `Victor van den Elzen`
+* `Viktor Dahl`
+* `ville-h`
+* `Vitali Haravy`
+* `Vladimir Matveev`
+* `Vladimir Smola`
+* `we`
+* `whataloadofwhat`
+* `YawarRaza7349`
+* `York Xiang`
+* `Zbigniew Siciarz`
+* `Ziad Hatahet`

--- a/_posts/2015-02-20-Rust-1.0-alpha2.md
+++ b/_posts/2015-02-20-Rust-1.0-alpha2.md
@@ -34,207 +34,207 @@ notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-100-alp
 
 Thank you to all 204 contributors for this release:
 
-* `Aaron Turon <aturon@mozilla.com>`
-* `Adam Roben <adam@roben.org>`
-* `Adolfo Ochagavía <aochagavia92@gmail.com>`
-* `Ahmed Charles <acharles@outlook.com>`
-* `Aidan Hobson Sayers <aidanhs@cantab.net>`
-* `Akos Kiss <akiss@inf.u-szeged.hu>`
-* `Alexander Bliskovsky <alexander.bliskovsky@gmail.com>`
-* `Alexander Korolkov <alexander.korolkov@gmail.com>`
-* `Alexander Light <allight@cs.brown.edu>`
-* `Alex Crichton <alex@alexcrichton.com>`
-* `Alexis <a.beingessner@gmail.com>`
-* `Alfie John <alfie@alfie.wtf>`
-* `Alfie John <alfiej@fastmail.fm>`
-* `Andrea Canciani <ranma42@gmail.com>`
-* `Andrew Barchuk <raindev@icloud.com>`
-* `Andrew Paseltiner <apaseltiner@gmail.com>`
-* `Ariel Ben-Yehuda <arielb1@mail.tau.ac.il>`
-* `Ariel Ben-Yehuda <ariel.byd@gmail.com>`
-* `Armin Preiml <apreiml@strohwolke.at>`
-* `Artem <artemciy@gmail.com>`
-* `Barosl Lee <vcs@barosl.com>`
-* `Benjamin Peterson <benjamin@python.org>`
-* `Ben S <ogham@users.noreply.github.com>`
-* `Björn Steinbrink <bsteinbr@gmail.com>`
-* `blackbeam <aikorsky@gmail.com>`
-* `Brian Anderson <banderson@mozilla.com>`
-* `Brian Leibig <brian@brianleibig.com>`
-* `caipre <platt.nicholas@gmail.com>`
-* `Cam Jackson <camjackson89@gmail.com>`
-* `Carl Lerche <me@carllerche.com>`
-* `Carol Nichols <carol.nichols@gmail.com>`
-* `Carter Hinsley <carterhinsley@gmail.com>`
-* `CarVac <c.lo.to.da.down.lo@gmail.com>`
-* `Caspar Krieger <caspar@asparck.com>`
-* `Chase Southwood <chase.southwood@gmail.com>`
-* `Chris Morgan <me@chrismorgan.info>`
-* `Chris Thorn <thorn@thoughtbot.com>`
-* `Chris Wong <lambda.fairy@gmail.com>`
-* `Clifford Caoile <piyo@users.sf.net>`
-* `Corey Farwell <coreyf@rwell.org>`
-* `Corey Richardson <corey@octayn.net>`
-* `Daniel Griffen <daniel@dgriffen.com>`
-* `Daniel Grunwald <daniel@danielgrunwald.de>`
-* `Daniel Raloff <draloff@side2.com>`
-* `Daniil Smirnov <danslapman@gmail.com>`
-* `Dan Yang <dsyang@fb.com>`
-* `David Creswick <dcrewi@gyrae.net>`
-* `Diggory Blake <diggsey@googlemail.com>`
-* `Dominik Inführ <dominik.infuehr@gmail.com>`
-* `Duane Edwards <mail@duaneedwards.net>`
-* `Duncan Regan <duncanregan@gmail.com>`
-* `Dzmitry Malyshau <kvarkus@gmail.com>`
-* `Earl St Sauver <estsauver@gmail.com>`
-* `Eduard Burtescu <edy.burt@gmail.com>`
-* `Edward Wang <edward.yu.wang@gmail.com>`
-* `Elantsev Serj <elantsev@yandex-team.ru>`
-* `emanueLczirai <emanueLczirai@cryptoLab.net>`
-* `Erick Rivas <chemical.rivas@gmail.com>`
-* `Erick Tryzelaar <erick.tryzelaar@gmail.com>`
-* `Eunji Jeong <eun-ji.jeong@samsung.com>`
-* `Felix S. Klock II <pnkfelix@pnkfx.org>`
-* `Fenhl <fenhl@fenhl.net>`
-* `Filip Szczepański <jazz2rulez@gmail.com>`
-* `Flavio Percoco <flaper87@gmail.com>`
-* `Florian Hahn <flo@fhahn.com>`
-* `Garrett Heel <garrettheel@gmail.com>`
-* `Geoffrey Thomas <geofft@ldpreload.com>`
-* `Greg Chapple <gregchapple1@gmail.com>`
-* `Guillaume Gomez <guillaume1.gomez@gmail.com>`
-* `Guillaume Pinot <texitoi@texitoi.eu>`
-* `Henrik Schopmans <h.schopmans@googlemail.com>`
-* `Hugo van der Wijst <hugo@wij.st>`
-* `Huon Wilson <dbau.pp+github@gmail.com>`
-* `Ignacio Corderi <icorderi@msn.com>`
-* `Ingo Blechschmidt <iblech@web.de>`
-* `Jake Goulding <jake.goulding@gmail.com>`
-* `James Miller <james@aatch.net>`
-* `Jared Roesch <roeschinc@gmail.com>`
-* `Jason Fager <jfager@gmail.com>`
-* `jatinn <jatinn@users.noreply.github.com>`
-* `Jay True <glacjay@gmail.com>`
-* `Jeff Belgum <jeffbelgum@gmail.com>`
-* `John Hodge <acessdev@gmail.com>`
-* `John Kåre Alsaker <john.kare.alsaker@gmail.com>`
-* `Jonathan Reem <jonathan.reem@gmail.com>`
-* `JONNALAGADDA Srinivas <js@ojuslabs.com>`
-* `Jorge Aparicio <japaricious@gmail.com>`
-* `Jorge Israel Peña <jorge.israel.p@gmail.com>`
-* `Jormundir <Chaseph@gmail.com>`
-* `Joseph Crail <jbcrail@gmail.com>`
-* `JP Sugarbroad <jpsugar@google.com>`
-* `Julian Orth <ju.orth@gmail.com>`
-* `Junseok Lee <lee.junseok@berkeley.edu>`
-* `Kang Seonghoon <public+git@mearie.org>`
-* `Keegan McAllister <kmcallister@mozilla.com>`
-* `Keegan McAllister <mcallister.keegan@gmail.com>`
-* `Ken Tossell <ken@tossell.net>`
-* `KernelJ <kernelj@epixxware.com>`
-* `Kevin Ballard <kevin@sb.org>`
-* `Kevin Butler <haqkrs@gmail.com>`
-* `Kevin Yap <me@kevinyap.ca>`
-* `Kim Røen <kim@pam.no>`
-* `klutzy <klutzytheklutzy@gmail.com>`
-* `Kostas Karachalios <vrinek@me.com>`
-* `kud1ing <github@kudling.de>`
-* `Lai Jiangshan <laijs@cn.fujitsu.com>`
-* `Lauri Lehmijoki <lauri.lehmijoki@iki.fi>`
-* `Leo Testard <leo.testard@gmail.com>`
-* `Liigo Zhuang <com.liigo@gmail.com>`
-* `Logan Chien <tzuhsiang.chien@gmail.com>`
-* `Loïc Damien <loic.damien@dzamlo.ch>`
-* `Luca Bruno <lucab@debian.org>`
-* `Luke Francl <look@recursion.org>`
-* `Luke Steensen <luke.steensen@gmail.com>`
-* `madmalik <matthias.tellen@googlemail.com>`
-* `Manish Goregaokar <manishsmail@gmail.com>`
-* `Markus Siemens <siemens1993@gmail.com>`
-* `Marvin Löbel <loebel.marvin@gmail.com>`
-* `Matt Roche <angst7@gmail.com>`
-* `Mátyás Mustoha <mmatyas@inf.u-szeged.hu>`
-* `mdinger <mdinger.bugzilla@gmail.com>`
-* `Michael Budde <mbudde@gmail.com>`
-* `Michael Neumann <mneumann@ntecs.de>`
-* `Michael Pankov <work@michaelpankov.com>`
-* `Michael Sproul <micsproul@gmail.com>`
-* `Michael Woerister <michaelwoerister@posteo>`
-* `Mike English <mike.english@atomicobject.com>`
-* `Mikhail Zabaluev <mikhail.zabaluev@gmail.com>`
-* `Ms2ger <ms2ger@gmail.com>`
-* `NAKASHIMA, Makoto <makoto.nksm+github@gmail.com>`
-* `nathan dotz <nathan.dotz@gmail.com>`
-* `Nathaniel Theis <nttheis@gmail.com>`
-* `Nathan Stoddard <nstodda@purdue.edu>`
-* `Nelson Chen <crazysim@gmail.com>`
-* `Nick Cameron <ncameron@mozilla.com>`
-* `Nick Howell <howellnick@gmail.com>`
-* `Nick Sarten <gen.battle@gmail.com>`
-* `Niko Matsakis <niko@alum.mit.edu>`
-* `NODA, Kai <nodakai@gmail.com>`
-* `Oliver 'ker' Schneider <rust19446194516@oli-obk.de>`
-* `Oliver Schneider <git1984941651981@oli-obk.de>`
-* `Orpheus Lummis <o@orpheuslummis.com>`
-* `P1start <rewi-github@whanau.org>`
-* `Pascal Hertleif <killercup@gmail.com>`
-* `Paul Collier <paul@paulcollier.ca>`
-* `Paul Crowley <paulcrowley@google.com>`
-* `Peter Atashian <retep998@gmail.com>`
-* `Peter Schuller <peter.schuller@infidyne.com>`
-* `Pierre Baillet <pierre@baillet.name>`
-* `Piotr Czarnecki <pioczarn@gmail.com>`
-* `posixphreak <posixphreak@gmail.com>`
-* `Potpourri <pot_pourri@mail.ru>`
-* `Pyfisch <pyfisch@gmail.com>`
-* `Raul Gutierrez S <rgs@itevenworks.net>`
-* `Renato Alves <alves.rjc@gmail.com>`
-* `Renato Zannon <renato@rrsz.com.br>`
-* `Richo Healey <richo@psych0tik.net>`
-* `Robin Stocker <robin@nibor.org>`
-* `Rohit Joshi <rohitjoshi@users.noreply.github.com>`
-* `Ryan Levick <ryan@6wunderkinder.com>`
-* `Sean Collins <sean@cllns.com>`
-* `Sean Gillespie <sean.william.g@gmail.com>`
-* `Sean Patrick Santos <SeanPatrickSantos@gmail.com>`
-* `Sean T Allen <sean@monkeysnatchbanana.com>`
-* `Sebastian Gesemann <s.gesemann@gmail.com>`
-* `Sebastian Rasmussen <sebras@gmail.com>`
-* `Sébastien Marie <semarie@users.noreply.github.com>`
-* `Seo Sanghyeon <sanxiyn@gmail.com>`
-* `Seth Faxon <seth.faxon@gmail.com>`
-* `Simonas Kazlauskas <git@kazlauskas.me>`
-* `Stepan Koltsov <stepan.koltsov@gmail.com>`
-* `Steve Klabnik <steve@steveklabnik.com>`
-* `Steven Allen <steven@stebalien.com>`
-* `Steven Crockett <crockett.j.steven@gmail.com>`
-* `Steven Fackler <sfackler@gmail.com>`
-* `Strahinja Val Markovic <val@markovic.io>`
-* `Thiago Carvalho <thiago.carvalho@westwing.de>`
-* `Tim Brooks <brooks@cern.ch>`
-* `Tim Cuthbertson <tim@gfxmonk.net>`
-* `Tim Dumol <tim@timdumol.com>`
-* `Tim Parenti <timparenti@gmail.com>`
-* `Tobias Bucher <tobiasbucher5991@gmail.com>`
-* `Toby Scrace <toby.scrace@gmail.com>`
-* `Tom Chittenden <thchittenden@cmu.edu>`
-* `Tom Jakubowski <tom@crystae.net>`
-* `Toni Cárdenas <toni@tcardenas.me>`
-* `Travis Watkins <amaranth@ubuntu.com>`
-* `Tristan Storch <tstorch@math.uni-bielefeld.de>`
-* `Tshepang Lekhonkhobe <tshepang@gmail.com>`
-* `Tyler Thrailkill <tylerbthrailkill@gmail.com>`
-* `Ulrik Sverdrup <root@localhost>`
-* `Vadim Chugunov <vadimcn@gmail.com>`
-* `Vadim Petrochenkov <vadim.petrochenkov@gmail.com>`
-* `Valerii Hiora <valerii.hiora@gmail.com>`
-* `Victory <git@dfhu.org>`
-* `visualfc <visualfc@gmail.com>`
-* `Vojtech Kral <vojtech@kral.hk>`
-* `Volker Mische <volker.mische@gmail.com>`
-* `Wangshan Lu <wisagan@gmail.com>`
-* `we <vadim.petrochenkov@gmail.com>`
-* `Willson Mock <willson.mock@gmail.com>`
-* `Will <will@glozer.net>`
-* `wonyong kim <wonyong.kim@samsung.com>`
-* `York Xiang <bombless@126.com>`
+* `Aaron Turon`
+* `Adam Roben`
+* `Adolfo Ochagavía`
+* `Ahmed Charles`
+* `Aidan Hobson Sayers`
+* `Akos Kiss`
+* `Alexander Bliskovsky`
+* `Alexander Korolkov`
+* `Alexander Light`
+* `Alex Crichton`
+* `Alexis`
+* `Alfie John`
+* `Alfie John`
+* `Andrea Canciani`
+* `Andrew Barchuk`
+* `Andrew Paseltiner`
+* `Ariel Ben-Yehuda`
+* `Ariel Ben-Yehuda`
+* `Armin Preiml`
+* `Artem`
+* `Barosl Lee`
+* `Benjamin Peterson`
+* `Ben S`
+* `Björn Steinbrink`
+* `blackbeam`
+* `Brian Anderson`
+* `Brian Leibig`
+* `caipre`
+* `Cam Jackson`
+* `Carl Lerche`
+* `Carol Nichols`
+* `Carter Hinsley`
+* `CarVac`
+* `Caspar Krieger`
+* `Chase Southwood`
+* `Chris Morgan`
+* `Chris Thorn`
+* `Chris Wong`
+* `Clifford Caoile`
+* `Corey Farwell`
+* `Corey Richardson`
+* `Daniel Griffen`
+* `Daniel Grunwald`
+* `Daniel Raloff`
+* `Daniil Smirnov`
+* `Dan Yang`
+* `David Creswick`
+* `Diggory Blake`
+* `Dominik Inführ`
+* `Duane Edwards`
+* `Duncan Regan`
+* `Dzmitry Malyshau`
+* `Earl St Sauver`
+* `Eduard Burtescu`
+* `Edward Wang`
+* `Elantsev Serj`
+* `emanueLczirai`
+* `Erick Rivas`
+* `Erick Tryzelaar`
+* `Eunji Jeong`
+* `Felix S. Klock II`
+* `Fenhl`
+* `Filip Szczepański`
+* `Flavio Percoco`
+* `Florian Hahn`
+* `Garrett Heel`
+* `Geoffrey Thomas`
+* `Greg Chapple`
+* `Guillaume Gomez`
+* `Guillaume Pinot`
+* `Henrik Schopmans`
+* `Hugo van der Wijst`
+* `Huon Wilson`
+* `Ignacio Corderi`
+* `Ingo Blechschmidt`
+* `Jake Goulding`
+* `James Miller`
+* `Jared Roesch`
+* `Jason Fager`
+* `jatinn`
+* `Jay True`
+* `Jeff Belgum`
+* `John Hodge`
+* `John Kåre Alsaker`
+* `Jonathan Reem`
+* `JONNALAGADDA Srinivas`
+* `Jorge Aparicio`
+* `Jorge Israel Peña`
+* `Jormundir`
+* `Joseph Crail`
+* `JP Sugarbroad`
+* `Julian Orth`
+* `Junseok Lee`
+* `Kang Seonghoon`
+* `Keegan McAllister`
+* `Keegan McAllister`
+* `Ken Tossell`
+* `KernelJ`
+* `Kevin Ballard`
+* `Kevin Butler`
+* `Kevin Yap`
+* `Kim Røen`
+* `klutzy`
+* `Kostas Karachalios`
+* `kud1ing`
+* `Lai Jiangshan`
+* `Lauri Lehmijoki`
+* `Leo Testard`
+* `Liigo Zhuang`
+* `Logan Chien`
+* `Loïc Damien`
+* `Luca Bruno`
+* `Luke Francl`
+* `Luke Steensen`
+* `madmalik`
+* `Manish Goregaokar`
+* `Markus Siemens`
+* `Marvin Löbel`
+* `Matt Roche`
+* `Mátyás Mustoha`
+* `mdinger`
+* `Michael Budde`
+* `Michael Neumann`
+* `Michael Pankov`
+* `Michael Sproul`
+* `Michael Woerister`
+* `Mike English`
+* `Mikhail Zabaluev`
+* `Ms2ger`
+* `NAKASHIMA, Makoto`
+* `nathan dotz`
+* `Nathaniel Theis`
+* `Nathan Stoddard`
+* `Nelson Chen`
+* `Nick Cameron`
+* `Nick Howell`
+* `Nick Sarten`
+* `Niko Matsakis`
+* `NODA, Kai`
+* `Oliver 'ker' Schneider`
+* `Oliver Schneider`
+* `Orpheus Lummis`
+* `P1start`
+* `Pascal Hertleif`
+* `Paul Collier`
+* `Paul Crowley`
+* `Peter Atashian`
+* `Peter Schuller`
+* `Pierre Baillet`
+* `Piotr Czarnecki`
+* `posixphreak`
+* `Potpourri`
+* `Pyfisch`
+* `Raul Gutierrez S`
+* `Renato Alves`
+* `Renato Zannon`
+* `Richo Healey`
+* `Robin Stocker`
+* `Rohit Joshi`
+* `Ryan Levick`
+* `Sean Collins`
+* `Sean Gillespie`
+* `Sean Patrick Santos`
+* `Sean T Allen`
+* `Sebastian Gesemann`
+* `Sebastian Rasmussen`
+* `Sébastien Marie`
+* `Seo Sanghyeon`
+* `Seth Faxon`
+* `Simonas Kazlauskas`
+* `Stepan Koltsov`
+* `Steve Klabnik`
+* `Steven Allen`
+* `Steven Crockett`
+* `Steven Fackler`
+* `Strahinja Val Markovic`
+* `Thiago Carvalho`
+* `Tim Brooks`
+* `Tim Cuthbertson`
+* `Tim Dumol`
+* `Tim Parenti`
+* `Tobias Bucher`
+* `Toby Scrace`
+* `Tom Chittenden`
+* `Tom Jakubowski`
+* `Toni Cárdenas`
+* `Travis Watkins`
+* `Tristan Storch`
+* `Tshepang Lekhonkhobe`
+* `Tyler Thrailkill`
+* `Ulrik Sverdrup`
+* `Vadim Chugunov`
+* `Vadim Petrochenkov`
+* `Valerii Hiora`
+* `Victory`
+* `visualfc`
+* `Vojtech Kral`
+* `Volker Mische`
+* `Wangshan Lu`
+* `we`
+* `Willson Mock`
+* `Will`
+* `wonyong kim`
+* `York Xiang`

--- a/_posts/2015-02-20-Rust-1.0-alpha2.md
+++ b/_posts/2015-02-20-Rust-1.0-alpha2.md
@@ -32,7 +32,7 @@ in nightly.
 For more detail, please see the [Release
 notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-100-alpha2-february-2015). 
 
-Thank you to all 204 contributors for this release:
+Thank you to all 201 contributors for this release:
 
 * `Aaron Turon`
 * `Adam Roben`
@@ -46,11 +46,9 @@ Thank you to all 204 contributors for this release:
 * `Alex Crichton`
 * `Alexis`
 * `Alfie John`
-* `Alfie John`
 * `Andrea Canciani`
 * `Andrew Barchuk`
 * `Andrew Paseltiner`
-* `Ariel Ben-Yehuda`
 * `Ariel Ben-Yehuda`
 * `Armin Preiml`
 * `Artem`
@@ -128,7 +126,6 @@ Thank you to all 204 contributors for this release:
 * `Julian Orth`
 * `Junseok Lee`
 * `Kang Seonghoon`
-* `Keegan McAllister`
 * `Keegan McAllister`
 * `Ken Tossell`
 * `KernelJ`

--- a/_posts/2015-04-03-Rust-1.0-beta.md
+++ b/_posts/2015-04-03-Rust-1.0-beta.md
@@ -73,175 +73,175 @@ community at large. Thanks to everyone who has participated in the RFC
 process, and a particular thank you to the 172 contributors for this
 release:
 
-- `Aaron Turon <aturon@mozilla.com>`
-- `Aaron Weiss <aaronweiss74@gmail.com>`
-- `Adam Jacob <adam@opscode.com>`
-- `Adenilson Cavalcanti <cavalcantii@gmail.com>`
-- `Adolfo Ochagavía <aochagavia92@gmail.com>`
-- `Ahmed Charles <ahmedcharles@gmail.com>`
-- `Alan Cutter <alancutter@chromium.org>`
-- `Alex Crichton <alex@alexcrichton.com>`
-- `Alexander Bliskovsky <alexander.bliskovsky@gmail.com>`
-- `Alexander Campbell <alexanderhcampbell@gmail.com>`
-- `Alexander Chernyakhovsky <achernya@mit.edu>`
-- `Alexis <a.beingessner@gmail.com>`
-- `Alexis Beingessner <a.beingessner@gmail.com>`
-- `Amol Mundayoor <amol.com@gmail.com>`
-- `Anders Kaseorg <andersk@mit.edu>`
-- `Andrew Hobden <andrew@hoverbear.org>`
-- `Andrew Paseltiner <apaseltiner@gmail.com>`
-- `Angus Lees <gus@inodes.org>`
-- `awlnx <alecweber1994@gmail.com>`
-- `Barosl Lee <vcs@barosl.com>`
-- `bcoopers <coopersmithbrian@gmail.com>`
-- `Björn Steinbrink <bsteinbr@gmail.com>`
-- `bombless <bombless@126.com>`
-- `Brian Anderson <banderson@mozilla.com>`
-- `Brian Brooks <brooks.brian@gmail.com>`
-- `Brian Leibig <brian@brianleibig.com>`
-- `Camille Roussel <camille@rousselfamily.com>`
-- `Camille TJHOA <camille.tjhoa@outlook.com>`
-- `Carol Nichols <carol.nichols@gmail.com>`
+- `Aaron Turon`
+- `Aaron Weiss`
+- `Adam Jacob`
+- `Adenilson Cavalcanti`
+- `Adolfo Ochagavía`
+- `Ahmed Charles`
+- `Alan Cutter`
+- `Alex Crichton`
+- `Alexander Bliskovsky`
+- `Alexander Campbell`
+- `Alexander Chernyakhovsky`
+- `Alexis`
+- `Alexis Beingessner`
+- `Amol Mundayoor`
+- `Anders Kaseorg`
+- `Andrew Hobden`
+- `Andrew Paseltiner`
+- `Angus Lees`
+- `awlnx`
+- `Barosl Lee`
+- `bcoopers`
+- `Björn Steinbrink`
+- `bombless`
+- `Brian Anderson`
+- `Brian Brooks`
+- `Brian Leibig`
+- `Camille Roussel`
+- `Camille TJHOA`
+- `Carol Nichols`
 - `Caspar Krieger`
-- `Ches Martin <ches@whiskeyandgrits.net>`
-- `Chloe <5paceToast@users.noreply.github.com>`
-- `Chris Wong <lambda.fairy@gmail.com>`
-- `Cody P Schafer <dev@codyps.com>`
-- `Corey Farwell <coreyf@rwell.org>`
-- `Corey Richardson <corey@octayn.net>`
-- `Dabo Ross <daboross@daboross.net>`
-- `Dan Burkert <dan@danburkert.com>`
-- `Dan Connolly <dckc@madmode.com>`
-- `Dan W. <1danwade@gmail.com>`
-- `Daniel Lobato García <elobatocs@gmail.com>`
-- `Darin Morrison <darinmorrison+git@gmail.com>`
-- `Darrell Hamilton <darrell.noice@gmail.com>`
-- `Dave Huseby <dhuseby@mozilla.com>`
-- `David Creswick <dcrewi@gyrae.net>`
-- `David King <dave@davbo.org>`
-- `David Mally <djmally@gmail.com>`
-- `defuz <defuz.net@gmail.com>`
-- `Denis Defreyne <denis.defreyne@stoneship.org>`
-- `Drew Crawford <drew@sealedabstract.com>`
-- `Dzmitry Malyshau <kvarkus@gmail.com>`
-- `Eduard Bopp <eduard.bopp@aepsil0n.de>`
-- `Eduard Burtescu <edy.burt@gmail.com>`
-- `Eduardo Bautista <me@eduardobautista.com>`
-- `Edward Wang <edward.yu.wang@gmail.com>`
-- `Emeliov Dmitrii <demelev1990@gmail.com>`
-- `Eric Platon <eric.platon@waku-waku.ne.jp>`
-- `Erick Tryzelaar <erick.tryzelaar@gmail.com>`
-- `Eunji Jeong <eun-ji.jeong@samsung.com>`
-- `Falco Hirschenberger <falco.hirschenberger@gmail.com>`
-- `Felix S. Klock II <pnkfelix@pnkfx.org>`
-- `Fenhl <fenhl@fenhl.net>`
-- `Flavio Percoco <flaper87@gmail.com>`
-- `Florian Hahn <flo@fhahn.com>`
-- `Florian Hartwig <florian.j.hartwig@gmail.com>`
-- `Florian Zeitz <florob@babelmonkeys.de>`
-- `FuGangqiang <fu_gangqiang@163.com>`
-- `Gary M. Josack <gary@byoteki.com>`
-- `Germano Gabbianelli <tyrion@users.noreply.github.com>`
-- `GlacJAY <glacjay@gmail.com>`
-- `Gleb Kozyrev <gleb@gkoz.com>`
-- `Guillaume Gomez <guillaume1.gomez@gmail.com>`
-- `GuillaumeGomez <guillaume1.gomez@gmail.com>`
-- `Huachao Huang <huachao.huang@gmail.com>`
-- `Huon Wilson <dbau.pp+github@gmail.com>`
-- `inrustwetrust <inrustwetrust@users.noreply.github.com>`
-- `Ivan Petkov <ivanppetkov@gmail.com>`
-- `Ivan Radanov Ivanov <ivanradanov@yahoo.co.uk>`
-- `Jake Goulding <jake.goulding@gmail.com>`
-- `Jakub Bukaj <jakub.bukaj@yahoo.com>`
-- `James Miller <bladeon@gmail.com>`
-- `Jessy Diamond Exum <jessy.diamondman@gmail.com>`
-- `Jihyun Yu <j.yu@navercorp.com>`
-- `Johannes Oertel <johannes.oertel@uni-due.de>`
-- `John Hodge <acessdev@gmail.com>`
-- `John Zhang <john@zhang.io>`
-- `Jonathan Reem <jonathan.reem@gmail.com>`
-- `Jordan Woehr <jordanwoehr@gmail.com>`
-- `Jorge Aparicio <japaric@linux.com>`
-- `Joseph Crail <jbcrail@gmail.com>`
-- `JP-Ellis <coujellis@gmail.com>`
-- `Julian Orth <ju.orth@gmail.com>`
-- `Julian Viereck <julian.viereck@gmail.com>`
-- `Junseok Lee <lee.junseok@berkeley.edu>`
-- `Kang Seonghoon <kang.seonghoon@mearie.org>`
-- `Keegan McAllister <kmcallister@mozilla.com>`
-- `Kevin Ballard <kevin@sb.org>`
-- `Kevin Butler <haqkrs@gmail.com>`
-- `Kevin Yap <me@kevinyap.ca>`
-- `kgv <mail@kgv.name>`
-- `kjpgit <kjpgit@users.noreply.github.com>`
-- `Lai Jiangshan <laijs@cn.fujitsu.com>`
-- `Leonids Maslovs <leonids.maslovs@galeoconsulting.com>`
-- `Liam Monahan <liam@monahan.io>`
-- `Liigo Zhuang <com.liigo@gmail.com>`
-- `Łukasz Niemier <lukasz@niemier.pl>`
-- `lummax <luogpg@googlemail.com>`
-- `Manish Goregaokar <manishsmail@gmail.com>`
-- `Markus Siemens <siemens1993@gmail.com>`
-- `Markus Unterwaditzer <markus@unterwaditzer.net>`
-- `Marvin Löbel <loebel.marvin@gmail.com>`
-- `Matt Brubeck <mbrubeck@limpet.net>`
-- `Matt Cox <mattcoxpdx@gmail.com>`
-- `mdinger <mdinger.bugzilla@gmail.com>`
-- `Michael Woerister <michaelwoerister@gmail>`
-- `Michał Krasnoborski <mkrdln@gmail.com>`
-- `Mihnea Dobrescu-Balaur <mihnea@linux.com>`
-- `Mikhail Zabaluev <mikhail.zabaluev@gmail.com>`
-- `Ms2ger <ms2ger@gmail.com>`
-- `Murarth <murarth@gmail.com>`
-- `Nicholas Bishop <nicholasbishop@gmail.com>`
-- `Nicholas Mazzuca <npmazzuca@gmail.com>`
-- `Nicholas <npmazzuca@gmail.com>`
-- `Nick Cameron <ncameron@mozilla.com>`
-- `Niko Matsakis <niko@alum.mit.edu>`
-- `nwin <nwin@users.noreply.github.com>`
-- `Oliver Schneider <git1984941651981@oli-obk.de>`
-- `Or Neeman <oneeman@gmail.com>`
-- `Pascal Hertleif <killercup@gmail.com>`
-- `Patrick Walton <pcwalton@mimiga.net>`
-- `Paul ADENOT <paul@paul.cx>`
-- `Paul Osborne <osbpau@gmail.com>`
-- `Peter Elmers <peter.elmers@yahoo.com>`
-- `Phil Dawes <pdawes@drw.com>`
-- `Philip Munksgaard <pmunksgaard@gmail.com>`
-- `Piotr Czarnecki <pioczarn@gmail.com>`
-- `Pyry Kontio <pyry.kontio@drasa.eu>`
-- `Raphael Nestler <raphael.nestler@gmail.com>`
-- `ray glover <ray@rayglover.net>`
-- `Ricardo Martins <ricardo@scarybox.net>`
-- `Richard Diamond <wichard@vitalitystudios.com>`
-- `Richo Healey <richo@psych0tik.net>`
-- `Ruud van Asseldonk <dev@veniogames.com>`
-- `Ryan Prichard <ryan.prichard@gmail.com>`
-- `Sae-bom Kim <sae-bom.kim@samsung.com>`
-- `Scott Olson <scott@scott-olson.org>`
-- `Sean McArthur <sean.monstar@gmail.com>`
-- `Sébastien Marie <semarie@users.noreply.github.com>`
-- `Seo Sanghyeon <sanxiyn@gmail.com>`
-- `Simonas Kazlauskas <github@kazlauskas.me>`
-- `Simonas Kazlauskas <git@kazlauskas.me>`
-- `Stepan Koltsov <nga@yandex-team.ru>`
-- `Stepan Koltsov <stepan.koltsov@gmail.com>`
-- `Steve Klabnik <steve@steveklabnik.com>`
-- `Steven Crockett <crockett.j.steven@gmail.com>`
-- `Steven Fackler <sfackler@gmail.com>`
-- `Tamir Duberstein <tamird@gmail.com>`
-- `Tero Hänninen <tejohann@kapsi.fi>`
-- `Tiago Nobrega <tigarmo@gmail.com>`
-- `Tobias Bucher <tobiasbucher5991@gmail.com>`
-- `Tom Jakubowski <tom@crystae.net>`
-- `Trent Nadeau <tanadeau@gmail.com>`
-- `Tshepang Lekhonkhobe <tshepang@gmail.com>`
-- `Ulrik Sverdrup <root@localhost>`
-- `Vadim Chugunov <vadimcn@gmail.com>`
-- `Vadim Petrochenkov <vadim.petrochenkov@gmail.com>`
-- `Valerii Hiora <valerii.hiora@gmail.com>`
-- `Vladimir Pouzanov <farcaller@gmail.com>`
-- `Vojtech Kral <vojtech@kral.hk>`
-- `Wangshan Lu <wisagan@gmail.com>`
-- `Wesley Wiser <wwiser@gmail.com>`
-- `York Xiang <bombless@126.com>`
+- `Ches Martin`
+- `Chloe`
+- `Chris Wong`
+- `Cody P Schafer`
+- `Corey Farwell`
+- `Corey Richardson`
+- `Dabo Ross`
+- `Dan Burkert`
+- `Dan Connolly`
+- `Dan W.`
+- `Daniel Lobato García`
+- `Darin Morrison`
+- `Darrell Hamilton`
+- `Dave Huseby`
+- `David Creswick`
+- `David King`
+- `David Mally`
+- `defuz`
+- `Denis Defreyne`
+- `Drew Crawford`
+- `Dzmitry Malyshau`
+- `Eduard Bopp`
+- `Eduard Burtescu`
+- `Eduardo Bautista`
+- `Edward Wang`
+- `Emeliov Dmitrii`
+- `Eric Platon`
+- `Erick Tryzelaar`
+- `Eunji Jeong`
+- `Falco Hirschenberger`
+- `Felix S. Klock II`
+- `Fenhl`
+- `Flavio Percoco`
+- `Florian Hahn`
+- `Florian Hartwig`
+- `Florian Zeitz`
+- `FuGangqiang`
+- `Gary M. Josack`
+- `Germano Gabbianelli`
+- `GlacJAY`
+- `Gleb Kozyrev`
+- `Guillaume Gomez`
+- `GuillaumeGomez`
+- `Huachao Huang`
+- `Huon Wilson`
+- `inrustwetrust`
+- `Ivan Petkov`
+- `Ivan Radanov Ivanov`
+- `Jake Goulding`
+- `Jakub Bukaj`
+- `James Miller`
+- `Jessy Diamond Exum`
+- `Jihyun Yu`
+- `Johannes Oertel`
+- `John Hodge`
+- `John Zhang`
+- `Jonathan Reem`
+- `Jordan Woehr`
+- `Jorge Aparicio`
+- `Joseph Crail`
+- `JP-Ellis`
+- `Julian Orth`
+- `Julian Viereck`
+- `Junseok Lee`
+- `Kang Seonghoon`
+- `Keegan McAllister`
+- `Kevin Ballard`
+- `Kevin Butler`
+- `Kevin Yap`
+- `kgv`
+- `kjpgit`
+- `Lai Jiangshan`
+- `Leonids Maslovs`
+- `Liam Monahan`
+- `Liigo Zhuang`
+- `Łukasz Niemier`
+- `lummax`
+- `Manish Goregaokar`
+- `Markus Siemens`
+- `Markus Unterwaditzer`
+- `Marvin Löbel`
+- `Matt Brubeck`
+- `Matt Cox`
+- `mdinger`
+- `Michael Woerister`
+- `Michał Krasnoborski`
+- `Mihnea Dobrescu-Balaur`
+- `Mikhail Zabaluev`
+- `Ms2ger`
+- `Murarth`
+- `Nicholas Bishop`
+- `Nicholas Mazzuca`
+- `Nicholas`
+- `Nick Cameron`
+- `Niko Matsakis`
+- `nwin`
+- `Oliver Schneider`
+- `Or Neeman`
+- `Pascal Hertleif`
+- `Patrick Walton`
+- `Paul ADENOT`
+- `Paul Osborne`
+- `Peter Elmers`
+- `Phil Dawes`
+- `Philip Munksgaard`
+- `Piotr Czarnecki`
+- `Pyry Kontio`
+- `Raphael Nestler`
+- `ray glover`
+- `Ricardo Martins`
+- `Richard Diamond`
+- `Richo Healey`
+- `Ruud van Asseldonk`
+- `Ryan Prichard`
+- `Sae-bom Kim`
+- `Scott Olson`
+- `Sean McArthur`
+- `Sébastien Marie`
+- `Seo Sanghyeon`
+- `Simonas Kazlauskas`
+- `Simonas Kazlauskas`
+- `Stepan Koltsov`
+- `Stepan Koltsov`
+- `Steve Klabnik`
+- `Steven Crockett`
+- `Steven Fackler`
+- `Tamir Duberstein`
+- `Tero Hänninen`
+- `Tiago Nobrega`
+- `Tobias Bucher`
+- `Tom Jakubowski`
+- `Trent Nadeau`
+- `Tshepang Lekhonkhobe`
+- `Ulrik Sverdrup`
+- `Vadim Chugunov`
+- `Vadim Petrochenkov`
+- `Valerii Hiora`
+- `Vladimir Pouzanov`
+- `Vojtech Kral`
+- `Wangshan Lu`
+- `Wesley Wiser`
+- `York Xiang`

--- a/_posts/2015-04-03-Rust-1.0-beta.md
+++ b/_posts/2015-04-03-Rust-1.0-beta.md
@@ -70,7 +70,7 @@ the development phase, but you can see a [sample report][sr] here.
 
 As always, this Rust release is the achievement of the fantastic Rust
 community at large. Thanks to everyone who has participated in the RFC
-process, and a particular thank you to the 172 contributors for this
+process, and a particular thank you to the 170 contributors for this
 release:
 
 - `Aaron Turon`
@@ -223,8 +223,6 @@ release:
 - `Sébastien Marie`
 - `Seo Sanghyeon`
 - `Simonas Kazlauskas`
-- `Simonas Kazlauskas`
-- `Stepan Koltsov`
 - `Stepan Koltsov`
 - `Steve Klabnik`
 - `Steven Crockett`


### PR DESCRIPTION
See #144. Oldest release blog posts now match the format of the newer pre-[thanks](thanks.rust-lang.org) blog posts in terms of contributor lists. I then also removed duplicate names from the lists, after determining that said duplicate names are most likely from the same person using different e-mail addresses. If you'd like me to separate these out into two pull requests, I can do so, but for now here's just the one pull request.