### PR TITLE
Transition rustc-guide to rustc-dev-guide

### DIFF
--- a/posts/2018-05-15-Rust-turns-three.md
+++ b/posts/2018-05-15-Rust-turns-three.md
@@ -44,7 +44,7 @@ Finally, the Rust community continues to work on inclusivity, through outreach
 programs like [Rust Reach](https://blog.rust-lang.org/2018/04/02/Increasing-Rusts-Reach-2018.html) and
 [RustBridge](https://rustbridge.github.io/), as well as
 [structured mentoring](https://blog.rust-lang.org/2017/09/18/impl-future-for-rust.html) and
-investments in [documentation](https://rust-lang-nursery.github.io/rustc-guide/)
+investments in [documentation](https://rust-lang-nursery.github.io/rustc-dev-guide/)
 to ease contribution. For 2018, a major goal is to
 [connect and empower Rust’s *global* community](https://blog.rust-lang.org/2018/03/12/roadmap.html),
 which we’re doing both through conference launches in multiple new continents,

--- a/posts/2018-05-15-Rust-turns-three.md
+++ b/posts/2018-05-15-Rust-turns-three.md
@@ -44,7 +44,7 @@ Finally, the Rust community continues to work on inclusivity, through outreach
 programs like [Rust Reach](https://blog.rust-lang.org/2018/04/02/Increasing-Rusts-Reach-2018.html) and
 [RustBridge](https://rustbridge.github.io/), as well as
 [structured mentoring](https://blog.rust-lang.org/2017/09/18/impl-future-for-rust.html) and
-investments in [documentation](https://rust-lang.github.io/rustc-dev-guide/)
+investments in [documentation](https://rustc-dev-guide.rust-lang.org/)
 to ease contribution. For 2018, a major goal is to
 [connect and empower Rust’s *global* community](https://blog.rust-lang.org/2018/03/12/roadmap.html),
 which we’re doing both through conference launches in multiple new continents,

--- a/posts/2018-05-15-Rust-turns-three.md
+++ b/posts/2018-05-15-Rust-turns-three.md
@@ -44,7 +44,7 @@ Finally, the Rust community continues to work on inclusivity, through outreach
 programs like [Rust Reach](https://blog.rust-lang.org/2018/04/02/Increasing-Rusts-Reach-2018.html) and
 [RustBridge](https://rustbridge.github.io/), as well as
 [structured mentoring](https://blog.rust-lang.org/2017/09/18/impl-future-for-rust.html) and
-investments in [documentation](https://rust-lang-nursery.github.io/rustc-dev-guide/)
+investments in [documentation](https://rust-lang.github.io/rustc-dev-guide/)
 to ease contribution. For 2018, a major goal is to
 [connect and empower Rust’s *global* community](https://blog.rust-lang.org/2018/03/12/roadmap.html),
 which we’re doing both through conference launches in multiple new continents,

--- a/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
+++ b/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
@@ -245,7 +245,7 @@ actual implementation looks like, check out PR [#64895][pr64895].
 
 If you're interested in improving diagnostics like this, or even just fixing bugs, consider
 contributing to the compiler! There are many working groups to join and resources to help you get
-started (like the [rustc guide][rustc_guide] or the [compiler team documentation][compiler_team]).
+started (like the [rustc dev guide][rustc_dev_guide] or the [compiler team documentation][compiler_team]).
 
 # What's next?
 
@@ -279,6 +279,6 @@ note: future does not implement `std::marker::Send` as this value is used across
 [tmandry_post]: https://tmandry.gitlab.io/blog/posts/optimizing-await-1/
 [send_doc]: https://doc.rust-lang.org/std/marker/trait.Send.html
 [compiler_team]: https://rust-lang.github.io/compiler-team
-[rustc_guide]: https://rust-lang.github.io/rustc-guide
+[rustc_dev_guide]: https://rust-lang.github.io/rustc-dev-guide
 [pr64895]: https://github.com/rust-lang/rust/pull/64895
 [play]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=7e80a8bc151df8817e0983e55bf2667a

--- a/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
+++ b/posts/inside-rust/2019-10-11-AsyncAwait-Not-Send-Error-Improvements.md
@@ -279,6 +279,6 @@ note: future does not implement `std::marker::Send` as this value is used across
 [tmandry_post]: https://tmandry.gitlab.io/blog/posts/optimizing-await-1/
 [send_doc]: https://doc.rust-lang.org/std/marker/trait.Send.html
 [compiler_team]: https://rust-lang.github.io/compiler-team
-[rustc_dev_guide]: https://rust-lang.github.io/rustc-dev-guide
+[rustc_dev_guide]: https://rustc-dev-guide.rust-lang.org
 [pr64895]: https://github.com/rust-lang/rust/pull/64895
 [play]: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=7e80a8bc151df8817e0983e55bf2667a

--- a/posts/inside-rust/2019-10-15-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-15-compiler-team-meeting.md
@@ -28,9 +28,9 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 ### [wg-learning](https://rust-lang.github.io/compiler-team/working-groups/learning/)
 
-`wg-learning` aims to make the compiler easier to learn by ensuring that rustc-guide and api docs are “complete”.
+`wg-learning` aims to make the compiler easier to learn by ensuring that rustc-dev-guide and api docs are “complete”.
 
-- `wg-learning` has been working on transcribing videos from the [compiler lecture series](https://www.youtube.com/watch?v=elBxMRSNYr4&list=PL85XCvVPmGQhOL-J2Ng7qlPvDVOwYpGTN) into [rustc-guide](https://rust-lang.github.io/rustc-guide/) chapters.
+- `wg-learning` has been working on transcribing videos from the [compiler lecture series](https://www.youtube.com/watch?v=elBxMRSNYr4&list=PL85XCvVPmGQhOL-J2Ng7qlPvDVOwYpGTN) into [rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/) chapters.
 
 - Originally, individuals were assigned one or lectures to complete but that hasn't worked very well.
 

--- a/posts/inside-rust/2019-10-15-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-15-compiler-team-meeting.md
@@ -28,9 +28,9 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 ### [wg-learning](https://rust-lang.github.io/compiler-team/working-groups/learning/)
 
-`wg-learning` aims to make the compiler easier to learn by ensuring that [rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/) and api docs are “complete”.
+`wg-learning` aims to make the compiler easier to learn by ensuring that [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/) and api docs are “complete”.
 
-- `wg-learning` has been working on transcribing videos from the [compiler lecture series](https://www.youtube.com/watch?v=elBxMRSNYr4&list=PL85XCvVPmGQhOL-J2Ng7qlPvDVOwYpGTN) into [rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/) chapters.
+- `wg-learning` has been working on transcribing videos from the [compiler lecture series](https://www.youtube.com/watch?v=elBxMRSNYr4&list=PL85XCvVPmGQhOL-J2Ng7qlPvDVOwYpGTN) into [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/) chapters.
 
 - Originally, individuals were assigned one or lectures to complete but that hasn't worked very well.
 

--- a/posts/inside-rust/2019-10-15-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-15-compiler-team-meeting.md
@@ -28,7 +28,7 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 ### [wg-learning](https://rust-lang.github.io/compiler-team/working-groups/learning/)
 
-`wg-learning` aims to make the compiler easier to learn by ensuring that rustc-dev-guide and api docs are “complete”.
+`wg-learning` aims to make the compiler easier to learn by ensuring that [rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/) and api docs are “complete”.
 
 - `wg-learning` has been working on transcribing videos from the [compiler lecture series](https://www.youtube.com/watch?v=elBxMRSNYr4&list=PL85XCvVPmGQhOL-J2Ng7qlPvDVOwYpGTN) into [rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/) chapters.
 

--- a/posts/inside-rust/2019-10-21-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-21-compiler-team-meeting.md
@@ -45,9 +45,9 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 - The [Inside Rust](https://blog.rust-lang.org/inside-rust/index.html) blog has launched.
 
-- The [ICE-Breaker group](https://rust-lang.github.io/rustc-guide/ice-breaker/about.html) has been formed!
+- The [ICE-Breaker group](https://rust-lang.github.io/rustc-dev-guide/ice-breaker/about.html) has been formed!
 
-- The [LLVM ICE-Breaker group](https://rust-lang.github.io/rustc-guide/ice-breaker/llvm.html) is also being formed.
+- The [LLVM ICE-Breaker group](https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html) is also being formed.
 
 [Link to full conversation](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/weekly.20meeting.202019-10-17.20.2354818/near/178389266)
 

--- a/posts/inside-rust/2019-10-21-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-10-21-compiler-team-meeting.md
@@ -45,9 +45,9 @@ Each week, we have general announcements from the team followed by check-ins fro
 
 - The [Inside Rust](https://blog.rust-lang.org/inside-rust/index.html) blog has launched.
 
-- The [ICE-Breaker group](https://rust-lang.github.io/rustc-dev-guide/ice-breaker/about.html) has been formed!
+- The [ICE-Breaker group](https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html) has been formed!
 
-- The [LLVM ICE-Breaker group](https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html) is also being formed.
+- The [LLVM ICE-Breaker group](https://rustc-dev-guide.rust-lang.org/ice-breaker/llvm.html) is also being formed.
 
 [Link to full conversation](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/weekly.20meeting.202019-10-17.20.2354818/near/178389266)
 

--- a/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
+++ b/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
@@ -12,11 +12,11 @@ Today I'm announcing a new experiment in the compiler team, the **LLVM ICE-break
 
 At its heart, the LLVM ICE-breaker group is just a list of people who would like to be notified when we come across LLVM bugs. You can add yourself to this list very easily -- just [open a PR]! When we come across a suitable bug, we'll write a message that `@`-mentions every Github user on that list. If you have some time, maybe you can fix one of them, or at least offer some words of wisdom to help somebody else figure out what's going on.
 
-[open a PR]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/about.html#join
+[open a PR]: https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html#join
 
 There are a few other things associated with the group too, however. For example, we've got a [guide] that offers some tips for how to fix LLVM-related bugs and may help you get started (particularly if you're not that familiar with rustc).
 
-[guide]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html
+[guide]: https://rustc-dev-guide.rust-lang.org/ice-breaker/llvm.html
 
 ### What kind of bugs are we talking about?
 

--- a/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
+++ b/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
@@ -12,11 +12,11 @@ Today I'm announcing a new experiment in the compiler team, the **LLVM ICE-break
 
 At its heart, the LLVM ICE-breaker group is just a list of people who would like to be notified when we come across LLVM bugs. You can add yourself to this list very easily -- just [open a PR]! When we come across a suitable bug, we'll write a message that `@`-mentions every Github user on that list. If you have some time, maybe you can fix one of them, or at least offer some words of wisdom to help somebody else figure out what's going on.
 
-[open a PR]: https://rust-lang.github.io/rustc-guide/ice-breaker/about.html#join
+[open a PR]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/about.html#join
 
 There are a few other things associated with the group too, however. For example, we've got a [guide] that offers some tips for how to fix LLVM-related bugs and may help you get started (particularly if you're not that familiar with rustc).
 
-[guide]: https://rust-lang.github.io/rustc-guide/ice-breaker/llvm.html
+[guide]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/llvm.html
 
 ### What kind of bugs are we talking about?
 

--- a/posts/inside-rust/2019-10-28-rustc-learning-working-group-introduction.md
+++ b/posts/inside-rust/2019-10-28-rustc-learning-working-group-introduction.md
@@ -74,8 +74,8 @@ can make the documentation better.
 - **[Zulip Stream: `#t-compiler/wg-learning` on Zulip]**
 
 [Learning Working Group]: https://github.com/rust-lang/compiler-team/tree/master/content/working-groups/learning
-[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
-[Rustc Dev Guide Book]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
+[Rustc Dev Guide Book]: https://rustc-dev-guide.rust-lang.org/
 [rustc-dev-guide Github repository]: https://github.com/rust-lang/rustc-dev-guide
 [Rustc Dev Guide Repository]: https://github.com/rust-lang/rustc-dev-guide
 [Representing types in rustc]: https://www.youtube.com/watch?v=c01TsOsr3-c

--- a/posts/inside-rust/2019-10-28-rustc-learning-working-group-introduction.md
+++ b/posts/inside-rust/2019-10-28-rustc-learning-working-group-introduction.md
@@ -7,14 +7,14 @@ team: the rustc learning working group <https://www.rust-lang.org/governance/tea
 ---
 
 The [Learning Working Group], formed in April 2019, is focused on making the
-compiler easier to learn by ensuring that [rustc-guide] and API docs are
+compiler easier to learn by ensuring that [rustc-dev-guide] and API docs are
 "complete". It is one of the many efforts by the Rust Compiler team to
 decrease the barrier of contributing to the compiler. As noted on the WG’s
 homepage —
 
 *This working group aims to accomplish the following:*
 
-- *Ensure that major components of rustc are covered in rustc-guide*
+- *Ensure that major components of rustc are covered in rustc-dev-guide*
 - *Ensure that API doc coverage is at least 90%*
 
 The Learning Group is making entry to contribute easier by improving the
@@ -30,9 +30,9 @@ The Learning group, in general, is starting to document the
 “Compiler lecture series”, which are a list of Youtube video lectures
 given earlier by the more knowledgeable members of the compiler team.
 There is also the task of improving the documentation structure of
-[rustc-guide]. At first, each member used to pick a video lecture by
+[rustc-dev-guide]. At first, each member used to pick a video lecture by
 themselves and contribute via a Github pull request to the
-[rustc-guide Github repository]. This proved to be a bit difficult
+[rustc-dev-guide Github repository]. This proved to be a bit difficult
 for the following reasons —
 
 1. Not all members would get to watch and work on the lectures of
@@ -66,20 +66,20 @@ can make the documentation better.
 ## Important  resources
 
 - **[Learning Working Group]**
-- **[Rustc Guide Book]**
-- **[Rustc Guide Repository]**
+- **[Rustc Dev Guide Book]**
+- **[Rustc Dev Guide Repository]**
 - **[Github Project (Kanban)]**
 - **[Learning WG Meeting Minutes]**
 - **[Rust Youtube Videos]** 
 - **[Zulip Stream: `#t-compiler/wg-learning` on Zulip]**
 
 [Learning Working Group]: https://github.com/rust-lang/compiler-team/tree/master/content/working-groups/learning
-[rustc-guide]: https://rust-lang.github.io/rustc-guide/
-[Rustc Guide Book]: https://rust-lang.github.io/rustc-guide/
-[rustc-guide Github repository]: https://github.com/rust-lang/rustc-guide
-[Rustc Guide Repository]: https://github.com/rust-lang/rustc-guide
+[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
+[Rustc Dev Guide Book]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc-dev-guide Github repository]: https://github.com/rust-lang/rustc-dev-guide
+[Rustc Dev Guide Repository]: https://github.com/rust-lang/rustc-dev-guide
 [Representing types in rustc]: https://www.youtube.com/watch?v=c01TsOsr3-c
-[Github Project (Kanban)]: https://github.com/rust-lang/rustc-guide/projects/2
+[Github Project (Kanban)]: https://github.com/rust-lang/rustc-dev-guide/projects/2
 [Learning WG Meeting Minutes]: https://github.com/rust-lang/compiler-team/tree/master/content/working-groups/learning/minutes
 [Rust Youtube Videos]: https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA/playlists
 [rust-lang/rust]: https://github.com/rust-lang/rust

--- a/posts/inside-rust/2019-11-07-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-11-07-compiler-team-meeting.md
@@ -20,7 +20,7 @@ Rust 1.39 ships on Thursday!
 
 ### [wg-pgo](https://rust-lang.github.io/compiler-team/working-groups/pgo/)
 
-- PGO is available in the stable compiler. Docs are in the rustc-dev-guide and the rustc-book
+- PGO is available in the stable compiler. Docs are in the [rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/) and the [rustc-book](https://doc.rust-lang.org/rustc/index.html)
 
 - Unfortunately we don't observe significant performance gains from applying it (except for tiny synthetic test cases).
 

--- a/posts/inside-rust/2019-11-07-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-11-07-compiler-team-meeting.md
@@ -20,7 +20,7 @@ Rust 1.39 ships on Thursday!
 
 ### [wg-pgo](https://rust-lang.github.io/compiler-team/working-groups/pgo/)
 
-- PGO is available in the stable compiler. Docs are in the rustc-guide and the rustc-book
+- PGO is available in the stable compiler. Docs are in the rustc-dev-guide and the rustc-book
 
 - Unfortunately we don't observe significant performance gains from applying it (except for tiny synthetic test cases).
 

--- a/posts/inside-rust/2019-11-07-compiler-team-meeting.md
+++ b/posts/inside-rust/2019-11-07-compiler-team-meeting.md
@@ -20,7 +20,7 @@ Rust 1.39 ships on Thursday!
 
 ### [wg-pgo](https://rust-lang.github.io/compiler-team/working-groups/pgo/)
 
-- PGO is available in the stable compiler. Docs are in the [rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/) and the [rustc-book](https://doc.rust-lang.org/rustc/index.html)
+- PGO is available in the stable compiler. Docs are in the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/) and the [rustc-book](https://doc.rust-lang.org/rustc/index.html)
 
 - Unfortunately we don't observe significant performance gains from applying it (except for tiny synthetic test cases).
 

--- a/posts/inside-rust/2019-11-25-const-if-match.md
+++ b/posts/inside-rust/2019-11-25-const-if-match.md
@@ -112,7 +112,7 @@ such as whether they allow for interior mutability or whether they have a
 `Drop` implementation that needs to be called. For example, we must reject the
 following code since it would result in a `const` being mutable at runtime!
 
-[miri]: https://rust-lang.github.io/rustc-guide/miri.html
+[miri]: https://rust-lang.github.io/rustc-dev-guide/miri.html
 
 ```rust
 const CELL: &std::cell::Cell<i32> = &std::cell::Cell::new(42); // Not allowed...

--- a/posts/inside-rust/2019-11-25-const-if-match.md
+++ b/posts/inside-rust/2019-11-25-const-if-match.md
@@ -112,7 +112,7 @@ such as whether they allow for interior mutability or whether they have a
 `Drop` implementation that needs to be called. For example, we must reject the
 following code since it would result in a `const` being mutable at runtime!
 
-[miri]: https://rust-lang.github.io/rustc-dev-guide/miri.html
+[miri]: https://rustc-dev-guide.rust-lang.org/miri.html
 
 ```rust
 const CELL: &std::cell::Cell<i32> = &std::cell::Cell::new(42); // Not allowed...

--- a/posts/inside-rust/2019-12-20-wg-learning-update.md
+++ b/posts/inside-rust/2019-12-20-wg-learning-update.md
@@ -72,12 +72,12 @@ Feel free to stop by and ping us.
 
 
 [oct]: https://blog.rust-lang.org/inside-rust/2019/10/28/rustc-learning-working-group-introduction.html
-[rg]: https://rust-lang.github.io/rustc-dev-guide/
+[rg]: https://rustc-dev-guide.rust-lang.org/
 [salsa]: https://crates.io/crates/salsa
-[salsach]: https://rust-lang.github.io/rustc-dev-guide/salsa.html
+[salsach]: https://rustc-dev-guide.rust-lang.org/salsa.html
 [ra]: https://github.com/rust-analyzer/rust-analyzer
 [ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/type.Ty.html
 [typr]: https://github.com/rust-lang/rustc-dev-guide/pull/530
 [meeting]: https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-learning/topic/planning.20meeting
-[glos]: https://rust-lang.github.io/rustc-dev-guide/appendix/glossary.html
+[glos]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html
 [zulip]: https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-learning

--- a/posts/inside-rust/2019-12-20-wg-learning-update.md
+++ b/posts/inside-rust/2019-12-20-wg-learning-update.md
@@ -13,7 +13,7 @@ have also held a meeting to decide what to work on next. So let's dig in...
 
 ## Work completed
 
-We mentioned before that we are in the process of producing [rustc-guide][rg]
+We mentioned before that we are in the process of producing [rustc-dev-guide][rg]
 chapters from the "Compiler Lecture Series" videos. The goal is to try to
 produce guide chapters that are approachable for beginners and give a good
 foundation for exploring and hacking on the compiler.
@@ -40,7 +40,7 @@ Specifically, the Learning WG decided that we wanted to pursue the following goa
 ### Overview chapter
 
 One of the challenges with big software systems is understanding how everything
-fits together. We have seen this problem come up with the rustc-guide; the chapters
+fits together. We have seen this problem come up with the rustc-dev-guide; the chapters
 tunnel down into a single part of the compiler, but it is hard to get a good
 view of all the things that happen to a piece of code between lexing and linking.
 
@@ -72,12 +72,12 @@ Feel free to stop by and ping us.
 
 
 [oct]: https://blog.rust-lang.org/inside-rust/2019/10/28/rustc-learning-working-group-introduction.html
-[rg]: https://rust-lang.github.io/rustc-guide/
+[rg]: https://rust-lang.github.io/rustc-dev-guide/
 [salsa]: https://crates.io/crates/salsa
-[salsach]: https://rust-lang.github.io/rustc-guide/salsa.html
+[salsach]: https://rust-lang.github.io/rustc-dev-guide/salsa.html
 [ra]: https://github.com/rust-analyzer/rust-analyzer
 [ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/type.Ty.html
-[typr]: https://github.com/rust-lang/rustc-guide/pull/530
+[typr]: https://github.com/rust-lang/rustc-dev-guide/pull/530
 [meeting]: https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-learning/topic/planning.20meeting
-[glos]: https://rust-lang.github.io/rustc-guide/appendix/glossary.html
+[glos]: https://rust-lang.github.io/rustc-dev-guide/appendix/glossary.html
 [zulip]: https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-learning

--- a/posts/inside-rust/2020-02-06-Cleanup-Crew-ICE-breakers.md
+++ b/posts/inside-rust/2020-02-06-Cleanup-Crew-ICE-breakers.md
@@ -37,7 +37,7 @@ bug, we'll write a message that `@`-mentions every Github user on that
 team. If you have some time, maybe you can provide some useful
 information.
 
-[instructions here]: https://rust-lang.github.io/rustc-guide/ice-breaker/about.html#join
+[instructions here]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/about.html#join
 
-You can find more information about the group on it's [rustc-guide
-section](https://rust-lang.github.io/rustc-guide/ice-breaker/cleanup-crew.html).
+You can find more information about the group on it's [rustc-dev-guide
+section](https://rust-lang.github.io/rustc-dev-guide/ice-breaker/cleanup-crew.html).

--- a/posts/inside-rust/2020-02-06-Cleanup-Crew-ICE-breakers.md
+++ b/posts/inside-rust/2020-02-06-Cleanup-Crew-ICE-breakers.md
@@ -37,7 +37,7 @@ bug, we'll write a message that `@`-mentions every Github user on that
 team. If you have some time, maybe you can provide some useful
 information.
 
-[instructions here]: https://rust-lang.github.io/rustc-dev-guide/ice-breaker/about.html#join
+[instructions here]: https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html#join
 
 You can find more information about the group on it's [rustc-dev-guide
-section](https://rust-lang.github.io/rustc-dev-guide/ice-breaker/cleanup-crew.html).
+section](https://rustc-dev-guide.rust-lang.org/ice-breaker/cleanup-crew.html).

--- a/posts/inside-rust/2020-03-04-recent-future-pattern-matching-improvements.md
+++ b/posts/inside-rust/2020-03-04-recent-future-pattern-matching-improvements.md
@@ -135,7 +135,7 @@ An OR-pattern covers the *union* of all the `|`-ed ("or-ed") patterns. To ensure
 ## Bindings after `@`
 
 [#16053]: https://github.com/rust-lang/rust/pull/16053
-[MIR]: https://rust-lang.github.io/rustc-guide/mir/index.html
+[MIR]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
 [rip_ast_borrowck]: https://github.com/rust-lang/rust/pull/64790
 [tracking_at]: https://github.com/rust-lang/rust/issues/65490
 

--- a/posts/inside-rust/2020-03-04-recent-future-pattern-matching-improvements.md
+++ b/posts/inside-rust/2020-03-04-recent-future-pattern-matching-improvements.md
@@ -135,7 +135,7 @@ An OR-pattern covers the *union* of all the `|`-ed ("or-ed") patterns. To ensure
 ## Bindings after `@`
 
 [#16053]: https://github.com/rust-lang/rust/pull/16053
-[MIR]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
+[MIR]: https://rustc-dev-guide.rust-lang.org/mir/index.html
 [rip_ast_borrowck]: https://github.com/rust-lang/rust/pull/64790
 [tracking_at]: https://github.com/rust-lang/rust/issues/65490
 


### PR DESCRIPTION
The `rustc-guide` is being renamed to the `rustc-dev-guide`.  The discussion is in https://github.com/rust-lang/rustc-guide/issues/470. 

This PR revises `rustc-guide`, `rustc guide`, and `Rustc Guide` to the new names.

Transition tracker: https://github.com/rust-lang/rustc-guide/issues/602