### PR TITLE
Replace footer link to "All" with "All Policies"

### DIFF
--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -16,7 +16,7 @@
           <li><a href="https://www.rust-lang.org/policies/licenses">Licenses</a></li>
           <li><a href="https://www.rust-lang.org/policies/media-guide">Logo Policy and Media Guide</a></li>
           <li><a href="https://www.rust-lang.org/policies/security">Security Disclosures</a></li>
-          <li><a href="https://www.rust-lang.org/policies">All</a></li>
+          <li><a href="https://www.rust-lang.org/policies">All Policies</a></li>
         </ul>
       </div>
       <div class="four columns mt3 mt0-l">


### PR DESCRIPTION
The other footer links make sense without looking at the header; "All" on its own is nondescriptive and confusing, whereas "All Policies" makes sense without context.

cf rust-lang/www.rust-lang.org#667