### PR TITLE
headers get § links

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -114,6 +114,24 @@ div.brand {
     background-color: rgba($gray, 0.05);
     border: 1px solid rgba($gray, 0.25);
   }
+
+  a.anchor::before {
+    content: "§";
+    display: none;
+    position: absolute;
+    width: 1em;
+    margin-left: -1em;
+    text-decoration: none;
+    opacity: 0.7;
+    color: $gray;
+    font-weight: normal;
+  }
+  :hover > a.anchor::before {
+    display: block;
+  }
+  a.anchor:hover::before {
+    opacity: 1;
+  }
 }
 
 ol, ul {


### PR DESCRIPTION
Fixes #280 

This PR adds a grey "§" sign on the left of a heading when it's hovered. When the mouse is moved over the "§", it gets darker. The "§" is an internal link to itself.

## Screenshot

![on](https://user-images.githubusercontent.com/15658558/49984192-33c40980-ff67-11e8-81f6-2fa27af01f29.png)

When you click on it, the website scrolls to the heading and the URL changes from

[blog.rust-lang.org/2018/10/25/Rust-1.30.0.html](blog.rust-lang.org/2018/10/25/Rust-1.30.0.html)

to

[blog.rust-lang.org/2018/10/25/Rust-1.30.0.html#procedural-macros](blog.rust-lang.org/2018/10/25/Rust-1.30.0.html#procedural-macros)
