### PR TITLE
add missing argument separator

### DIFF
--- a/posts/2018-12-06-Rust-1.31-and-rust-2018.md
+++ b/posts/2018-12-06-Rust-1.31-and-rust-2018.md
@@ -334,7 +334,7 @@ This release includes Rustfmt 1.0. From now on we guarantee backwards
 compatibility for Rustfmt: if you can format your code today, then the
 formatting will not change in the future (only with the default options).
 Backwards compatibility means that running Rustfmt on your CI is practical
-(use `cargo fmt --check`). Try that and 'format on save' in your editor to
+(use `cargo fmt -- --check`). Try that and 'format on save' in your editor to
 revolutionize your workflow.
 
 IDE support is one of the most requested tooling features for Rust. There are


### PR DESCRIPTION
Arguments after '--' are passed to rustfmt.