### PR TITLE
Added explicit links to tagging syntax one uses to ping ICE breakers.

### DIFF
--- a/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
+++ b/posts/inside-rust/2019-10-22-LLVM-ICE-breakers.md
@@ -14,13 +14,18 @@ At its heart, the LLVM ICE-breaker group is just a list of people who would like
 
 [open a PR]: https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html#join
 
-There are a few other things associated with the group too, however. For example, we've got a [guide] that offers some tips for how to fix LLVM-related bugs and may help you get started (particularly if you're not that familiar with rustc).
+There are a few other things associated with the group too, however. For example, we've got a [guide][llvm guide] that offers some tips for how to fix LLVM-related bugs and may help you get started (particularly if you're not that familiar with rustc).
 
-[guide]: https://rustc-dev-guide.rust-lang.org/ice-breaker/llvm.html
+[llvm guide]: https://rustc-dev-guide.rust-lang.org/ice-breaker/llvm.html
 
 ### What kind of bugs are we talking about?
 
 The goal is to identify "self-contained" bugs that are unlikely to require large-scale compiler refactorings or to get entangled in other big projects.
+
+As Rust developers triage bugs and tag them for the ICE-breakers,
+they will [ping][tag syntax] the group on Github.
+
+[tag syntax]: https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html#tagging-an-issue-for-an-ice-breaker-group
 
 ### Who should join?
 
@@ -44,6 +49,11 @@ But of course we also hope that these ICE-breaker groups can help people to get 
 ### Will there be more ICE-breaker groups?
 
 I certainly hope so! As I mentioned before, this is an experiment, but presuming that it works out well we fully intend to create more ICE-breaker groups.
+
+The current list of ICE-breaker groups is documented in the
+[rustc development guide][rustc dev guide]
+
+[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html
 
 ### So how do I sign up again?
 

--- a/posts/inside-rust/2020-02-06-Cleanup-Crew-ICE-breakers.md
+++ b/posts/inside-rust/2020-02-06-Cleanup-Crew-ICE-breakers.md
@@ -33,11 +33,13 @@ This kind of cleanup is invaluable in getting bugs fixed.
 It can be done by anybody who knows Rust, without any particularly deep
 knowledge of the compiler.  If you want to be part of it and be notified
 about things to do, just [add yourself to the list][instructions here]! When we come across a suitable
-bug, we'll write a message that `@`-mentions every Github user on that
+bug, we'll [write a message][tag syntax] that `@`-mentions every Github user on that
 team. If you have some time, maybe you can provide some useful
 information.
 
 [instructions here]: https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html#join
+
+[tag syntax]: https://rustc-dev-guide.rust-lang.org/ice-breaker/about.html#tagging-an-issue-for-an-ice-breaker-group
 
 You can find more information about the group on it's [rustc-dev-guide
 section](https://rustc-dev-guide.rust-lang.org/ice-breaker/cleanup-crew.html).


### PR DESCRIPTION
Added some explicit links to tagging syntax one uses to ping the ICE breakers.

(Yes, the "#join" link *also* goes to the same page (but a different section). But as a reader, I am not going to realize that.)

As a drive-by, also added link to the complete list of ICE breakers that will be updated over time (at least, that is true today, and I suspect it will remain so in the future).