### PR TITLE
Inside Rust: Announcing the Docs.rs Team

### DIFF
--- a/posts/inside-rust/2019-12-09-announcing-the-docsrs-team.md
+++ b/posts/inside-rust/2019-12-09-announcing-the-docsrs-team.md
@@ -18,11 +18,12 @@ the new Docs.rs Team, leaving [@GuillaumeGomez] to lead the Rustdoc Team. The Do
 welcomes [@pietroalbini], who has been helping out a lot with maintaining the infrastructure and
 operations side of Docs.rs.
 
-To get involved with either team, join us [on Discord]! The Rustdoc Team hangs out in `#rustdoc`,
-and the Docs.rs Team hangs out in `#docs-rs`.
+To get involved with either team, join us on Discord! The Rustdoc Team hangs out in [`#rustdoc`],
+and the Docs.rs Team hangs out in [`#docs-rs`].
 
 [Docs.rs]: https://docs.rs/
 [@QuietMisdreavus]: https://github.com/QuietMisdreavus
 [@GuillaumeGomez]: https://github.com/GuillaumeGomez
 [@pietroalbini]: https://github.com/pietroalbini
-[on Discord]: https://discord.gg/rust-lang
+[`#rustdoc`]: https://discord.gg/4yEYPuT
+[`#docs-rs`]: https://discord.gg/2k5vVWn

--- a/posts/inside-rust/2019-12-09-announcing-the-docsrs-team.md
+++ b/posts/inside-rust/2019-12-09-announcing-the-docsrs-team.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "Announcing the Docs.rs Team"
+author: QuietMisdreavus
+team: The Rustdoc Team <https://www.rust-lang.org/governance/teams/dev-tools#rustdoc>
+---
+
+Today we're announcing a brand new team: The Docs.rs Team!
+
+Previously, [Docs.rs] has been managed by the Rustdoc Team, as many of the initial concerns of
+Docs.rs were shared by Rustdoc as Docs.rs was being brought into team maintainership. However, as
+time went on, those concerns started to diverge more and more, and so did the people who contributed
+to either tool.
+
+The new Docs.rs Team will be responsible for the operations and development for [Docs.rs], leaving
+the Rustdoc Team to be responsible for the Rustdoc tool itself. [@QuietMisdreavus] will be leading
+the new Docs.rs Team, leaving [@GuillaumeGomez] to lead the Rustdoc Team. The Docs.rs Team also
+welcomes [@pietroalbini], who has been helping out a lot with maintaining the infrastructure and
+operations side of Docs.rs.
+
+To get involved with either team, join us [on Discord]! The Rustdoc Team hangs out in `#rustdoc`,
+and the Docs.rs Team hangs out in `#docs-rs`.
+
+[Docs.rs]: https://docs.rs/
+[@QuietMisdreavus]: https://github.com/QuietMisdreavus
+[@GuillaumeGomez]: https://github.com/GuillaumeGomez
+[@pietroalbini]: https://github.com/pietroalbini
+[on Discord]: https://discord.gg/rust-lang

--- a/posts/inside-rust/2019-12-09-announcing-the-docsrs-team.md
+++ b/posts/inside-rust/2019-12-09-announcing-the-docsrs-team.md
@@ -14,9 +14,13 @@ to either tool.
 
 The new Docs.rs Team will be responsible for the operations and development for [Docs.rs], leaving
 the Rustdoc Team to be responsible for the Rustdoc tool itself. [@QuietMisdreavus] will be leading
-the new Docs.rs Team, leaving [@GuillaumeGomez] to lead the Rustdoc Team. The Docs.rs Team also
-welcomes [@pietroalbini], who has been helping out a lot with maintaining the infrastructure and
-operations side of Docs.rs.
+the new Docs.rs Team, leaving [@GuillaumeGomez] to lead the Rustdoc Team.
+
+Joining QuietMisdreavus on the Docs.rs Team is GuillaumeGomez, coordinating work between Rustdoc and
+Docs.rs; [@onur], the original creator of Docs.rs; [@pietroalbini], who has coordinated work in
+Docs.rs from the perspective of the Infrastrucure Team; and introducing [@jyn514], who has worked to
+improve the developer experience of contributing to Docs.rs by converting the local development
+configuration to use `docker-compose`!
 
 To get involved with either team, join us on Discord! The Rustdoc Team hangs out in [`#rustdoc`],
 and the Docs.rs Team hangs out in [`#docs-rs`].
@@ -24,6 +28,8 @@ and the Docs.rs Team hangs out in [`#docs-rs`].
 [Docs.rs]: https://docs.rs/
 [@QuietMisdreavus]: https://github.com/QuietMisdreavus
 [@GuillaumeGomez]: https://github.com/GuillaumeGomez
+[@onur]: https://github.com/onur
 [@pietroalbini]: https://github.com/pietroalbini
+[@jyn514]: https://github.com/jyn514
 [`#rustdoc`]: https://discord.gg/4yEYPuT
 [`#docs-rs`]: https://discord.gg/2k5vVWn


### PR DESCRIPTION
This is an announcement post for https://github.com/rust-lang/team/pull/182. I set its "publish date" to tomorrow, but that could be optimistic for the team PR's approval. I can change it if need be.