### PR TITLE
Fix 1.39's references to 1.36 NLL

### DIFF
--- a/posts/2019-11-07-Rust-1.39.0.md
+++ b/posts/2019-11-07-Rust-1.39.0.md
@@ -110,16 +110,16 @@ The attributes you can use in this position include:
 
 ### Borrow check migration warnings are hard errors in Rust 2018
 
-[rel-1350]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html#nll-for-rust-2015
+[rel-1360-nll]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html#nll-for-rust-2015
 [rel-1310]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html#non-lexical-lifetimes
 [err-2018]: https://github.com/rust-lang/rust/pull/63565
 [err-2015]: https://github.com/rust-lang/rust/pull/64221
 [rip-ast-borrowck]: https://github.com/rust-lang/rust/pull/64790
 [niko-blog-nll]: https://blog.rust-lang.org/2019/11/01/nll-hard-errors.html
 
-In the 1.35.0 release, [we announced][rel-1350] that NLL had come to Rust 2015 after first being released for Rust 2018 in [1.31][rel-1310].
+In the 1.36.0 release, [we announced][rel-1360-nll] that NLL had come to Rust 2015 after first being released for Rust 2018 in [1.31][rel-1310].
 
-As noted in the 1.35.0 release, the old borrow checker had some bugs which would allow memory unsafety. These bugs were fixed by the NLL borrow checker. As these fixes broke some stable code, we decided to gradually phase in the errors by checking if the old borrow checker would accept the program and the NLL checker would reject it. If so, the errors would instead become warnings.
+As noted in the 1.36.0 release, the old borrow checker had some bugs which would allow memory unsafety. These bugs were fixed by the NLL borrow checker. As these fixes broke some stable code, we decided to gradually phase in the errors by checking if the old borrow checker would accept the program and the NLL checker would reject it. If so, the errors would instead become warnings.
 
 With Rust 1.39.0, these warnings are now [errors in Rust 2018][err-2018].
 In the next release, Rust 1.40.0, [this will also apply to Rust 2015][err-2015], which will finally allow us to [remove the old borrow checker][rip-ast-borrowck], and keep the compiler clean.


### PR DESCRIPTION
The text said 1.35, though it correctly linked to 1.36's NLL changes.