### PR TITLE
Fix h3 on blog posts

### DIFF
--- a/posts/inside-rust/2019-10-15-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-15-compiler-team-meeting.md
@@ -26,8 +26,6 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 ## Working group sync
 
-<br/>
-
 ### [wg-learning](https://rust-lang.github.io/compiler-team/working-groups/learning/)
 
 `wg-learning` aims to make the compiler easier to learn by ensuring that rustc-guide and api docs are “complete”.

--- a/posts/inside-rust/2019-10-21-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-21-compiler-team-meeting.md
@@ -27,8 +27,6 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 ## Working group sync
 
-<br/>
-
 ### [wg-mir-opt](https://rust-lang.github.io/compiler-team/working-groups/mir-opt/)
 
 - [@wesleywiser] Moved promoted MIR out of `mir::Body` [#63580](https://github.com/rust-lang/rust/pull/63580)

--- a/posts/inside-rust/2019-10-30-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-30-compiler-team-meeting.md
@@ -16,8 +16,6 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 ## Working group sync
 
-<br/>
-
 ### [wg-nll](https://rust-lang.github.io/compiler-team/working-groups/nll/)
 
 - Rust 1.40 (current nightly) will be the first stable release without the HIR borrow checker.

--- a/posts/inside-rust/2019-11-07-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-11-07-compiler-team-meeting.md
@@ -18,8 +18,6 @@ Rust 1.39 ships on Thursday!
 
 ## Working group sync
 
-<br/>
-
 ### [wg-pgo](https://rust-lang.github.io/compiler-team/working-groups/pgo/)
 
 - PGO is available in the stable compiler. Docs are in the rustc-guide and the rustc-book

--- a/posts/inside-rust/2019-11-11-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-11-11-compiler-team-meeting.md
@@ -20,8 +20,6 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 ## Working group sync
 
-<br/>
-
 ### [wg-polonius]
 
 We ran out of time this week to have a check-in from this working group.

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -251,6 +251,10 @@ h3, .post h2, header h2 {
   h2 {
     font-size: 2em;
   }
+  
+  h3 {
+    display: block;
+  }
 
   img {
     display: block;


### PR DESCRIPTION
The CSS was setting h3 to inline-block, this caused it to sometimes combine headers in blog posts unintentionally.

Fixes #453 