### PR TITLE
Fix "feel freeo" typo

### DIFF
--- a/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
+++ b/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
@@ -31,7 +31,7 @@ This group is a great fit for anyone who is familiar with LLVM and who would lik
 * reducing LLVM IR to minimal problem cases;
 * and so forth.
 
-(For that matter, feel freeo to join the group even if you're *not* all that familiar with LLVM -- no better way to learn!)
+(For that matter, feel free to join the group even if you're *not* all that familiar with LLVM -- no better way to learn!)
 
 ### What's with the name ICE-breaker anyway?
 


### PR DESCRIPTION
Fix "feel freeo" typo in the LLVM ICE-breaker post