### PR TITLE
Fix primitives::reverse_bits() link in 1.37.0 blog post

### DIFF
--- a/posts/2019-08-15-Rust-1.37.0.md
+++ b/posts/2019-08-15-Rust-1.37.0.md
@@ -143,7 +143,7 @@ struct AlignN<T>(T);
 [`DoubleEndedIterator::nth_back`]: https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html#method.nth_back
 [`Option::xor`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.xor
 [`Wrapping::reverse_bits`]: https://doc.rust-lang.org/std/num/struct.Wrapping.html#method.reverse_bits
-[`{i,u}{8,16,64,128,size}::reverse_bits`]: https://doc.rust-lang.org/std/primitive.u8.html#method.reverse_bits
+[`{i,u}{8,16,32,64,128,size}::reverse_bits`]: https://doc.rust-lang.org/std/primitive.u8.html#method.reverse_bits
 [`slice::copy_within`]: https://doc.rust-lang.org/std/primitive.slice.html#method.copy_within
 
 In Rust 1.37.0 there have been a number of standard library stabilizations:


### PR DESCRIPTION
8d46a0ca05e72a6b74d15c47959a9d910e5d17b5 didn't change the link ref