### PR TITLE
Make code inside h* look like a header

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -222,7 +222,7 @@
 .post-content {
     margin-bottom: $spacing-unit;
 
-    h2 {
+    h2, h2 code {
         font-size: 32px;
 
         @include media-query($on-laptop) {
@@ -230,7 +230,7 @@
         }
     }
 
-    h3 {
+    h3, h3 code {
         font-size: 26px;
 
         @include media-query($on-laptop) {
@@ -238,7 +238,7 @@
         }
     }
 
-    h4 {
+    h4, h4 code {
         font-size: 20px;
 
         @include media-query($on-laptop) {


### PR DESCRIPTION
I almost missed https://blog.rust-lang.org/2018/06/21/Rust-1.27.html#dyn-trait because there's nothing other than the shortness of the sencence indicating that it is a header, https://blog.rust-lang.org/2018/06/21/Rust-1.27.html#must_use-on-functions also looks a little weird currently.