### PR TITLE
Fix typo in "? in doctests" example

### DIFF
--- a/posts/2019-04-11-Rust-1.34.0.md
+++ b/posts/2019-04-11-Rust-1.34.0.md
@@ -102,7 +102,7 @@ Now, you can write this in your documentation tests:
 /// use std::io;
 /// let mut input = String::new();
 /// io::stdin().read_line(&mut input)?;
-/// # Ok::<(), io:Error>(())
+/// # Ok::<(), io::Error>(())
 /// ```
 fn my_func() {}
 ````


### PR DESCRIPTION
This didn't compile as-is.

Closes https://github.com/rust-lang/rust/issues/59961