### PR TITLE
Fix profile directory in crate graph self-profiling example

### DIFF
--- a/posts/inside-rust/2020-02-25-intro-rustc-self-profile.md
+++ b/posts/inside-rust/2020-02-25-intro-rustc-self-profile.md
@@ -213,7 +213,7 @@ Since this will create a lot of files, we'll tell `rustc` to create a folder to 
 ```sh
 $ rm regex-17088.* regex-23649.* # clean up the old trace files since we're done with them
 $ cargo clean
-$ RUSTFLAGS="-Zself-profile=./profiles -Zself-profile-events=default,args" cargo build
+$ RUSTFLAGS="-Zself-profile=$(pwd)/profiles -Zself-profile-events=default,args" cargo build
 ```
 
 This creates quite a few trace files in the working directory.


### PR DESCRIPTION
In the rustc self-profiling blog post, the proposed crate graph-wide self-profiling command is incorrect.

```sh
$ RUSTFLAGS="-Zself-profile=./profiles -Zself-profile-events=default,args" cargo build
```

The problem is that the `./profiles` relative directory will be resolved with respect to whatever directory rustc happens to be working in at the time where the RUSTFLAGS are parsed. Which, for dependency crates, will be the source directory of those dependencies, not the source directory of the crate that we are working on.

Forcing directory resolution to be relative to the active crate's directory by replacing the rustc-evaluated `.` with a shell-evaluated `$(pwd)` resolves this problem.

Kudos to @bjorn3 for figuring this out!