### PR TITLE
Fix Cargo Config Linker Reference

### DIFF
--- a/_posts/2016-05-13-rustup.md
+++ b/_posts/2016-05-13-rustup.md
@@ -401,7 +401,7 @@ so we don't have to keep calling cargo with the `--target` option.
 target = "arm-linux-androideabi"
 
 [target.arm-linux-androideabi]
-linker = "/home/rust/android-18-toolchain"
+linker = "/home/rust/android-18-toolchain/bin/arm-linux-androideabi-clang"
 ```
 
 Now let's change back to the 'hello' project directory and try


### PR DESCRIPTION
Today I went through [this guide](https://blog.rust-lang.org/2016/05/13/rustup.html) to running Rust on Android. I got everything working but had to make one modification to the cargo config file.

Instead of

```toml
[target.arm-linux-androideabi]
linker = "/home/rust/android-18-toolchain"
```

I had to write something like

```toml
linker = "/home/rust/android-18-toolchain/bin/arm-linux-androideabi-clang"
```

I was getting an error on cargo build which looked like this:

```
$ cargo build -v --release
...snipped output...
checking for C compiler default output file name... 

--- stderr
configure: WARNING: If you wanted to set the --build type, don't use --host.
    If a cross compiler is detected then cross compile mode will be used.
configure: error: in `/Users/brian/projects/helloRust/rust-code/target/arm-linux-androideabi/release/build/backtrace-sys-c41044212322c9f2/out':
configure: error: C compiler cannot create executables
See `config.log' for more details.
thread 'main' panicked at 'failed with: exit code: 77', /Users/brian/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-sys-0.1.10/build.rs:134
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

Just plain `clang` worked as well so I'm not sure what the best solution is here. For the record, here are all the binaries in the `/bin` directory of the standalone toolchain I made:

```
$ ls android-18-toolchain/bin/
arm-linux-androideabi-addr2line  arm-linux-androideabi-gcov       armeabi                          llvm-ar
arm-linux-androideabi-ar         arm-linux-androideabi-gdb        armeabi-v7a                      llvm-as
arm-linux-androideabi-as         arm-linux-androideabi-gprof      armeabi-v7a-hard                 llvm-dis
arm-linux-androideabi-c++        arm-linux-androideabi-ld         asan_device_setup                llvm-link
arm-linux-androideabi-c++filt    arm-linux-androideabi-ld.bfd     clang                            mips
arm-linux-androideabi-clang      arm-linux-androideabi-ld.gold    clang++                          mips64
arm-linux-androideabi-clang++    arm-linux-androideabi-ld.mcld    clang36                          ndk-link
arm-linux-androideabi-cpp        arm-linux-androideabi-nm         clang36++                        ndk-strip
arm-linux-androideabi-dwp        arm-linux-androideabi-objcopy    ld.mcld                          ndk-translate
arm-linux-androideabi-elfedit    arm-linux-androideabi-objdump    le32-none-ndk-link               opt
arm-linux-androideabi-g++        arm-linux-androideabi-ranlib     le32-none-ndk-strip              python
arm-linux-androideabi-gcc        arm-linux-androideabi-readelf    le32-none-ndk-translate          python2
arm-linux-androideabi-gcc-4.8    arm-linux-androideabi-size       le64-none-ndk-link               python2.7
arm-linux-androideabi-gcc-ar     arm-linux-androideabi-strings    le64-none-ndk-strip              x86
arm-linux-androideabi-gcc-nm     arm-linux-androideabi-strip      le64-none-ndk-translate          x86_64
arm-linux-androideabi-gcc-ranlib arm64-v8a                        llc

```

In any case, I just want to update this article so no one is as confused as I was when trying to build a shared lib for Android.