### PR TITLE
Add new post: The 2018 Rust Event Lineup

### DIFF
--- a/_posts/2018-01-19-event-lineup.md
+++ b/_posts/2018-01-19-event-lineup.md
@@ -19,7 +19,7 @@ Find all information on [the Roadshow website][roadshow].
 
 ### February 3-4: FOSDEM - Rust Dev Room
 
-After a very successful Bird of Feathers session for Rust last year at FOSDEM,
+After a very successful [Birds of a Feather][bof] session for Rust last year at FOSDEM,
 this year will have the first edition of the [Rust Dev Room][fosdem-rust].
 Co-located with [FOSDEM 2018][fosdem], the annual conference about free and open source software,
 it will bring together the Rust community in **Brussel, Belgium**.
@@ -27,6 +27,7 @@ it will bring together the Rust community in **Brussel, Belgium**.
 A fully packed Sunday brings you 16 talks covering topics ranging from GUI programming, robotics and multimedia to idiomatic Rust, testing and memory management.
 Check out [the full devromm schedule][devroom-schedule].
 
+[bof]: https://en.wikipedia.org/wiki/Birds_of_a_feather_(computing)
 [fosdem]: https://fosdem.org/2018/
 [fosdem-rust]: https://rust-fosdem.github.io/
 [devroom-schedule]: https://fosdem.org/2018/schedule/track/rust/

--- a/_posts/2018-01-19-event-lineup.md
+++ b/_posts/2018-01-19-event-lineup.md
@@ -7,14 +7,17 @@ description: "Multitude of Rust event are happening this year; join us at one ne
 
 Every year there are multiple Rust events around the world, bringing together the community.
 
-### February 1-3: Mozilla Rust Roadshow Brasil 2018
+### February 1-4: Mozilla Rust Roadshow Brasil 2018
 
-The [Rust Roadshow][roadshow] is a series of workshops for Rust.
-Learn Rust with the community in several cities across Brazil.
+The Mozilla Rust Roadshow Brasil is a series of workshops that will happen
+throughout the country between February 1st and 4th to broaden the adoption of Rust in Brazil.
+The project is organized by developers and community leaders, contributing along with Mozilla Brasil community organizers.
 
-Several workshops are already scheduled for the beginning of February, with hopefully more to come.
-Find all information on [the Roadshow website][roadshow].
+Find more about who's leading and contributing to the Mozilla Rust Roadshow Brasil 2018 in [Adding Superheroes to the Rust Brazilian Community][heroes].
 
+Learn about the workshops and where they are happening on [the Roadshow website][roadshow].
+
+[heroes]: https://mozillabr.org/2018/01/adding-superheroes-to-the-rust-brazilian-community/
 [roadshow]: https://rust-br.github.io/2018-roadshow/
 
 ### February 3-4: FOSDEM - Rust Dev Room

