### PR TITLE
Improve typography of 2019 roadmap post

### DIFF
--- a/posts/2019-04-23-roadmap.md
+++ b/posts/2019-04-23-roadmap.md
@@ -31,9 +31,9 @@ The work we have planned for this year falls into three major categories:
 
 ## Governance
 
-Over the last three years, the Rust project has grown a lot. Rust used to have a core team of 8 members. When we added sub-teams in 2015, we grew to 23 members. We've now grown to over 100 -- that's bigger than many companies! And of course, looking beyond the teams, the size of the Rust community as a whole has grown tremendously as well. As a result of this growth, we've found that the processes which served us well when we were a smaller project are starting to feel some strain.
+Over the last three years, the Rust project has grown a lot. Rust used to have a core team of 8 members. When we added sub-teams in 2015, we grew to 23 members. We've now grown to over 100 — that's bigger than many companies! And of course, looking beyond the teams, the size of the Rust community as a whole has grown tremendously as well. As a result of this growth, we've found that the processes which served us well when we were a smaller project are starting to feel some strain.
 
-Many of the teams have announced plans to look over revamp their processes to scale better. Often this can be as simple as taking the time to write down things that previously were understood only informally -- sometimes it means establishing new structures. 
+Many of the teams have announced plans to look over revamp their processes to scale better. Often this can be as simple as taking the time to write down things that previously were understood only informally — sometimes it means establishing new structures. 
 
 Because of this widespread interest in governance, we've also created a new [**Governance Working Group**][gov]. This group is going to be devoted to working with each team to hone its governance structure and to help pass lessons and strategies between teams.
 
@@ -45,7 +45,7 @@ We may look at revisions to the process this year.
 ## Long-standing requests
 
 There are a number of exciting initiatives that have been sitting in a limbo
-state -- the majority of the design is done, but there are some lingering
+state — the majority of the design is done, but there are some lingering
 complications that we haven't had time to work out. This year we hope to take
 a fresh look at some of these problems and try hard to resolve those
 lingering problems.
@@ -61,7 +61,7 @@ Examples include:
 Finally, the last few years have also seen a lot of foundational work. The
 compiler, for example, was massively refactored to support incremental
 compilation and to be better prepared for IDEs. Now that we've got these
-pieces in place, we want to do the "polish" work that really makes for a
+pieces in place, we want to do the “polish” work that really makes for a
 great experience.
 
 Examples:


### PR DESCRIPTION
The double dashes `--` kind of stuck out to me so I thought I'd tidy them up and also added some typographic quotation marks at the same time.