### PR TITLE
Update 2018-10-25-Rust-1.30.0.md

### DIFF
--- a/_posts/2018-10-25-Rust-1.30.0.md
+++ b/_posts/2018-10-25-Rust-1.30.0.md
@@ -335,7 +335,7 @@ A few new APIs were [stabilized for this
 release](https://github.com/rust-lang/rust/blob/master/RELEASES.md#stabilized-apis):
 
 * `Ipv4Addr::{BROADCAST, LOCALHOST, UNSPECIFIED}`
-* `Ipv6Addr::{BROADCAST, LOCALHOST, UNSPECIFIED}`
+* `Ipv6Addr::{LOCALHOST, UNSPECIFIED}`
 * `Iterator::find_map`
 
 Additionally, the standard library has long had functions like `trim_left` to eliminate


### PR DESCRIPTION
There's no `Ipv6Addr::BROADCAST` item. Fixing the typo, probably introduced by coping over from `Ipv4Addr` items that went public.

Ref: https://github.com/rust-lang/rust/blob/master/RELEASES.md#stabilized-apis