### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @website
-posts/* @website @nikomatsakis
+* @rust-lang/website
+posts/* @rust-lang/website @nikomatsakis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @website
+posts/* @website @nikomatsakis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @rust-lang/website
-posts/* @rust-lang/website @nikomatsakis
+posts/* @rust-lang/website @rust-lang/core


### PR DESCRIPTION
This creates a `CODEOWNERS` file to replace highfive for assigning reviewers for the blog as currently highfive just always assigns to @nikomatsakis  which seems a bit unfair.