--- a/_posts/2018-01-19-event-lineup.md
+++ b/_posts/2018-01-19-event-lineup.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title: "The 2018 Rust Event Lineup"
+author: Rust Community
+description: "Multitude of Rust event are happening this year; join us at one near you!"
+---
+
+Every year there are multiple Rust events around the world, bringing together the community.
+
+### February 1-3: Mozilla Rust Roadshow Brasil 2018
+
+The [Rust Roadshow][roadshow] is a series of workshops for Rust.
+Learn Rust with the community in several cities across Brazil.
+
+Several workshops are already scheduled for the beginning of February, with hopefully more to come.
+Find all information on [the Roadshow website][roadshow].
+
+[roadshow]: https://rust-br.github.io/2018-roadshow/
+
+### February 3-4: FOSDEM - Rust Dev Room
+
+After a very successful Bird of Feathers session for Rust last year at FOSDEM,
+this year will have the first edition of the [Rust Dev Room][fosdem-rust].
+Co-located with [FOSDEM 2018][fosdem], the annual conference about free and open source software,
+it will bring together the Rust community in **Brussel, Belgium**.
+
+A fully packed Sunday brings you 16 talks covering topics ranging from GUI programming, robotics and multimedia to idiomatic Rust, testing and memory management.
+Check out [the full devromm schedule][devroom-schedule].
+
+[fosdem]: https://fosdem.org/2018/
+[fosdem-rust]: https://rust-fosdem.github.io/
+[devroom-schedule]: https://fosdem.org/2018/schedule/track/rust/
+
+### May XX-YY: RustFest Paris
+
+The fourth iteration of RustFest will happen on May XXth and YYth in **Paris, France**.
+Once again there will be a full day of talks and a second day with multiple workshops, allowing you to learn, connect and code together with other Rustaceans.
+
+The CfP and ticket sales will open soon.
+Keep an eye on [rustfest.eu], get all updates on the [blog][rustfest-blog] and don’t forget to follow [@rustfest] on Twitter.
+Want to get a glimpse into what it's like? Check out last year's videos from [Kyiv] or [Zurich]!
+
+[rustfest.eu]: http://rustfest.eu
+[rustfest-blog]: http://blog.rustfest.eu/
+[@rustfest]: https://twitter.com/rustfest
+[kyiv]: https://www.youtube.com/watch?v=AHprJNUCgQ0&list=PL85XCvVPmGQhvs1Rnet_24B-AI3YSM2YG
+[zurich]: https://www.youtube.com/watch?v=jywiVWKm1TI&list=PL85XCvVPmGQj9mqbJizw-zi-EhcpS5jTP
+
+### August 16-17: RustConf
+
+[RustConf] is a two-day event held in **Portland, OR, USA** on August 16-17.
+
+The first day will again offer tutorials on Rust given directly by members of the Rust core team, ranging from absolute basics to advanced ownership techniques.
+The second day is the main event, with talks at every level of expertise, so don't miss the CfP to submit your talk soon!
+
+More details will be available on [rustconf.com][rustconf]. You can also follow [@rustconf] on Twitter for all announcements.
+
+[rustconf]: http://rustconf.com/
+[@rustconf]: https:/twitter.com/rustconf
+
+### October: Rust Belt Rust
+
+[Rust Belt Rust](https://www.rust-belt-rust.com/) will have its third iteration this year in October.
+You can once again expect two days of talks and workshops.
+
+More details will come soon.
+Follow [@rustbeltrust] on Twitter for the latest news.
+
+[@rustbeltrust]: https://twitter.com/rustbeltrust
+
+---
+
+As always, there are nearly a hundred [Rust User Groups][usergroups] worldwide.
+Take a look if there's one near you or get people together and start a new one!
+
+[usergroups]: https://www.rust-lang.org/en-US/user-groups.html

--- a/_posts/2018-01-19-event-lineup.md
+++ b/_posts/2018-01-19-event-lineup.md
@@ -73,7 +73,7 @@ Follow [@rustbeltrust] on Twitter for the latest news.
 
 As always, there are nearly a hundred [Rust User Groups][usergroups] worldwide.
 Take a look if there's one near you or look at upcoming events in the [Rust Community calendar][calendar].
-If you are running a Rust event email the [Rust Community Team][commteam] to add it.
+If you are running a Rust event or are interested in starting one email the [Rust Community Team][commteam] to add it.
 
 [usergroups]: https://www.rust-lang.org/en-US/user-groups.html
 [calendar]: https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com

--- a/_posts/2018-01-19-event-lineup.md
+++ b/_posts/2018-01-19-event-lineup.md
@@ -72,6 +72,9 @@ Follow [@rustbeltrust] on Twitter for the latest news.
 ---
 
 As always, there are nearly a hundred [Rust User Groups][usergroups] worldwide.
-Take a look if there's one near you or get people together and start a new one!
+Take a look if there's one near you or look at upcoming events in the [Rust Community calendar][calendar].
+If you are running a Rust event email the [Rust Community Team][commteam] to add it.
 
 [usergroups]: https://www.rust-lang.org/en-US/user-groups.html
+[calendar]: https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com
+[commteam]: mailto:community-team@rust-lang.org

--- a/_posts/2018-01-19-event-lineup.md
+++ b/_posts/2018-01-19-event-lineup.md
@@ -22,7 +22,7 @@ Find all information on [the Roadshow website][roadshow].
 After a very successful [Birds of a Feather][bof] session for Rust last year at FOSDEM,
 this year will have the first edition of the [Rust Dev Room][fosdem-rust].
 Co-located with [FOSDEM 2018][fosdem], the annual conference about free and open source software,
-it will bring together the Rust community in **Brussel, Belgium**.
+it will bring together the Rust community in **Brussels, Belgium**.
 
 A fully packed Sunday brings you 16 talks covering topics ranging from GUI programming, robotics and multimedia to idiomatic Rust, testing and memory management.
 Check out [the full devromm schedule][devroom-schedule].


### PR DESCRIPTION
This is my first go at an early rust event post for 2018.
Includes the three major conferences plus 

Todo:
* [ ] Fill in RustFest date (hopefully in a day or 2)
* [ ] Decide on publishing date (currently set to Friday, 19th January)
* [ ] Any major event missing?

This is a community team effort, coordination happening here: https://github.com/rust-community/team/issues/196.

cc @ashleygwilliams @skade @booyaa @Manishearth @sebasmagri @johannhof @carols10cents @bstrie @erickt @jonathandturner 