### PR TITLE
Fix internal link

### DIFF
--- a/posts/2018-12-06-Rust-1.31-and-rust-2018.md
+++ b/posts/2018-12-06-Rust-1.31-and-rust-2018.md
@@ -40,7 +40,7 @@ post, so here's a table of contents:
 * [New website](#new-website)
 * [Library stabilizations](#library-stabilizations)
 * [Cargo features](#cargo-features)
-* [Contributors](#contributors-to-1310)
+* [Contributors](#contributors-to-131.0)
 
 ### Rust 2018
 


### PR DESCRIPTION
The internal link from the "What's in 1.31.0 stable" section to the "Contributors" section in [Announcing Rust 1.31 and Rust 2018](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html) is incorrect. This PR fixes the link.

Current: [#contributors-to-1310](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html#contributors-to-1310)

![image](https://user-images.githubusercontent.com/933552/50051297-4acc3e00-00c4-11e9-994f-4f347b0268e1.png)

With change: [#contributors-to-131.0](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html#contributors-to-131.0)

![image](https://user-images.githubusercontent.com/933552/50051306-5c154a80-00c4-11e9-93c8-373bb586bb56.png)
