### PR TITLE
Updated 2020 Event lineup

### DIFF
--- a/posts/2020-06-02-event-lineup-update.md
+++ b/posts/2020-06-02-event-lineup-update.md
@@ -1,0 +1,110 @@
+---
+layout: post
+title: "2020 Event Lineup - Update"
+author: Rust Community
+description: "Join Rust events online"
+---
+
+In 2020 the way we can do events suddenly changed.
+In the past we had in-person events all around the world, with some major conferences throughout the year.
+With everything changed due to a global pandemic this won't be possible anymore.
+Nonetheless the Rust community found ways to continue with events in some form or another.
+With more and more events moving online they are getting more accessible to people no matter where they are.
+
+Below you find updated information about Rust events in 2020.
+
+Do you plan to run a Rust online event?
+Send an email to the [Rust Community team][community-team] and the team will be able to get your event on the calendar and might be able to offer further help.
+
+---
+
+**Rust LATAM**
+---
+
+Unfortunately the Latin American event [Rust LATAM][latam-site] had to be canceled this year.
+The team hopes to be able to resume the event in the future.
+
+[latam-site]: https://rustlatam.org/
+
+---
+
+**Oxidize**<br>July 17th-20th, 2020
+---
+
+The [Oxidize conference][oxidize-site] was relabeld to become Oxidize Global.
+From July 17-20 you will be able to learn about embedded systems and IoT in Rust.
+Over the course of 4 days you will be able to attend online workshops (July 17th), listen to talks (July 18th) and take part in the Impl Days, where you can collaborate with other Embedded Rust contributors in active programming sessions.
+
+Tickets are on sale and the [Call for Papers][oxidize-cfp] is still open until June 7th.
+
+[oxidize-site]: https://oxidizeconf.com/
+[oxidize-cfp]: https://cfp.oxidizeconf.com/events/oxidize-2020
+
+---
+
+**RustConf**<br>August 20th, 2020
+---
+
+The official [RustConf][conf-site] will be taking place fully online.
+Listen to talks and meet other Rust enthusiasts online in digital meetups & breakout rooms.
+See the [list of speakers][conf-speakers], register already and follow [Twitter][conf-twitter] for updates as the event date approaches!
+
+[conf-site]: https://rustconf.com/
+[conf-speakers]: https://rustconf.com/speakers
+[conf-twitter]: https://twitter.com/rustconf
+
+---
+
+**Rusty Days**<br>July 27th - August 2nd, 2020
+---
+
+[Rusty Days][days-site] is a new conference and was planned to happen in Wroclaw, Poland.
+It now turned into a virtual Rust conference stretched over five days.
+You'll be able to see five speakers with five talks -- and everything is free of charge, streamed online and available to watch later.
+
+The [Call for Papers][days-cfp] is open. Follow [Twitter][days-twitter] for updates.
+
+[days-site]: https://rusty-days.org/
+[days-cfp]: https://rusty-days.org/cfp
+[days-twitter]: https://twitter.com/rdconf
+
+---
+
+**RustLab**<br>October 16th-17th, 2020
+---
+
+[RustLab 2020][lab-site] is also turning into an online event.
+The details are not yet settled, but they are aiming for the original dates.
+Keep an eye on [their Twitter stream][lab-twitter] for further details.
+
+[lab-site]: https://www.rustlab.it
+[lab-twitter]: https://twitter.com/rustlab_conf
+
+---
+
+**RustFest Netherlands**<br>Q4, 2020
+---
+
+[RustFest Netherlands][nether-site] was supposed to happen this June.
+The team decided to postpone the event and is now happening as an online conference in Q4 of this year.
+More information will be available soon on the [RustFest blog][nether-blog] and also on [Twitter][nether-twitter].
+
+[nether-site]: https://netherlands.rustfest.eu/
+[nether-blog]: https://blog.rustfest.eu/
+[nether-twitter]: https://twitter.com/rustfest
+
+---
+
+Conferences are not the only thing happening.
+More and more local meetups get turned into online events.
+We try to highlight these in the [community calendar][calendar] as well as in the [This Week in Rust newsletter][twir].
+Some Rust developers are streaming their work on the language & their Rust projects.
+You can get more information in a [curated list of Rust streams][rust-streaming].
+
+Do you plan to run a Rust online event?
+Send an email to the [Rust Community team][community-team] and the team will be able to get your event on the calendar and might be able to offer further help.
+
+[twir]: https://this-week-in-rust.org/
+[rust-streaming]: https://github.com/jamesmunns/awesome-rust-streaming
+[community-team]: mailto:community@rust-lang.org
+[calendar]: https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com


### PR DESCRIPTION
[As discussed in the community team](https://github.com/rust-community/team/issues/281) this is an update to the Event lineup and a call for online meetups to contact the team.

cc @rust-lang/community @rust-lang/community-events 

currently set to be posted tomorrow (2020-06-02), but I can adjust (though it does call out one still-open CfP, closing June 7th, so I wouldn't want to delay it too much)