### PR TITLE
Fix compliance with Atom specification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod blogs;
 mod posts;
 
+use chrono::Timelike;
 use crate::blogs::Blog;
 use crate::posts::Post;
 use handlebars::{handlebars_helper, Handlebars};

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ impl<'a> Generator<'a> {
         let data = json!({
             "blog": blog,
             "posts": posts,
-            "feed_updated": chrono::Utc::now().to_rfc3339(),
+            "feed_updated": chrono::Utc::now().with_nanosecond(0).unwrap().to_rfc3339(),
         });
 
         self.render_template(blog.prefix().join("feed.xml"), "feed", data)?;
@@ -185,7 +185,7 @@ impl<'a> Generator<'a> {
             .collect();
         let data = Releases {
             releases: releases,
-            feed_updated: chrono::Utc::now().to_rfc3339(),
+            feed_updated: chrono::Utc::now().with_nanosecond(0).unwrap().to_rfc3339(),
         };
         fs::write(
             self.out_directory.join(blog.prefix()).join("releases.json"),


### PR DESCRIPTION
With commit db0164fe8 the code that generates the `atom:updated` element has been changed from `time::now_utc().rfc3339().to_string()` to `chrono::Utc::now().to_rfc3339()`, but unfortunately the latter isn't a replacement of the first because it includes the nanoseconds in its output:

```
2009-02-13T15:31:30-08:00 (time)
2020-05-12T14:24:08.866226229+00:00 (chrono)
```

The [Atom specification](https://tools.ietf.org/html/rfc4287#section-4.2.15) defines the `updated` element of type `xsd:dateTime` which doesn't include the nanoseconds.

I discovered this by using [feed-io](https://feed-io.net/) to parse your Atom feed.