### PR TITLE
posts: Rustup 1.22.1 release

### DIFF
--- a/posts/2020-07-08-Rustup-1.22.1.md
+++ b/posts/2020-07-08-Rustup-1.22.1.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title: "Announcing Rustup 1.22.1"
+author: The Rustup Working Group
+---
+
+The rustup working group is happy to announce the release of rustup version 1.22.1. [Rustup][install] is the recommended tool to install [Rust][rust], a programming language that is empowering everyone to build reliable and efficient software.
+
+If you have a previous version of rustup installed, getting rustup 1.22.0 may be as easy as closing your IDE and running:
+
+```
+rustup self update
+```
+
+Rustup will also automatically update itself at the end of a normal toolchain update:
+
+```
+rustup update
+```
+
+If you don't have it already, or if the 1.22.0 release of rustup caused you to experience the problem that 1.22.1 fixes, you can [get rustup][install] from the appropriate page on our website.
+
+[rust]: https://www.rust-lang.org
+[install]: https://rustup.rs
+
+## What's new in rustup 1.22.1
+
+When updating dependency crates for 1.22.0, a change in behaviour of the `url` crate slipped in which caused `env_proxy` to cease to work with proxy data set in the environment.  This is unfortunate since those of you who use `rustup` behind a proxy and have updated to 1.22.0 will now find that rustup may not work properly for you.
+
+If you are affected by this, simply [re-download the installer][install] and run it.  It will update your existing installation of Rust with no need to uninstall first.
+
+## Thanks
+
+Thanks to Ivan Nejgebauer who spotted the issue, provided the fix, and made rustup 1.22.1 possible,
+and to Ben Chen who provided a fix for our website.
+


### PR DESCRIPTION
This is an embarassing `.1` release as they all are.

I've pushed the `stable` build for `rustup` and asked @pietroalbini on Zulip about when we might be able to make the release, so this text needs vetting and checking, but I imagine Pietro will handle merging when we've made the release.