### PR TITLE
Fix broken link

### DIFF
--- a/_posts/2017-08-31-Rust-1.20.md
+++ b/_posts/2017-08-31-Rust-1.20.md
@@ -172,7 +172,7 @@ stack guard on Linux]. You don't need to do anything to get these protections
 other than using Rust 1.20.
 
 [stack probes]: https://github.com/rust-lang/rust/pull/42816
-[skipping the main thread's manual stack guard on Linux]: (https://github.com/rust-lang/rust/pull/43072)
+[skipping the main thread's manual stack guard on Linux]: https://github.com/rust-lang/rust/pull/43072
 
 We've added a new trio of sorting functions to the standard library:
 [`slice::sort_unstable_by_key`], [`slice::sort_unstable_by`], and


### PR DESCRIPTION
The link for `skipping the main thread's manual stack guard on Linux` was broken (surrounded by parens)