### PR TITLE
Fix width of nav link to homepage

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -63,7 +63,7 @@ section .container {
   padding-top: 20px;
 }
 
-a.brand {
+div.brand {
   $v-top: 3px; // for getting the vertical rhythm just right
 
   color: black;
@@ -71,6 +71,11 @@ a.brand {
   font-size: 3rem;
   text-decoration: none;
   margin-top: $v-top;
+
+  & a {
+    color: black;
+    text-decoration: none;
+  }
 
   img {
     width: 80px;

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -1,8 +1,11 @@
 <nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr4-ns">
-  <a href="https://www.rust-lang.org"  class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
-    <img class="v-mid ml0-l" alt="Rust Logo" src="/images/rust-logo-blk.svg">
-    <span class="dib ml1 ml0-l">Rust</span>
-  </a>
+  <div class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
+    <a href="https://www.rust-lang.org">
+      <img class="v-mid ml0-l" alt="Rust Logo" src="/images/rust-logo-blk.svg">
+      <span class="dib ml1 ml0-l">Rust</span>
+    </a>
+  </div>
+
   <ul class="nav list w-100 w-auto-l flex flex-none flex-row flex-wrap justify-center justify-end-l items-center pv2 ph0 ph4-ns">
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/tools/install">Install</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/learn">Learn</a></li>


### PR DESCRIPTION
The link to the rust homepage is too wide. This wraps it in a div and makes it only as wide as necessary.

Related issue: [#617 on rust-lang/www.rust-lang.org](https://github.com/rust-lang/www.rust-lang.org/issues/617)