### PR TITLE
Move canonical links from http to https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,12 +3,12 @@ title: The Rust Programming Language Blog
 description: >
   Words from the Rust team
 baseurl: ""
-url: "http://blog.rust-lang.org"
+url: "https://blog.rust-lang.org"
 logo: "https://www.rust-lang.org/logos/rust-logo-64x64-blk.png"
 twitter_username: rustlang
-github_username:  rust-lang
+github_username: rust-lang
 
 # Build settings
 highlighter: rouge
 
-root: http://blog.rust-lang.org
+root: https://blog.rust-lang.org

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<div class="footer-links"><a href="http://rust-lang.org/">More about Rust</a> &mdash; <a href="http://doc.rust-lang.org/book/index.html">Jump straight in</a></div>
+<div class="footer-links"><a href="https://www.rust-lang.org/">More about Rust</a> &mdash; <a href="https://doc.rust-lang.org/book/index.html">Jump straight in</a></div>
 
 <footer class="site-footer">
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
 
     <title>{% if page.title %}{{ page.title }} - {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="description" content="{{ site.description }}">
-    <link rel="alternate" type="application/rss+xml" title="The Rust Programming Language Blog" href="http://blog.rust-lang.org/feed.xml" />
+    <link rel="alternate" type="application/rss+xml" title="The Rust Programming Language Blog" href="https://blog.rust-lang.org/feed.xml" />
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/css/center-img.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
Fixes #150 

Only moves the canonical URLs, blog posts are left intact.

Also links https://www.rust-lang.org, https://rust-lang.org doesn't work.
