### PR TITLE
Disable err class in syntax highlighting

### DIFF
--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -6,7 +6,9 @@
     @extend %vertical-rhythm;
 
     .c     { color: #998; font-style: italic } // Comment
+    /* Disabled due to false positives
     .err   { color: #a61717; background-color: #e3d2d2 } // Error
+    */
     .k     { font-weight: bold } // Keyword
     .o     { font-weight: bold } // Operator
     .cm    { color: #998; font-style: italic } // Comment.Multiline


### PR DESCRIPTION
`'a` is always highlighted as an error (unmatched quote); until this is fixed, disable error highlighting.