### PR TITLE
Fetch social images via HTTPS from www.rust-lang.org.

### DIFF
--- a/templates/headers.hbs
+++ b/templates/headers.hbs
@@ -4,12 +4,12 @@
  <meta name="twitter:creator" content="@rustlang">
  <meta name="twitter:title" content="{{title}}">
  <meta name="twitter:description" content="Empowering everyone to build reliable and efficient software.">
-<meta name="twitter:image" content="http://new-rust-www.herokuapp.com/static/images/rust-social.jpg">
+<meta name="twitter:image" content="https://www.rust-lang.org/static/images/rust-social.jpg">
 
 <!-- Facebook OpenGraph -->
 <meta property="og:title" content="{{title}}" />
 <meta property="og:description" content="Empowering everyone to build reliable and efficient software.">
-<meta property="og:image" content="http://new-rust-www.herokuapp.com/static/images/rust-social-wide.jpg" />
+<meta property="og:image" content="https://www.rust-lang.org/static/images/rust-social-wide.jpg" />
 <meta property="og:type" content="website" />
 <meta property="og:locale" content="en_US" />
 


### PR DESCRIPTION
I noticed that accessing the rust blog would cause HTTP requests in firefox due to the referenced opengraph image (I believe Firefox accesses them due to activity stream).

With the goal of an HTTPS web in mind I think it'd be good to convert these to HTTPS. The normal rust page (www.rust-lang.org) references the same images from its own host via HTTPS, so I guess changing it to that URL should suffice.