### PR TITLE
Deterministic order of blog posts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ impl Blog {
 
         // finally, sort the posts. oldest first.
 
-        posts.sort_by_key(|post| format!("{}-{}-{}", post.year, post.month, post.day));
+        posts.sort_by_key(|post| post.url.clone());
 
         posts.reverse();
 


### PR DESCRIPTION
Fixes #330 

This makes sure that blog posts from the _same day_ always appear in the same order, every time the site is built.