### PR TITLE
create the "Inside Rust" blog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.6.9"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -52,6 +52,8 @@ dependencies = [
  "comrak 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sass-rs 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -96,10 +98,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "entities 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -146,12 +148,12 @@ name = "handlebars"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,7 +166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -192,13 +194,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "pest"
@@ -280,23 +277,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.4"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ryu"
@@ -425,7 +418,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -443,7 +436,7 @@ name = "twoway"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -462,11 +455,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "ucd-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,18 +470,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "utf8-ranges"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "vec_map"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -542,7 +520,7 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
@@ -561,12 +539,12 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d82e5750d8027a97b9640e3fefa66bbaf852a35228e1c90790efd13c4b09c166"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
-"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
+"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a677051ad923732bb5c70f2d45f8985a96e3eee2e2bff86697e3b11b0c3fcfde"
 "checksum pest_derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b76f477146419bc539a63f4ef40e902166cb43b3e51cecc71d9136fd12c567e7"
 "checksum pest_generator 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ebee4e9680be4fd162e6f3394ae4192a6b60b1e4d17d845e631f0c68d1a3386"
@@ -577,8 +555,8 @@ dependencies = [
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
-"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
+"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum sass-rs 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90f8cf6e645aa843ffffcbdc1e8752b1f221dfa314c81895aeb229a77aea7e05"
@@ -599,13 +577,10 @@ dependencies = [
 "checksum typed-arena 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c6c06a92aef38bb4dc5b0df00d68496fc31307c5344c867bb61678c6e1671ec5"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
-"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2018"
 
 [dependencies]
 handlebars = "1.1.0"
+lazy_static = "1.4.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.8"
 serde_json = "1.0"
 comrak = "0.4"
 fs_extra = "1.1.0"
+regex = "1.3"
 sass-rs = "0.2.1"
 time = "0.1.41"

--- a/posts/2018-01-03-new-years-rust-a-call-for-community-blogposts.md
+++ b/posts/2018-01-03-new-years-rust-a-call-for-community-blogposts.md
@@ -1,6 +1,7 @@
 ---
 title: "New Year's Rust: A Call for Community Blogposts"
 author: "The Rust Core Team"
+layout: post
 ---
 
 'Tis the season for people and communities to reflect and set goals- and the Rust team is

--- a/posts/2018-10-30-help-test-rust-2018.md
+++ b/posts/2018-10-30-help-test-rust-2018.md
@@ -1,6 +1,7 @@
 ---
 title: "Help test Rust 2018"
 author: "The Rust Core Team"
+layout: post
 ---
 
 Back in July, we talked about ["Rust 2018"]. In short, we are launching a

--- a/posts/2019-10-03-inside-rust-blog.md
+++ b/posts/2019-10-03-inside-rust-blog.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Announcing the Inside Rust blog"
 author: Niko Matsakis
-release: true
 ---
 
 Today we're happy to announce that we're starting a second blog, the

--- a/posts/2019-10-03-inside-rust-blog.md
+++ b/posts/2019-10-03-inside-rust-blog.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: "Announcing the Inside Rust blog"
+author: Niko Matsakis
+release: true
+---
+
+Today we're happy to announce that we're starting a second blog, the
+[**Inside Rust** blog][irb]. This blog will be used to post regular
+updates by the various Rust teams and working groups. If you're
+interested in following along with the "nitty gritty" of Rust
+development, then you should take a look!
+
+[irb]: /inside-rust/index.html
+

--- a/posts/blog.yml
+++ b/posts/blog.yml
@@ -1,6 +1,8 @@
 title: Rust Blog
 index-title: The Rust Programming Language Blog
 description: Empowering everyone to build reliable and efficient software.
+index-html: This is the <b>main Rust blog</b>. We use this blog to
+            announce big developments in the world of Rust.
 maintained-by: the Rust Team
 requires-team: false
 

--- a/posts/blog.yml
+++ b/posts/blog.yml
@@ -1,5 +1,6 @@
 title: Rust Blog
 index-title: The Rust Programming Language Blog
+link-text: the main Rust blog
 description: Empowering everyone to build reliable and efficient software.
 index-html: This is the <b>main Rust blog</b>. We use this blog to
             announce big developments in the world of Rust.

--- a/posts/blog.yml
+++ b/posts/blog.yml
@@ -2,8 +2,9 @@ title: Rust Blog
 index-title: The Rust Programming Language Blog
 link-text: the main Rust blog
 description: Empowering everyone to build reliable and efficient software.
-index-html: This is the <b>main Rust blog</b>. We use this blog to
-            announce big developments in the world of Rust.
+index-html: This is the <b>main Rust blog</b>. The
+            <a href="https://www.rust-lang.org/governance/teams/core">core team</a>
+            uses this blog to announce big developments in the world of Rust.
 maintained-by: the Rust Team
 requires-team: false
 

--- a/posts/blog.yml
+++ b/posts/blog.yml
@@ -2,3 +2,5 @@ title: Rust Blog
 index-title: The Rust Programming Language Blog
 description: Empowering everyone to build reliable and efficient software.
 maintained-by: the Rust Team
+requires-team: false
+

--- a/posts/inside-rust/2019-09-25-Welcome.md
+++ b/posts/inside-rust/2019-09-25-Welcome.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title: "Announcing the Inside Rust blog!"
+author: Niko Matsakis
+description: "A new blog where the Rust team can post updates on the latest developments"
+team: the core team <https://www.rust-lang.org/governance/teams/core>
+---
+
+Welcome to the inaugural post of the **Inside Rust** blog! This is a
+new blog where the various Rust teams and working groups can post
+updates about new developments. It's a great place to watch if you're
+interested in following along with Rust development -- and a
+particularly great place to watch if you're interested in contributing
+to Rust. Expect to see updates on new projects, calls for help, design
+notes, and other similar items. Thanks for reading!
+

--- a/posts/inside-rust/blog.yml
+++ b/posts/inside-rust/blog.yml
@@ -1,5 +1,6 @@
 title: Inside Rust Blog
 index-title: The "Inside Rust" Blog
+link-text: the "Inside Rust" blog
 description: Want to follow along with Rust development? Curious how you might get involved? Take a look!
 index-html: This is the <b>"Inside Rust"</b> blog. This blog is aimed at those who wish
             to follow along with Rust development. The various

--- a/posts/inside-rust/blog.yml
+++ b/posts/inside-rust/blog.yml
@@ -1,0 +1,5 @@
+title: Inside Rust blog
+index-title: the Inside Rust blog
+description: Want to follow along with Rust development? Curious how you might get involved? Take a look!
+maintained-by: the Rust Teams
+requires-team: true

--- a/posts/inside-rust/blog.yml
+++ b/posts/inside-rust/blog.yml
@@ -1,5 +1,5 @@
 title: Inside Rust blog
-index-title: the Inside Rust blog
+index-title: The "Inside Rust" Blog
 description: Want to follow along with Rust development? Curious how you might get involved? Take a look!
 index-html: This is the <b>"Inside Rust"</b> blog. This blog is aimed at those who wish
             to follow along with Rust development. The various

--- a/posts/inside-rust/blog.yml
+++ b/posts/inside-rust/blog.yml
@@ -1,5 +1,10 @@
 title: Inside Rust blog
 index-title: the Inside Rust blog
 description: Want to follow along with Rust development? Curious how you might get involved? Take a look!
+index-html: This is the <b>"Inside Rust"</b> blog. This blog is aimed at those who wish
+            to follow along with Rust development. The various
+            <a href="https://www.rust-lang.org/governance">Rust teams and working groups</a>
+            use this blog to post status updates, calls for help, and other
+            similar announcements.
 maintained-by: the Rust Teams
 requires-team: true

--- a/posts/inside-rust/blog.yml
+++ b/posts/inside-rust/blog.yml
@@ -1,4 +1,4 @@
-title: Inside Rust blog
+title: Inside Rust Blog
 index-title: The "Inside Rust" Blog
 description: Want to follow along with Rust development? Curious how you might get involved? Take a look!
 index-html: This is the <b>"Inside Rust"</b> blog. This blog is aimed at those who wish

--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -8,11 +8,12 @@ static POSTS_EXT: &str = "md";
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-struct Manifest {
-    title: String,
-    index_title: String,
-    description: String,
-    maintained_by: String,
+pub(crate) struct Manifest {
+    pub(crate) title: String,
+    pub(crate) index_title: String,
+    pub(crate) description: String,
+    pub(crate) maintained_by: String,
+    pub(crate) requires_team: bool,
 }
 
 #[derive(Serialize)]
@@ -36,7 +37,7 @@ impl Blog {
             let path = entry?.path();
             let ext = path.extension().and_then(|e| e.to_str());
             if path.metadata()?.file_type().is_file() && ext == Some(POSTS_EXT) {
-                posts.push(Post::open(&path)?);
+                posts.push(Post::open(&path, &manifest)?);
             }
         }
 

--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -13,6 +13,7 @@ pub(crate) struct Manifest {
     pub(crate) index_title: String,
     pub(crate) description: String,
     pub(crate) maintained_by: String,
+    pub(crate) index_html: String,
     pub(crate) requires_team: bool,
 }
 
@@ -22,6 +23,7 @@ pub(crate) struct Blog {
     index_title: String,
     description: String,
     maintained_by: String,
+    index_html: String,
     #[serde(serialize_with = "add_postfix_slash")]
     prefix: PathBuf,
     posts: Vec<Post>,
@@ -55,6 +57,7 @@ impl Blog {
             index_title: manifest.index_title,
             description: manifest.description,
             maintained_by: manifest.maintained_by,
+            index_html: manifest.index_html,
             prefix,
             posts,
         })

--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -15,6 +15,7 @@ pub(crate) struct Manifest {
     pub(crate) maintained_by: String,
     pub(crate) index_html: String,
     pub(crate) requires_team: bool,
+    pub(crate) link_text: String,
 }
 
 #[derive(Serialize)]

--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -9,12 +9,26 @@ static POSTS_EXT: &str = "md";
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct Manifest {
+    /// Title to display in the "top row".
     pub(crate) title: String,
+
+    /// Title to use in the html header.
     pub(crate) index_title: String,
+
+    /// Description for metadata
     pub(crate) description: String,
+
+    /// Who maintains this blog? Appears in the rss feed.
     pub(crate) maintained_by: String,
+
+    /// Raw html describing the blog to insert into the index page.
     pub(crate) index_html: String,
+
+    /// If true, posts require a `team` in their metadata.
     pub(crate) requires_team: bool,
+
+    /// What text to use when linking to this blog in the "see also"
+    /// section from other blogs.
     pub(crate) link_text: String,
 }
 
@@ -22,6 +36,7 @@ pub(crate) struct Manifest {
 pub(crate) struct Blog {
     title: String,
     index_title: String,
+    link_text: String,
     description: String,
     maintained_by: String,
     index_html: String,
@@ -59,6 +74,7 @@ impl Blog {
             description: manifest.description,
             maintained_by: manifest.maintained_by,
             index_html: manifest.index_html,
+            link_text: manifest.link_text,
             prefix,
             posts,
         })
@@ -66,6 +82,10 @@ impl Blog {
 
     pub(crate) fn title(&self) -> &str {
         &self.title
+    }
+
+    pub(crate) fn link_text(&self) -> &str {
+        &self.link_text
     }
 
     pub(crate) fn index_title(&self) -> &str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ impl Generator {
         let other_blogs: Vec<_> = self.blogs.iter().filter(|b| b.index_title() != blog.index_title())
             .map(|other_blog| json!({
                 "name": other_blog.index_title(),
-                "url": other_blog.prefix().join("index.html"),
+                "url": PathBuf::from("/").join(other_blog.prefix()).join("index.html"),
             }))
             .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ impl Generator {
     fn render_index(&self, blog: &Blog) -> Result<(), Box<dyn Error>> {
         let other_blogs: Vec<_> = self.blogs.iter().filter(|b| b.index_title() != blog.index_title())
             .map(|other_blog| json!({
-                "name": other_blog.index_title(),
+                "name": other_blog.title(),
                 "url": PathBuf::from("/").join(other_blog.prefix()).join("index.html"),
             }))
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ impl Generator {
             "post": post,
         });
 
-        self.render_template(path.join(filename), "post", data)?;
+        self.render_template(path.join(filename), &post.layout, data)?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ impl Generator {
     fn render_index(&self, blog: &Blog) -> Result<(), Box<dyn Error>> {
         let other_blogs: Vec<_> = self.blogs.iter().filter(|b| b.index_title() != blog.index_title())
             .map(|other_blog| json!({
-                "name": other_blog.title(),
+                "link_text": other_blog.link_text(),
                 "url": PathBuf::from("/").join(other_blog.prefix()).join("index.html"),
             }))
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,10 +131,18 @@ impl Generator {
     }
 
     fn render_index(&self, blog: &Blog) -> Result<(), Box<dyn Error>> {
+        let other_blogs: Vec<_> = self.blogs.iter().filter(|b| b.index_title() != blog.index_title())
+            .map(|other_blog| json!({
+                "name": other_blog.index_title(),
+                "url": other_blog.prefix().join("index.html"),
+            }))
+            .collect();
+
         let data = json!({
             "title": blog.index_title(),
             "parent": "layout",
             "blog": blog,
+            "other_blogs": other_blogs,
         });
         self.render_template(blog.prefix().join("index.html"), "index", data)?;
         Ok(())

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -102,7 +102,7 @@ impl Post {
 
         // Enforce extra conditions
         if manifest.requires_team && team_string.is_none() {
-            panic!("blog post at path `{}` lacks team/team_url metadata", path.display());
+            panic!("blog post at path `{}` lacks team metadata", path.display());
         }
 
         // If they supplied team, it should look like `team-text <team-url>`

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -1,4 +1,6 @@
+use crate::blogs::Manifest;
 use comrak::ComrakOptions;
+use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
 use std::path::{Path, PathBuf};
@@ -9,11 +11,14 @@ struct YamlHeader {
     author: String,
     #[serde(default)]
     release: bool,
+    team: Option<String>,
+    layout: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct Post {
     pub(crate) filename: String,
+    pub(crate) layout: String,
     pub(crate) title: String,
     pub(crate) author: String,
     pub(crate) year: String,
@@ -24,10 +29,13 @@ pub(crate) struct Post {
     pub(crate) url: String,
     pub(crate) published: String,
     pub(crate) release: bool,
+    pub(crate) has_team: bool,
+    pub(crate) team: String,
+    pub(crate) team_url: String,
 }
 
 impl Post {
-    pub(crate) fn open(path: &Path) -> Result<Self, Box<dyn Error>> {
+    pub(crate) fn open(path: &Path, manifest: &Manifest) -> Result<Self, Box<dyn Error>> {
         // yeah this might blow up, but it won't
         let filename = path.file_name().unwrap().to_str().unwrap();
 
@@ -49,6 +57,8 @@ impl Post {
             author,
             title,
             release,
+            team: team_string,
+            layout,
         } = serde_yaml::from_str(yaml)?;
         // next, the contents. we add + to get rid of the final "---\n\n"
         let options = ComrakOptions {
@@ -84,6 +94,34 @@ impl Post {
 
         let published = published.rfc3339().to_string();
 
+        // validate for now that the layout is specified as "post"
+        match &*layout {
+            "post" => (),
+            _ => panic!("blog post at path `{}` should have layout `post`", path.display()),
+        };
+
+        // Enforce extra conditions
+        if manifest.requires_team && team_string.is_none() {
+            panic!("blog post at path `{}` lacks team/team_url metadata", path.display());
+        }
+
+        // If they supplied team, it should look like `team-text <team-url>`
+        let (team, team_url) = match team_string {
+            Some(s) => {
+                lazy_static::lazy_static! {
+                    static ref R: Regex = Regex::new(r"(?P<name>[^<]*) <(?P<url>[^>]+)>").unwrap();
+                }
+                let captures = match R.captures(&s) {
+                    Some(c) => c,
+                    None => panic!("team from path `{}` should have format `$name <$url>`",
+                                   path.display()),
+                };
+                (Some(captures["name"].to_string()), Some(captures["url"].to_string()))
+            }
+
+            None => (None, None)
+        };
+
         Ok(Self {
             filename,
             title,
@@ -96,6 +134,10 @@ impl Post {
             url,
             published,
             release,
+            layout,
+            has_team: team.is_some(),
+            team: team.unwrap_or_default(),
+            team_url: team_url.unwrap_or_default(),
         })
     }
 }

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -2,7 +2,15 @@
 <header class="mt3 mt0-ns mb6-ns">
   <div class="container flex flex-column flex-row-l justify-between-l">
     <div class="mw8-l">
-      <h1>Blog</h1>
+      <h1>Posts</h1>
+    </div>
+  </div>
+  <div class="container flex flex-column flex-row-l justify-between-l">
+    <div class="mw8-l">
+      <b>See also:</b>
+      {{#each other_blogs}}
+              <a href="{{url}}">{{name}}</a>
+      {{/each}}
     </div>
   </div>
 </header>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -1,16 +1,18 @@
 {{#*inline "page"}}
-<header class="mt3 mt0-ns mb6-ns">
+<header class="mt3 mt0-ns mb4-ns">
   <div class="container flex flex-column flex-row-l justify-between-l">
-    <div class="mw8-l">
-      <h1>Posts</h1>
+    <div class="mw6-l">
+      <p>{{{blog.index_html}}}</p>
     </div>
-  </div>
+  </div>    
   <div class="container flex flex-column flex-row-l justify-between-l">
     <div class="mw8-l">
+      <p>
       <b>See also:</b>
       {{#each other_blogs}}
               <a href="{{url}}">{{name}}</a>
       {{/each}}
+      </p>
     </div>
   </div>
 </header>
@@ -22,7 +24,7 @@
     {{#each blog.posts}}
       {{#if show_year}}<tr>
         <td class="bn"></td>
-        <td class="bn"><h3 class="f0-l f1-m f2-s mt4 mb0">{{year}}</h3></td>
+        <td class="bn"><h3 class="f0-l f1-m f2-s mt4 mb0">Posts in {{year}}</h3></td>
       </tr>{{/if}}
       <tr>
         <td class="tr o-60 pr4 pr5-l bn">{{month_name month}}&nbsp;{{day}}</td>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -10,7 +10,7 @@
       <p>
       <b>See also:</b>
       {{#each other_blogs}}
-              <a href="{{url}}">{{name}}</a>
+              <a href="{{url}}">the {{name}}</a>
       {{/each}}
       </p>
     </div>

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -10,7 +10,7 @@
       <p>
       <b>See also:</b>
       {{#each other_blogs}}
-              <a href="{{url}}">the {{name}}</a>
+              <a href="{{url}}">{{link_text}}</a>
       {{/each}}
       </p>
     </div>

--- a/templates/post.hbs
+++ b/templates/post.hbs
@@ -6,7 +6,9 @@
       <div class="highlight"></div>
     </header>
 
-    <div class="publish-date-author">{{month_name post.month}} {{post.day}}, {{post.year}} &middot; {{post.author}}</div>
+    <div class="publish-date-author">{{month_name post.month}} {{post.day}}, {{post.year}} &middot; {{post.author}}
+    {{#if post.has_team}} on behalf of <a href="{{post.team_url}}">{{post.team}}</a> {{/if}}
+    </div>
 
     <div class="post">
       {{{ post.contents }}}


### PR DESCRIPTION
This PR creates the "Rust Team Blog", which will be visible at `blog.rust-lang.org/team`. This is a draft PR because I'd like to resolve a few questions:

- [x] prep an announcement blog post for the main blog 
- [x] Settled the name ("Inside Rust" wins!)
- [x] Modify PR to use the "Inside Rust" name and adjust other things
- [x] How should we expose this blog on the site? Right now, you'd just have to guess the URL.
    - I'm not sure this has to block us from deploying the blog now though -- there is a lot of demand to have a place 
- [x] I added an ad-hoc tag `team: core` to the first post -- I'd like each post to be tagged with a team, and ideally I'd like that to be visible in the post (and to enable filtering by team/working group). Can we at least enforce that we have a `team:` tag somewhere for now?
- [x] Any thoughts on the other "front matter" in the blog.yml file? (e.g., tagphrase)
- [x] And of course any thoughts on the text of the inaugural post itself?
- [x] A draft of blog policies are visible here https://github.com/rust-lang/wg-governance/issues/23
- [x] Remove "dual layout" system and replace with a change to blog configuration.