### PR TITLE
Sort posts as YYYY-MM-DD-TITLE, not YYYY-M-D-TITLE

### DIFF
--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -59,7 +59,12 @@ impl Blog {
             }
         }
 
-        posts.sort_by_key(|post| post.url.clone());
+        posts.sort_by_key(|post| {
+            format!(
+                "{}-{:02}-{:02}-{}",
+                post.year, post.month, post.day, post.title
+            )
+        });
         posts.reverse();
 
         // Decide which posts should show the year in the index.


### PR DESCRIPTION
Previously all December, November and October posts were buried
below February, because `2019/2/1` (Feb 1) is lexicographically
above (in front of?) `2019/10/1` (Oct 1). This is not how mother
nature intended it in ISO8601:

* https://en.wikipedia.org/wiki/ISO_8601

Let's correct this mistake by sorting dates with zero prefixed
month and day numbers to make all dates of fixed size.

Among other things, this puts Rust 1.40 (released `2019-12-19`)
as the version newer than Rust 1.38 (released `2019-09-26`),
which is now linked as the latest version on rust-lang.org,
despite link saying it's Rust 1.40.

Closes #500