### PR TITLE
Make it so updated time is always unique in feed.xml

### DIFF
--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -68,6 +68,16 @@ impl Blog {
             posts[i].show_year = posts[i - 1].year != posts[i].year;
         }
 
+        // Make the updated time is unique, by incrementing seconds for duplicates
+        let mut last_matching_updated = 0;
+        for i in 1..posts.len() {
+            if posts[i].updated == posts[last_matching_updated].updated {
+                posts[i].set_updated((i - last_matching_updated) as u32);
+            } else {
+                last_matching_updated = i;
+            }
+        }
+
         Ok(Blog {
             title: manifest.title,
             index_title: manifest.index_title,

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -144,6 +144,10 @@ impl Post {
 }
 
 fn build_post_time(year: u32, month: u32, day: u32, seconds: u32) -> String {
+    let seconds = Duration::seconds(seconds as i64);
+    if seconds >= Duration::days(1) {
+        panic!("seconds must be less then a day")
+    };
     // build the time. this is only approximate, which is fine.
     let mut time = Tm {
         tm_sec: 0,
@@ -159,6 +163,6 @@ fn build_post_time(year: u32, month: u32, day: u32, seconds: u32) -> String {
         tm_utcoff: 0,
         tm_nsec: 0,
     };
-    time = time + Duration::seconds(seconds as i64);
+    time = time + seconds;
     time.rfc3339().to_string()
 }

--- a/templates/feed.hbs
+++ b/templates/feed.hbs
@@ -17,7 +17,7 @@
         <title>{{title}}</title>
         <link rel="alternate" href="https://blog.rust-lang.org/{{../blog.prefix}}{{url}}" type="text/html" title="{{title}}" />
         <published>{{published}}</published>
-        <updated>{{published}}</updated>
+        <updated>{{updated}}</updated>
         <id>https://blog.rust-lang.org/{{../blog.prefix}}{{url}}</id>
         <content type="html" xml:base="https://blog.rust-lang.org/{{../blog.prefix}}{{url}}">{{contents}}</content>
 


### PR DESCRIPTION
Resolves issue: https://github.com/rust-lang/blog.rust-lang.org/issues/355
This change separates published time, and updated time, and ensures that updated time is unique for blog posts on the same day.