### PR TITLE
Fix broken link to MIR data structures code

### DIFF
--- a/posts/2016-04-19-MIR.md
+++ b/posts/2016-04-19-MIR.md
@@ -597,7 +597,7 @@ interested in contributing, look for
 [CFG]: https://en.wikipedia.org/wiki/Control_flow_graph
 [AST]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
 [LLVM]: http://llvm.org/
-[the code]: https://github.com/rust-lang/rust/blob/master/src/librustc/mir/repr.rs
+[the code]: https://github.com/rust-lang/rust/blob/master/src/librustc/mir/mod.rs
 [orbit]: https://en.wikipedia.org/wiki/Mir
 [crater]: https://github.com/brson/taskcluster-crater
 

--- a/posts/2016-04-19-MIR.md
+++ b/posts/2016-04-19-MIR.md
@@ -597,7 +597,7 @@ interested in contributing, look for
 [CFG]: https://en.wikipedia.org/wiki/Control_flow_graph
 [AST]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
 [LLVM]: http://llvm.org/
-[the code]: https://github.com/rust-lang/rust/blob/master/src/librustc/mir/mod.rs
+[the code]: https://github.com/rust-lang/rust/blob/f7ec6873ccfbf7dcdbd1908c0857c866b3e7087a/src/librustc/mir/repr.rs
 [orbit]: https://en.wikipedia.org/wiki/Mir
 [crater]: https://github.com/brson/taskcluster-crater
 


### PR DESCRIPTION
The blog points to the GitHub code for the rust compiler at `src/librustc/mir/repr.rs` which no longer exists. This fix points it at `src/librustc/mir/mod.rs`.