### PR TITLE
Add support for multiple blogs

### DIFF
--- a/posts/blog.yml
+++ b/posts/blog.yml
@@ -1,0 +1,4 @@
+title: Rust Blog
+index-title: The Rust Programming Language Blog
+description: Empowering everyone to build reliable and efficient software.
+maintained-by: the Rust Team

--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -1,0 +1,123 @@
+use crate::posts::Post;
+use serde_derive::{Deserialize, Serialize};
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+static MANIFEST_FILE: &str = "blog.yml";
+static POSTS_EXT: &str = "md";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct Manifest {
+    title: String,
+    index_title: String,
+    description: String,
+    maintained_by: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct Blog {
+    title: String,
+    index_title: String,
+    description: String,
+    maintained_by: String,
+    #[serde(serialize_with = "add_postfix_slash")]
+    prefix: PathBuf,
+    posts: Vec<Post>,
+}
+
+impl Blog {
+    fn load(prefix: PathBuf, dir: &Path) -> Result<Self, Box<dyn Error>> {
+        let manifest_content = std::fs::read_to_string(dir.join(MANIFEST_FILE))?;
+        let manifest: Manifest = serde_yaml::from_str(&manifest_content)?;
+
+        let mut posts = Vec::new();
+        for entry in std::fs::read_dir(dir)? {
+            let path = entry?.path();
+            let ext = path.extension().and_then(|e| e.to_str());
+            if path.metadata()?.file_type().is_file() && ext == Some(POSTS_EXT) {
+                posts.push(Post::open(&path)?);
+            }
+        }
+
+        posts.sort_by_key(|post| post.url.clone());
+        posts.reverse();
+
+        // Decide which posts should show the year in the index.
+        posts[0].show_year = true;
+        for i in 1..posts.len() {
+            posts[i].show_year = posts[i - 1].year != posts[i].year;
+        }
+
+        Ok(Blog {
+            title: manifest.title,
+            index_title: manifest.index_title,
+            description: manifest.description,
+            maintained_by: manifest.maintained_by,
+            prefix,
+            posts,
+        })
+    }
+
+    pub(crate) fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub(crate) fn index_title(&self) -> &str {
+        &self.index_title
+    }
+
+    pub(crate) fn prefix(&self) -> &Path {
+        &self.prefix
+    }
+
+    pub(crate) fn posts(&self) -> &[Post] {
+        &self.posts
+    }
+}
+
+/// Recursively load blogs in a directory. A blog is a directory with a `blog.yml`
+/// file inside it.
+pub(crate) fn load(base: &Path) -> Result<Vec<Blog>, Box<dyn Error>> {
+    let mut blogs = Vec::new();
+    load_recursive(base, base, &mut blogs)?;
+    Ok(blogs)
+}
+
+fn load_recursive(
+    base: &Path,
+    current: &Path,
+    blogs: &mut Vec<Blog>,
+) -> Result<(), Box<dyn Error>> {
+    for entry in std::fs::read_dir(current)? {
+        let path = entry?.path();
+        let file_type = path.metadata()?.file_type();
+
+        if file_type.is_dir() {
+            load_recursive(base, &path, blogs)?;
+        } else if file_type.is_file() {
+            let file_name = path.file_name().and_then(|n| n.to_str());
+            if let (Some(file_name), Some(parent)) = (file_name, path.parent()) {
+                if file_name == MANIFEST_FILE {
+                    let prefix = parent
+                        .strip_prefix(base)
+                        .map(|p| p.to_path_buf())
+                        .unwrap_or_else(|_| PathBuf::new());
+                    blogs.push(Blog::load(prefix, parent)?);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn add_postfix_slash<S>(path: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut str_repr = path.to_string_lossy().to_string();
+    if !str_repr.is_empty() {
+        str_repr.push('/');
+    }
+    serializer.serialize_str(&str_repr)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,46 +1,19 @@
-use std::{
-    error::Error,
-    fs::{self, File},
-    io::Write,
-    path::PathBuf,
-};
+mod posts;
 
-use comrak::ComrakOptions;
-
+use crate::posts::Post;
 use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContext, RenderError};
-
-use serde_derive::{Deserialize, Serialize};
-use serde_json::json;
-
 use sass_rs::{compile_file, Options};
+use serde_derive::Serialize;
+use serde_json::json;
+use std::error::Error;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::PathBuf;
 
 struct Blog {
     handlebars: Handlebars,
     posts: Vec<Post>,
     out_directory: PathBuf,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct Post {
-    filename: String,
-    title: String,
-    author: String,
-    year: String,
-    show_year: bool,
-    month: String,
-    day: String,
-    contents: String,
-    url: String,
-    published: String,
-    release: bool,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct YamlHeader {
-    title: String,
-    author: String,
-    #[serde(default)]
-    release: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -115,91 +88,19 @@ impl Blog {
         let mut posts = Vec::new();
 
         for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            // yeah this might blow up, but it won't
-            let filename = path.file_name().unwrap().to_str().unwrap();
+            let path = entry?.path();
 
             // ignore vim temporary files
+            let filename = path.file_name().unwrap().to_str().unwrap();
             if filename.starts_with(".") && filename.ends_with(".swp") {
                 continue;
             }
 
-            // we need to get the metadata out of the url
-            let mut split = filename.splitn(4, "-");
-
-            let year = split.next().unwrap().to_string();
-            let month = split.next().unwrap().to_string();
-            let day = split.next().unwrap().to_string();
-            let filename = split.next().unwrap().to_string();
-
-            let contents = fs::read_to_string(path)?;
-
-            // yaml headers.... we know the first four bytes of each file are "---\n"
-            // so we need to find the end. we need the fours to adjust for those first bytes
-            let end_of_yaml = contents[4..].find("---").unwrap() + 4;
-            let yaml = &contents[..end_of_yaml];
-            let YamlHeader {
-                author,
-                title,
-                release,
-            } = serde_yaml::from_str(yaml)?;
-            // next, the contents. we add + to get rid of the final "---\n\n"
-            let options = ComrakOptions {
-                ext_header_ids: Some(String::new()),
-                ..ComrakOptions::default()
-            };
-
-            let contents = comrak::markdown_to_html(&contents[end_of_yaml + 5..], &options);
-
-            // finally, the url.
-            let mut url = PathBuf::from(&*filename);
-            url.set_extension("html");
-
-            // this is fine
-            let url = format!("{}/{}/{}/{}", year, month, day, url.to_str().unwrap());
-
-            // build the published time. this is only approximate, which is fine.
-            // we do some unwraps because these need to be valid
-            let published = time::Tm {
-                tm_sec: 0,
-                tm_min: 0,
-                tm_hour: 0,
-                tm_mday: day.parse::<i32>().unwrap(),
-                tm_mon: month.parse::<i32>().unwrap() - 1, // 0-11 not 1-12
-                tm_year: year.parse::<i32>().unwrap() - 1900, // from the year 1900, not the actual year
-                // these next two fields are wrong but we never use them to generate our times
-                tm_wday: 1,
-                tm_yday: 1,
-                tm_isdst: 0,
-                tm_utcoff: 0,
-                tm_nsec: 0,
-            };
-
-            let published = published.rfc3339().to_string();
-
-            let post = Post {
-                filename,
-                title,
-                author,
-                year,
-                show_year: false,
-                month,
-                day,
-                contents,
-                url,
-                published,
-                release,
-            };
-
-            posts.push(post);
+            posts.push(Post::open(&path)?);
         }
 
         // finally, sort the posts. oldest first.
-
         posts.sort_by_key(|post| post.url.clone());
-
         posts.reverse();
 
         for i in 1..posts.len() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn hb_month_helper<'a>(
     _b: &Handlebars,
     _ctx: &Context,
     _rc: &mut RenderContext,
-    out: &mut Output,
+    out: &mut dyn Output,
 ) -> HelperResult {
     let num: u32 = h
         .param(0)
@@ -90,7 +90,7 @@ fn hb_month_helper<'a>(
 }
 
 impl Blog {
-    fn new<T>(out_directory: T, posts_directory: T) -> Result<Blog, Box<Error>>
+    fn new<T>(out_directory: T, posts_directory: T) -> Result<Blog, Box<dyn Error>>
     where
         T: Into<PathBuf>,
     {
@@ -111,7 +111,7 @@ impl Blog {
         })
     }
 
-    fn load_posts(dir: PathBuf) -> Result<Vec<Post>, Box<Error>> {
+    fn load_posts(dir: PathBuf) -> Result<Vec<Post>, Box<dyn Error>> {
         let mut posts = Vec::new();
 
         for entry in fs::read_dir(dir)? {
@@ -209,7 +209,7 @@ impl Blog {
         Ok(posts)
     }
 
-    fn render(&self) -> Result<(), Box<Error>> {
+    fn render(&self) -> Result<(), Box<dyn Error>> {
         // make sure our output directory exists
         fs::create_dir_all(&self.out_directory)?;
 
@@ -253,7 +253,7 @@ impl Blog {
         fs::write("./static/styles/vendor.css", &concatted).expect("couldn't write vendor css");
     }
 
-    fn render_index(&self) -> Result<(), Box<Error>> {
+    fn render_index(&self) -> Result<(), Box<dyn Error>> {
         let data = json!({
             "title": "The Rust Programming Language Blog",
             "parent": "layout",
@@ -265,7 +265,7 @@ impl Blog {
         Ok(())
     }
 
-    fn render_posts(&self) -> Result<(), Box<Error>> {
+    fn render_posts(&self) -> Result<(), Box<dyn Error>> {
         for post in &self.posts {
             // first, we create the path
             //let path = PathBuf::from(&self.out_directory);
@@ -292,7 +292,7 @@ impl Blog {
         Ok(())
     }
 
-    fn render_feed(&self) -> Result<(), Box<Error>> {
+    fn render_feed(&self) -> Result<(), Box<dyn Error>> {
         let posts: Vec<_> = self.posts.iter().by_ref().take(10).collect();
         let data =
             json!({ "posts": posts, "feed_updated":  time::now_utc().rfc3339().to_string() });
@@ -301,7 +301,7 @@ impl Blog {
         Ok(())
     }
 
-    fn generate_releases_feed(&self) -> Result<(), Box<Error>> {
+    fn generate_releases_feed(&self) -> Result<(), Box<dyn Error>> {
         let posts = self.posts.clone();
         let is_released: Vec<&Post> = posts.iter().filter(|post| post.release).collect();
         let releases: Vec<ReleasePost> = is_released
@@ -322,7 +322,7 @@ impl Blog {
         Ok(())
     }
 
-    fn copy_static_files(&self) -> Result<(), Box<Error>> {
+    fn copy_static_files(&self) -> Result<(), Box<dyn Error>> {
         use fs_extra::dir::{self, CopyOptions};
 
         let mut options = CopyOptions::new();
@@ -341,7 +341,7 @@ impl Blog {
         name: &str,
         template: &str,
         data: serde_json::Value,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let out_file = self.out_directory.join(name);
 
         let file = File::create(out_file)?;
@@ -352,7 +352,7 @@ impl Blog {
     }
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let blog = Blog::new("site", "posts")?;
 
     blog.render()?;

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -1,0 +1,101 @@
+use comrak::ComrakOptions;
+use serde_derive::{Deserialize, Serialize};
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct YamlHeader {
+    title: String,
+    author: String,
+    #[serde(default)]
+    release: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Post {
+    pub(crate) filename: String,
+    pub(crate) title: String,
+    pub(crate) author: String,
+    pub(crate) year: String,
+    pub(crate) show_year: bool,
+    pub(crate) month: String,
+    pub(crate) day: String,
+    pub(crate) contents: String,
+    pub(crate) url: String,
+    pub(crate) published: String,
+    pub(crate) release: bool,
+}
+
+impl Post {
+    pub(crate) fn open(path: &Path) -> Result<Self, Box<dyn Error>> {
+        // yeah this might blow up, but it won't
+        let filename = path.file_name().unwrap().to_str().unwrap();
+
+        // we need to get the metadata out of the url
+        let mut split = filename.splitn(4, "-");
+
+        let year = split.next().unwrap().to_string();
+        let month = split.next().unwrap().to_string();
+        let day = split.next().unwrap().to_string();
+        let filename = split.next().unwrap().to_string();
+
+        let contents = std::fs::read_to_string(path)?;
+
+        // yaml headers.... we know the first four bytes of each file are "---\n"
+        // so we need to find the end. we need the fours to adjust for those first bytes
+        let end_of_yaml = contents[4..].find("---").unwrap() + 4;
+        let yaml = &contents[..end_of_yaml];
+        let YamlHeader {
+            author,
+            title,
+            release,
+        } = serde_yaml::from_str(yaml)?;
+        // next, the contents. we add + to get rid of the final "---\n\n"
+        let options = ComrakOptions {
+            ext_header_ids: Some(String::new()),
+            ..ComrakOptions::default()
+        };
+
+        let contents = comrak::markdown_to_html(&contents[end_of_yaml + 5..], &options);
+
+        // finally, the url.
+        let mut url = PathBuf::from(&*filename);
+        url.set_extension("html");
+
+        // this is fine
+        let url = format!("{}/{}/{}/{}", year, month, day, url.to_str().unwrap());
+
+        // build the published time. this is only approximate, which is fine.
+        // we do some unwraps because these need to be valid
+        let published = time::Tm {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: day.parse::<i32>().unwrap(),
+            tm_mon: month.parse::<i32>().unwrap() - 1, // 0-11 not 1-12
+            tm_year: year.parse::<i32>().unwrap() - 1900, // from the year 1900, not the actual year
+            // these next two fields are wrong but we never use them to generate our times
+            tm_wday: 1,
+            tm_yday: 1,
+            tm_isdst: 0,
+            tm_utcoff: 0,
+            tm_nsec: 0,
+        };
+
+        let published = published.rfc3339().to_string();
+
+        Ok(Self {
+            filename,
+            title,
+            author,
+            year,
+            show_year: false,
+            month,
+            day,
+            contents,
+            url,
+            published,
+            release,
+        })
+    }
+}

--- a/templates/feed.hbs
+++ b/templates/feed.hbs
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
-    <generator uri="https://blog.rust-lang.org/" version="0.1.0">Rust Blog</generator>
-    <link href="https://blog.rust-lang.org/feed.xml" rel="self" type="application/atom+xml" />
-    <link href="https://blog.rust-lang.org/" rel="alternate" type="text/html" />
-    <id>https://blog.rust-lang.org/</id>
-    <title>Rust Blog</title>
-    <subtitle>Empowering everyone to build reliable and efficient software.</subtitle>
+    <generator uri="https://blog.rust-lang.org/{{blog.prefix}}" version="0.1.0">{{blog.title}}</generator>
+    <link href="https://blog.rust-lang.org/{{blog.prefix}}feed.xml" rel="self" type="application/atom+xml" />
+    <link href="https://blog.rust-lang.org/{{blog.prefix}}" rel="alternate" type="text/html" />
+    <id>https://blog.rust-lang.org/{{blog.prefix}}</id>
+    <title>{{blog.title}}</title>
+    <subtitle>{{blog.description}}</subtitle>
     <author>
-        <name>Maintained by the Rust Team.</name>
+        <name>Maintained by {{blog.maintained_by}}.</name>
         <uri>https://github.com/rust-lang/blog.rust-lang.org/</uri>
     </author>
-    <updated>{{ feed_updated }}</updated>
+    <updated>{{feed_updated}}</updated>
 
     {{#each posts}}
     <entry>
         <title>{{title}}</title>
-        <link rel="alternate" href="https://blog.rust-lang.org/{{url}}" type="text/html" title="{{title}}" />
-        <published>{{ published }}</published>
-        <updated>{{ published }}</updated>
-        <id>https://blog.rust-lang.org/{{url}}</id>
-        <content type="html" xml:base="https://blog.rust-lang.org/{{url}}">{{contents}}</content>
+        <link rel="alternate" href="https://blog.rust-lang.org/{{../blog.prefix}}{{url}}" type="text/html" title="{{title}}" />
+        <published>{{published}}</published>
+        <updated>{{published}}</updated>
+        <id>https://blog.rust-lang.org/{{../blog.prefix}}{{url}}</id>
+        <content type="html" xml:base="https://blog.rust-lang.org/{{../blog.prefix}}{{url}}">{{contents}}</content>
 
         <author>
             <name>{{author}}</name>

--- a/templates/headers.hbs
+++ b/templates/headers.hbs
@@ -3,12 +3,12 @@
  <meta name="twitter:site" content="@rustlang">
  <meta name="twitter:creator" content="@rustlang">
  <meta name="twitter:title" content="{{title}}">
- <meta name="twitter:description" content="Empowering everyone to build reliable and efficient software.">
+ <meta name="twitter:description" content="{{blog.description}}">
 <meta name="twitter:image" content="https://www.rust-lang.org/static/images/rust-social.jpg">
 
 <!-- Facebook OpenGraph -->
 <meta property="og:title" content="{{title}}" />
-<meta property="og:description" content="Empowering everyone to build reliable and efficient software.">
+<meta property="og:description" content="{{blog.description}}">
 <meta property="og:image" content="https://www.rust-lang.org/static/images/rust-social-wide.jpg" />
 <meta property="og:type" content="website" />
 <meta property="og:locale" content="en_US" />
@@ -39,4 +39,4 @@
 <meta name="theme-color" content="#ffffff">
 
  <!-- atom -->
- <link type="application/atom+xml" rel="alternate" href="https://blog.rust-lang.org/feed.xml" title="Rust Blog" />
+ <link type="application/atom+xml" rel="alternate" href="https://blog.rust-lang.org/{{blog.prefix}}feed.xml" title="{{blog.title}}" />

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -11,14 +11,14 @@
    <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
 
     <table class="post-list collapse w-100 f2-l f2-m f3-s">
-    {{#each posts}}
+    {{#each blog.posts}}
       {{#if show_year}}<tr>
         <td class="bn"></td>
         <td class="bn"><h3 class="f0-l f1-m f2-s mt4 mb0">{{year}}</h3></td>
       </tr>{{/if}}
       <tr>
         <td class="tr o-60 pr4 pr5-l bn">{{month_name month}}&nbsp;{{day}}</td>
-        <td class="bn"><a href="{{url}}">{{title}}</a></td>
+        <td class="bn"><a href="/{{../blog.prefix}}{{url}}">{{title}}</a></td>
       </tr>
     {{/each}}
     </table>

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -1,8 +1,8 @@
 <nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr4-ns">
   <div class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
-    <a href="/">
+    <a href="/{{blog.prefix}}">
       <img class="v-mid ml0-l" alt="Rust Logo" src="/images/rust-logo-blk.svg">
-      <span class="dib ml1 ml0-l">Rust Blog</span>
+      <span class="dib ml1 ml0-l">{{blog.title}}</span>
     </a>
   </div>
 


### PR DESCRIPTION
Some teams (for example the compiler team) expressed their interest in creating separate blogs on blog.rust-lang.org, to post content that might not interest the community as a whole. This PR adds support for multiple, isolated blogs while keeping the top-level one unchanged. It doesn't add any other blog yet so it's safe to merge it.

Adding a new blog is simple: a subdirectory of `posts/` needs to be created with a `blog.yml` in it (use `posts/blog.yml` as a guide), and then posts can just be written there. It's possible to nest subdirectories even if the parents aren't blogs (for example `teams/compiler` without a blog in `teams`).

There is future work that can be done to improve this:

* Create an "all" blog that contains all the posts. This will especially be useful for users with feed readers that want to read everything.
* Add a page or navigation bar to switch between blogs. At the moment there is no way to go to another blog without knowing the link. Doing this will need some design work and I'm not the best person to do that.