### PR TITLE
Add post on opening up the Core Team agenda

### DIFF
--- a/posts/inside-rust/2020-07-24-opening-up-the-core-team-agenda.md
+++ b/posts/inside-rust/2020-07-24-opening-up-the-core-team-agenda.md
@@ -5,7 +5,7 @@ author: Pietro Albini
 team: the Core Team <https://www.rust-lang.org/governance/teams/core>
 ---
 
-The Core Team tends to project-wide policy questions on all sorts of matters,
+The Core Team works on project-wide policy questions on all sorts of matters,
 as well as generally monitoring the overall health of the project. While some
 of the discussed topics are sensitive (related to personal issues, finances, or
 security) and can’t be shared outside the Core Team, a lot of them are not.

--- a/posts/inside-rust/2020-07-24-opening-up-the-core-team-agenda.md
+++ b/posts/inside-rust/2020-07-24-opening-up-the-core-team-agenda.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: "Opening up the Core Team agenda"
+author: Pietro Albini
+team: the Core Team <https://www.rust-lang.org/governance/teams/core>
+---
+
+The Core Team tends to project-wide policy questions on all sorts of matters,
+as well as generally monitoring the overall health of the project. While some
+of the discussed topics are sensitive (related to personal issues, finances, or
+security) and can’t be shared outside the Core Team, a lot of them are not.
+
+Much of the activity of the Core Team happens during weekly “triage” calls,
+where we discuss and make decisions on the items brought to our attention. Last
+year, we started opening up those calls by recording the parts where
+non-sensitive topics are discussed and uploading the videos [on our YouTube
+channel][yt]. While the videos provide the full context and nuance of the
+discussion, they take a good amount of time to watch, and referring to parts of
+the discussion is not always practical.
+
+Continuing with the effort of opening up our meetings, we’re happy to announce
+that the public agenda of those calls is now recorded in [issues inside the
+rust-lang/core-team][issues] repository! Each discussed topic will have its own issue,
+and we will provide updates each week with a summary of what we discussed
+during the call.
+
+We hope this setup will allow people to easily follow what’s on the Core Team’s
+plate by subscribing to either all the activity in the repository or just to
+the issues you care about. We will still continue to publish recordings of the
+calls for the people who care to listen to the whole discussion.
+
+We’ve decided at this time to limit permissions to post on the issues to the
+Core Team only, and possibly invited collaborators as relevant to particular
+topics. If you have an item you’d like us to discuss or if you have thoughts on
+an existing topic, please email [core-team@rust-lang.org].
+
+[yt]: https://www.youtube.com/playlist?list=PL85XCvVPmGQjmo8ivhTMipwQRFl4ZW2cZ
+[issues]: https://github.com/rust-lang/core-team/issues
+[core-team@rust-lang.org]: mailto:core-team@rust-lang.org


### PR DESCRIPTION
This should be posted tomorrow.

r? @rust-lang/core?