### PR TITLE
Add redirect from /impl-days to the announcement post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'github-pages'
 gem 'jekyll', '~>3.1.6'
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll (~> 3.1.6)
+  jekyll-redirect-from
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,9 @@ github_username: rust-lang
 highlighter: rouge
 
 root: https://blog.rust-lang.org
+
+gems:
+  - jekyll-redirect-from
+
+whitelist:
+  - jekyll-redirect-from

--- a/_posts/2017-09-18-impl-future-for-rust.md
+++ b/_posts/2017-09-18-impl-future-for-rust.md
@@ -3,6 +3,8 @@ layout: post
 title: "impl Future for Rust"
 author: Aaron Turon
 description: "The Rust community is going to finish out its 2017 roadmap with a bang—and we want your help!"
+redirect_from:
+  - /impl-days
 ---
 
 The Rust community has been hard at work on our [2017 roadmap], but as we come


### PR DESCRIPTION
This adds jekyll-redirect-from as suggested in the outdated docs [here](https://help.github.com/articles/redirects-on-github-pages/), but according to its docs [here](https://github.com/jekyll/jekyll-redirect-from). I hope that builds on Githubs infrastructure...

It then adds a redirect from "/impl-days" to the announcement blog post. This allows us to better communicate this in, for example, printed material.