### PR TITLE
Fix broken link to rustup

### DIFF
--- a/posts/2018-12-06-Rust-1.31-and-rust-2018.md
+++ b/posts/2018-12-06-Rust-1.31-and-rust-2018.md
@@ -19,7 +19,7 @@ If you don't have it already, you can [get `rustup`][install] from the
 appropriate page on our website, and check out the [detailed release notes for
 1.31.0][notes] on GitHub.
 
-[install]: https://www.rust-lang.org/install.html
+[install]: https://www.rust-lang.org/tools/install
 [notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1310-2018-12-06
 
 ## What's in 1.31.0 stable


### PR DESCRIPTION
Before: https://www.rust-lang.org/install.html
After: https://www.rust-lang.org/tools/install