### PR TITLE
Fix (and improve) enum representation of an async fn future

### DIFF
--- a/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
+++ b/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
@@ -121,9 +121,25 @@ async fn bar(x: &Mutex<u32>) {
 ```
 
 ```rust
-enum BarGenerator {
-    Unresumed { x: &Mutex<u32>, g: MutexGuard<'_, u32>, },
-    Suspend0 { x: &Mutex<u32>, g: MutexGuard<'_, u32>, }
+enum BarAsyncFnGenerator {
+    Unresumed {
+        // async fn params
+        x: &Mutex<u32>,
+    },
+
+    Suspend0 {
+        // future being polled: baz_fut = baz()
+        baz_fut: BazAsyncFnGenerator,
+
+        // locals that cross the await point
+        x: &Mutex<u32>,
+        g: MutexGuard<'_, u32>,
+    },
+
+    Return(
+        // value returned by the future
+        ()
+    )
 }
 ```
 

--- a/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
+++ b/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
@@ -121,25 +121,20 @@ async fn bar(x: &Mutex<u32>) {
 ```
 
 ```rust
-enum BarAsyncFnGenerator {
-    Unresumed {
-        // async fn params
-        x: &Mutex<u32>,
-    },
+enum BarGenerator {
+    // `bar`'s parameters.
+    Unresumed { x: &Mutex<u32> },
 
     Suspend0 {
-        // future being polled: baz_fut = baz()
-        baz_fut: BazAsyncFnGenerator,
+        // Future returned by `baz`, which is being polled.
+        baz_future: BazGenerator,
 
-        // locals that cross the await point
+        // Locals that are used across the await point.
         x: &Mutex<u32>,
         g: MutexGuard<'_, u32>,
     },
 
-    Return(
-        // value returned by the future
-        ()
-    )
+    Returned { value: () }
 }
 ```
 


### PR DESCRIPTION
`g: MutexGuard<'_, u32>` does not exist in the scope of the "unresumed" generator / future, so this fixes it.

On top of that, I have taken the freedom to add a the `Return` variant to the enum, and have also added some comments on top of it, in order to have a precise recap' of the cited post about generators.