### PR TITLE
inline-asm: Update for new style

### DIFF
--- a/posts/inside-rust/2020-06-08-new-inline-asm.md
+++ b/posts/inside-rust/2020-06-08-new-inline-asm.md
@@ -95,14 +95,14 @@ fn main() {
         let popcnt;
         unsafe {
             asm!(
-                "    popcnt {popcnt}, {v}",
+                "popcnt {popcnt}, {v}",
                 "2:",
-                "    blsi rax, {v}",
-                "    jz 1f",
-                "    xor {v}, rax",
-                "    tzcnt rax, rax",
-                "    stosb",
-                "    jmp 2b",
+                "blsi rax, {v}",
+                "jz 1f",
+                "xor {v}, rax",
+                "tzcnt rax, rax",
+                "stosb",
+                "jmp 2b",
                 "1:",
                 v = inout(reg) value => _,
                 popcnt = out(reg) popcnt,

--- a/posts/inside-rust/2020-06-08-new-inline-asm.md
+++ b/posts/inside-rust/2020-06-08-new-inline-asm.md
@@ -116,7 +116,7 @@ fn main() {
 ```
 
 (You can [try this example on the
-playground](https://play.rust-lang.org/?version=nightly&mode=release&edition=2018&gist=38874735e48aa20289f23f5a3cbeae0c).
+playground](https://play.rust-lang.org/?version=nightly&mode=release&edition=2018&gist=894a407f0fe858559aa378edf6ec4801).
 Note that this code serves to demonstrate inline assembly, not to demonstrate
 an efficient implementation of any particular algorithm.)
 

--- a/posts/inside-rust/2020-06-08-new-inline-asm.md
+++ b/posts/inside-rust/2020-06-08-new-inline-asm.md
@@ -94,17 +94,16 @@ fn main() {
     for value in 0..=1024u64 {
         let popcnt;
         unsafe {
-            asm!("
-                popcnt {popcnt}, {v}
-                2:
-                blsi rax, {v}
-                jz 1f
-                xor {v}, rax
-                tzcnt rax, rax
-                stosb
-                jmp 2b
-                1:
-                ",
+            asm!(
+                "    popcnt {popcnt}, {v}",
+                "2:",
+                "    blsi rax, {v}",
+                "    jz 1f",
+                "    xor {v}, rax",
+                "    tzcnt rax, rax",
+                "    stosb",
+                "    jmp 2b",
+                "1:",
                 v = inout(reg) value => _,
                 popcnt = out(reg) popcnt,
                 out("rax") _, // scratch


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/73364 implemented support for
providing multiple lines of assembly as separate arguments to `asm!`;
update the blog post to use that new syntax, so that people who find it
will use that style as an example.