### PR TITLE
Rearrange header links

### DIFF
--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -1,17 +1,17 @@
 <nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr4-ns">
   <div class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
-    <a href="https://www.rust-lang.org">
+    <a href="/">
       <img class="v-mid ml0-l" alt="Rust Logo" src="/images/rust-logo-blk.svg">
-      <span class="dib ml1 ml0-l">Rust</span>
+      <span class="dib ml1 ml0-l">Rust Blog</span>
     </a>
   </div>
 
   <ul class="nav list w-100 w-auto-l flex flex-none flex-row flex-wrap justify-center justify-end-l items-center pv2 ph0 ph4-ns">
+    <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org">Rust</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/tools/install">Install</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/learn">Learn</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/tools">Tools</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/governance">Governance</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://www.rust-lang.org/community">Community</a></li>
-    <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://blog.rust-lang.org/" target="_blank" rel="noopener">Blog</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
Issue: #325

- Move the link to [blog.rust-lang.org](https://blog.rust-lang.org) to the rust logo on the left
- Move the link to www.rust-lang.org to the right side.
- The logotype next to the logo now says "Rust Blog"

Preview:

![changed title](https://user-images.githubusercontent.com/15658558/49690806-f579b500-fb36-11e8-82a5-5f1f63562c63.png)

I would also like to emphasize the word "blog" more, so I created this logo, which is **NOT** included in this PR:

![rust-blog-logo](https://user-images.githubusercontent.com/15658558/49973450-63f2b480-ff35-11e8-8f19-04107c365f69.png)

Please, tell me what you think!