### PR TITLE
Fix typo in Rust 1.27.1 release post

### DIFF
--- a/_posts/2018-07-10-Rust-1.27.1.md
+++ b/_posts/2018-07-10-Rust-1.27.1.md
@@ -26,7 +26,7 @@ appropriate page on our website, and check out the [detailed release notes for
 This patch release fixes a bug in the borrow checker verification of `match` expressions.
 This bug was introduced in 1.26.0 with the stabilization of [match ergonomics]. We are
 uncertain that this specific problem actually indicated unsoundness in the borrow checker,
-but suspected that it might be a possibility, so decided to issue at point release. The
+but suspected that it might be a possibility, so decided to issue a point release. The
 code sample below caused a panic inside the compiler prior to this patch.
 
 ```rust


### PR DESCRIPTION
Just a small typo I noticed while reading the post.