### PR TITLE
Fix typos in 1.17 release post

### DIFF
--- a/_posts/2017-04-27-Rust-1.17.md
+++ b/_posts/2017-04-27-Rust-1.17.md
@@ -221,10 +221,10 @@ Now, you can write
 ```rust
 SocketAddr::from(([127, 0, 0, 1], 3000))
 // or even
-([127, 0, 0, 1], 3000).into())
+([127, 0, 0, 1], 3000).into()
 ```
 
-This removes some unnecesary run-time parsing, and is roughly as readable, depending on
+This removes some unnecessary run-time parsing, and is roughly as readable, depending on
 your preferences.
 
 Backtraces [now have nicer formatting](https://github.com/rust-lang/rust/pull/38165), eliding


### PR DESCRIPTION
This PR fixes an extra paren in a code sample and a misspelling of of "unnecessary".