### PR TITLE
Remove google analytics

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -49,14 +49,3 @@
   </div>
 
 </footer>
-
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-58390457-2', 'auto');
-  ga('send', 'pageview');
-
-</script>


### PR DESCRIPTION
This removes google analytics from blog.rust-lang.org.
See discussion in https://github.com/rust-lang/rust/issues/47347 for more details.