### PR TITLE
Replace "less" with "fewer" as constraints is a countable noun

### DIFF
--- a/_posts/2017-08-31-Rust-1.20.md
+++ b/_posts/2017-08-31-Rust-1.20.md
@@ -212,7 +212,7 @@ rust
 
 That is, the results *may* not be in the same original order.
 
-As you might imagine, less constraints often means faster results. If you don't care
+As you might imagine, fewer constraints often means faster results. If you don't care
 about stability, these sorts may be faster for you than the stable variants. As always,
 best to check both and see! These functions were added by [RFC 1884], if you'd like
 more details, including benchmarks.


### PR DESCRIPTION
I hope I got this correction right, English likes to trick me 😁 