### PR TITLE
Remove non-working "center" attributes

### DIFF
--- a/posts/2016-04-19-MIR.md
+++ b/posts/2016-04-19-MIR.md
@@ -10,7 +10,7 @@ compiler internals. Over the past year or so, we have been steadily
 working on a plan to change our internal compiler pipeline, as shown
 here:
 
-![Compiler Flowchart][flow]{:class="center"}
+![Compiler Flowchart][flow]
 
 That is, we are introducing a new intermediate representation (IR) of
 your program that we call **MIR**: MIR stands for *mid-level* IR, because
@@ -260,7 +260,7 @@ of that cycle.
 Here is the running example from the previous section, expressed as a
 control-flow graph:
 
-![Control-flow-graph][cfg]{:class="center"}
+![Control-flow-graph][cfg]
 
 Building a control-flow graph is typically a first step for any kind
 of flow-sensitive analysis. It's also a natural match for LLVM IR,
@@ -341,7 +341,7 @@ break:
 Of course, the actual MIR is based on a control-flow-graph, so it
 would look something like this:
 
-![Loop-break control-flow graph][loop-break]{:class="center"}
+![Loop-break control-flow graph][loop-break]
 
 ### Explicit drops and panics
 
@@ -388,14 +388,14 @@ control-flow-graph to show explicitly where the `iterator` value gets
 freed. Take a look at the new graph, and in particular what happens
 when a `None` variant is found:
 
-![Drop control-flow graph][drop]{:class="center"}
+![Drop control-flow graph][drop]
 
 Here we see that, when the loop exits normally, we will drop the
 iterator once it has finished. But what about if a panic occurs? Any
 of the function calls we see here could panic, after all. To account
 for that, we introduce panic edges into the graph:
 
-![Panic control-flow graph][drop-unwind]{:class="center"}
+![Panic control-flow graph][drop-unwind]
 
 Here we have introduced `panic` edges onto each of the function
 calls. By looking at these edges, you can see that if the call to
@@ -512,7 +512,7 @@ like the current overwriting semantics. So this means that the MIR for
 `send_if` might look like this (for simplicity, I'll ignore unwinding
 edges).
 
-![Non-zeroing drop example][nzd]{:class="center"}
+![Non-zeroing drop example][nzd]
 
 We can then transform this graph by identifying each place where
 `data` is moved or dropped and checking whether any of those places
@@ -520,7 +520,7 @@ can reach one another. In this case, the `send_to_other_thread(data)` block can
 reach `drop(data)`. This indicates that we will need to introduce a
 flag, which can be done rather mechanically:
 
-![Non-zeroing drop with flags][nzd-flags]{:class="center"}
+![Non-zeroing drop with flags][nzd-flags]
 
 Finally, we can apply standard compiler techniques to optimize this
 flag (but in this case, the flag is needed, and so the final result
@@ -544,20 +544,20 @@ fn send_if2(data: Vec<Data>) {
 
 This would generate MIR like:
 
-![Control-flow graph for send_if2][send_if2]{:class="center"}
+![Control-flow graph for send_if2][send_if2]
 
 As before, we still generate the drops of `data` in all cases, at
 least to start. Since there are still moves that can later reach a
 drop, we could now introduce a stack flag variable, just as before:
 
-![send_if2 with flags][send_if2-flags]{:class="center"}
+![send_if2 with flags][send_if2-flags]
 
 But in this case, if we apply constant propagation, we can see that at
 each point where we test `data_is_owned`, we know statically whether
 it is true or false, which would allow us to remove the stack flag and
 optimize the graph above, yielding this result:
 
-![Optimized send_if2][send_if2-opt]{:class="center"}
+![Optimized send_if2][send_if2-opt]
 
 ### Conclusion
 


### PR DESCRIPTION
The new Markdown parser doesn't support them.