### PR TITLE
Fix typo in Rust 1.31 release post

### DIFF
--- a/posts/2018-12-06-Rust-1.31-and-rust-2018.md
+++ b/posts/2018-12-06-Rust-1.31-and-rust-2018.md
@@ -442,7 +442,7 @@ See the [detailed release notes][notes] for more.
 Cargo will now download packages in parallel using HTTP/2.
 
 Additionally, now that `extern crate` is not usually required, it would be
-jarring to do `extern crate foo as bar;` to rename a crate. As such, you can
+jarring to do `extern crate foo as baz;` to rename a crate. As such, you can
 do so in your `Cargo.toml`, like this:
 
 ```toml


### PR DESCRIPTION
Fixed typo in the "Cargo features" section. The "extern crate" statement renamed "foo" to "bar", while the following examples renamed it to "baz" instead, which might be confusing.