### PR TITLE
Match colours with main website

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -3,11 +3,11 @@
 $body-font: 'Fira Sans', Helvetica, Arial, sans-serif;
 $header-font: 'Alfa Slab One', serif;
 
-$gray: #454C52;
-$red: #C14566;
-$green: #398277;
-$purple: #403D58;
-$yellow: #FFD45E;
+$gray: #2a3439;
+$red: #a72145;
+$green: #0b7261;
+$purple: #2e2459;
+$yellow: #ffc832;
 
 html {
   font-size: 62.5%
@@ -163,8 +163,8 @@ ul, ol {
   padding-left: 1.2em;
 }
 
-.purple {
-  background-color: $purple;
+.posts {
+  background-color: $gray;
   color: white;
   .highlight {
     background-color: $red;

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -17,7 +17,7 @@
   </div>
 </header>
 
-<section id="posts" class="purple">
+<section id="posts" class="posts">
    <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
 
     <table class="post-list collapse w-100 f2-l f2-m f3-s">


### PR DESCRIPTION
This changes the colours on the blog to match the new colours on the website. I'm also proposing changing from using the background colour for the posts feed to gray, as I feel that works better with the post list than the purple (though I don't mind the the purple). I've put in a comparison screenshots below.


### Old / New Purple
<img width="1680" alt="Screenshot 2020-03-04 at 10 52 31" src="https://user-images.githubusercontent.com/4464295/75870099-ca017b00-5e0a-11ea-9fd7-442973eb9036.png">

### Old Purple / New Gray
<img width="1680" alt="Screenshot 2020-03-04 at 10 54 32" src="https://user-images.githubusercontent.com/4464295/75870095-c968e480-5e0a-11ea-92a5-f8f2e24d6000.png">

### New Purple / New Gray
<img width="1680" alt="Screenshot 2020-03-04 at 10 55 38" src="https://user-images.githubusercontent.com/4464295/75870092-c837b780-5e0a-11ea-99bf-8f51bb4877c4.png">


