### PR TITLE
Better example

### DIFF
--- a/_posts/2017-11-22-Rust-1.22.md
+++ b/_posts/2017-11-22-Rust-1.22.md
@@ -42,17 +42,15 @@ In Rust 1.22, basic usage of `?` with `Option<T>` is now stable.
 This code will now compile:
 
 ```rust
-fn try_option_some() -> Option<u8> {
-    let val = Some(1)?;
-    Some(val)
+fn add_one_to_first(list: &[u8]) -> Option<u8> {
+    // get first element, if exists
+    // return None if it doesn't
+    let first = list.get(0)?;
+    Some(first + 1)
 }
-assert_eq!(try_option_some(), Some(1));
 
-fn try_option_none() -> Option<u8> {
-    let val = None?;
-    Some(val)
-}
-assert_eq!(try_option_none(), None);
+assert_eq!(add_one_to_first(&[10, 20, 30]), Some(11));
+assert_eq!(add_one_to_first(&[]), None);
 ```
 
 However, this functionality is still a bit limited; you cannot yet write


### PR DESCRIPTION
Folks seem to be getting confused by the explicit `Some(1)` in the code ; here's an example which isn't hardcoded.