### PR TITLE
Preview of the call for 2019 roadmap blogposts

### DIFF
--- a/_posts/2018-12-06-call-for-rust-2019-roadmap-blogposts.md
+++ b/_posts/2018-12-06-call-for-rust-2019-roadmap-blogposts.md
@@ -1,0 +1,76 @@
+# A call for Rust 2019 Roadmap blog posts
+
+It's almost 2019! As such, the Rust team needs to create a roadmap for Rust's
+development next year. At the highest level, Rust's development process looks
+like this:
+
+1. The Rust community blogs about what they'd like to see.
+2. The core team reads these posts, and produces a "roadmap RFC," a proposal
+   for what next year's development looks like.
+3. The RFC is widely discussed, and modified in response to feedback, and
+   eventually accepted.
+4. This RFC becomes a guideline for accepting or postponing RFCs for the next
+   year.
+
+We try to align this with the calendar year, but it doesn't 100% match up,
+currently. Last year, [we had a call for posts on January
+3](https://blog.rust-lang.org/2018/01/03/new-years-rust-a-call-for-community-blogposts.html),
+the roadmap RFC was opened [on Jan
+29th](https://github.com/rust-lang/rfcs/pull/2314), and was [accepted on
+March
+5th](https://github.com/rust-lang/rfcs/pull/2314#issuecomment-370576889).
+This year, we're starting a bit earlier, but it's still not going to be
+accepted before January 1.
+
+## We need you
+
+Starting today and running until of January 15, we’d like to ask the
+community to write blogposts reflecting on Rust in 2018 and proposing goals
+and directions for Rust in 2019. Like last year, these can take many forms:
+
+* A post on your personal or company blog
+* A Medium post
+* A GitHub gist
+* Or any other online writing platform you prefer.
+
+We’re looking for posts on many topics:
+
+* Ideas for community programs
+* Language features
+* Documentation improvements
+* Ecosystem needs
+* Tooling enhancements
+* Or anything else Rust related you hope for in 2019
+
+There's one additional thing this year, however. With the shipping of Rust
+2018 today, it's time to think about the next edition. In other words:
+
+* Rust 2015: Stability
+* Rust 2018: Productivity
+* Rust 2021: ?
+
+We aren't yet *committing* to an edition in 2021, but that's the current
+estimate. Each edition has had some sort of theme associated with it. As
+such, we wouldn't just like to know what you're thinking for Rust in 2019,
+but also, what you want the theme of Rust 2021 to be. Ideally, suggestions
+for Rust in 2019 will fit into the overall goal of the next edition, though
+of course, three years is a lot of time, and so not every single thing must.
+As Rust matures, we need to start thinking of ever-longer horizons, and how
+our current plans fit into those eventual plans.
+
+If you're not sure what to write, check out all of the blog posts from last
+year [over at ReadRust](https://readrust.net/rust-2018/). They may give you
+some inspiration!
+
+## Please share these posts with us
+
+You can write up these posts and email them to `community@rust-lang.org` or
+tweet them with the hashtag `#rust2019`.
+
+The Core team will be reading all of the submitted posts and using them to
+inform the initial roadmap RFC for 2019. Once the RFC is submitted, we’ll
+open up the normal RFC process, though if you want, you are welcome to write
+a post and link to it on the GitHub discussion.
+
+We look forward to working with the entire community to make Rust even more
+wonderful in 2019. Thanks for an awesome 2018!

--- a/_posts/2018-12-06-call-for-rust-2019-roadmap-blogposts.md
+++ b/_posts/2018-12-06-call-for-rust-2019-roadmap-blogposts.md
@@ -59,7 +59,7 @@ As Rust matures, we need to start thinking of ever-longer horizons, and how
 our current plans fit into those eventual plans.
 
 If you're not sure what to write, check out all of the blog posts from last
-year [over at ReadRust](https://readrust.net/rust-2018/). They may give you
+year [over at Read Rust](https://readrust.net/rust-2018/). They may give you
 some inspiration!
 
 ## Please share these posts with us


### PR DESCRIPTION
To be published December 6, alongside the Rust 2018 announcement.

r? @rust-lang/core and everyone else. <3