### PR TITLE
Add a link to 2019 Rust developer survey's Chinese translation

### DIFF
--- a/posts/2020-04-17-Rust-survey-2019.md
+++ b/posts/2020-04-17-Rust-survey-2019.md
@@ -4,6 +4,8 @@ title: "Rust Survey 2019 Results"
 author: The Rust Survey Team
 ---
 
+> Translation available for [Chinese | 中文](http://www.secondstate.info/blog/rust-2019)
+
 Greetings Rustaceans!
 
 We are happy to present the results of our fourth annual survey of our Rust community. Before we dig into the analysis, we want to give a big "thank you!" to all of the people who took the time to respond. You are vital to Rust continuing to improve year after year!


### PR DESCRIPTION
Hello,

Since Chinese is now the second most popular language among Rust developers, we translated the developer survey blog post into Chinese and inserted a link into the blog post.

If this is not the way to publicize translations, please let me know. I am just trying to help. :)

cheers
Michael Yuan