### PR TITLE
Update SEO titles on index page and post pages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,7 +198,7 @@ impl Blog {
 
     fn render_index(&self) -> Result<(), Box<Error>> {
         let data = json!({
-            "title": "Blog",
+            "title": "The Rust Programming Language Blog",
             "parent": "layout",
             "posts": self.posts,
         });
@@ -224,7 +224,7 @@ impl Blog {
             filename.set_extension("html");
 
             let data = json!({
-                "title": "The Rust Programming Language Blog",
+                "title": format!("{} | Rust Blog", post.title),
                 "parent": "layout",
                 "post": post,
             });

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -2,7 +2,7 @@
 <header class="mt3 mt0-ns mb6-ns">
   <div class="container flex flex-column flex-row-l justify-between-l">
     <div class="mw8-l">
-      <h1>{{ title }}</h1>
+      <h1>Blog</h1>
     </div>
   </div>
 </header>


### PR DESCRIPTION
This PR updates the SEO title (i.e., `<title>`, `twitter:title`, and `og:title`) for the index page and post pages.

### Current SEO Titles
#### Index page
"Blog"
![image](https://user-images.githubusercontent.com/933552/50072674-efb14e80-018a-11e9-81e9-bc1343939bc8.png)

#### Post Page
"The Rust Programming Language Blog"
![image](https://user-images.githubusercontent.com/933552/50072708-13749480-018b-11e9-8493-27b552539463.png)

### SEO Titles After Change
#### Index page
"The Rust Programming Language Blog"
![image](https://user-images.githubusercontent.com/933552/50072801-5c2c4d80-018b-11e9-8221-4f4844a0daea.png)

#### Post Page
"`post.title` | Rust Blog"
![image](https://user-images.githubusercontent.com/933552/50072860-8c73ec00-018b-11e9-8ea7-e557741c7f3a.png)

Note on other approaches: I went through an earlier approach that added a second attribute on the render data (e.g., `"seo_title"`), but I ultimately did not go with it because index.hbs is used to render only one page, so hardcoding "Blog" seems reasonable.

If merged, this fixes #315 (and also the index page). I modified the suggested string in #315 because I found more examples of blog posts that combine the post title and blog name than just use the post title. I'm happy to change it to anything else, if there's a strong preference otherwise.