### PR TITLE
1.25 announcement: Fix description for NonNull again

### DIFF
--- a/_posts/2018-03-29-Rust-1.25.md
+++ b/_posts/2018-03-29-Rust-1.25.md
@@ -100,7 +100,7 @@ See the [detailed release notes][notes] for more.
 The biggest story in libraries this release is [`std::ptr::NonNull<T>`]. This type
 is similar to `*mut T`, but is non-null and covariant. This blog post isn't the right
 place to explain variance, but in a nutshell, `NonNull<T>`, well, guarantees that it
-won't be null, which means that `Option<NonNull<T>>` has the same size as `T`.
+won't be null, which means that `Option<NonNull<T>>` has the same size as `*mut T`.
 If you're building a data structure with unsafe code, `NonNull<T>` is often the right
 type for you!
 


### PR DESCRIPTION
`Option<NonNull<T>>` has the same size as `*mut T`, not `T`.