### PR TITLE
Updated nokogiri since the 1.8.1 version has a CVE.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
+    ffi (1.9.18-x64-mingw32)
     ffi (1.9.18-x86-mingw32)
     gemoji (2.1.0)
     github-pages (92)
@@ -100,9 +101,11 @@ GEM
     minitest (5.11.1)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.1-x86-mingw32)
+    nokogiri (1.8.2-x64-mingw32)
+      mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.2-x86-mingw32)
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -111,7 +114,6 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rouge (1.11.1)
-    ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
@@ -132,6 +134,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
   x86-mingw32
 
 DEPENDENCIES
@@ -139,4 +142,4 @@ DEPENDENCIES
   jekyll (~> 3.1.6)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1


### PR DESCRIPTION
As I was trying to provide a [blog boilerplate](https://github.com/o0Ignition0o/rust-lang-blog-boilerplate), based on this blog (as part of the Mozilla sprint / content-o-tron initiative) Github notified me nokogiri version 1.8.1 is vulnerable (https://nvd.nist.gov/vuln/detail/CVE-2017-18258)
I've updated it locally and could not find any issue, and the CVE seems to have been patched.