### PR TITLE
fix typo in blog post about async-await diagnostics

### DIFF
--- a/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
+++ b/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
@@ -166,7 +166,7 @@ async fn bar(x: &Mutex<u32>) {
 } // <- `g` is dropped here
 ```
 
-`bar` unlocks the mutex before `await`ing `baz`. `std::sync::MutexGuard<u32>` does not implement
+`bar` locks the mutex before `await`ing `baz`. `std::sync::MutexGuard<u32>` does not implement
 `Send` and lives across the `baz().await` point (because `g` is dropped at the end of the scope)
 which causes the entire future not to implement `Send`.
 


### PR DESCRIPTION
If I'm reading the code correctly, and if I understand the Sync requirement correctly, the problem here is that bar() _locks_ the mutex, not that bar() unlocks the mutex.