### PR TITLE
Create 2020-07-31-upcoming-compiler-design-meeting.md

### DIFF
--- a/posts/inside-rust/2020-07-31-upcoming-compiler-design-meeting.md
+++ b/posts/inside-rust/2020-07-31-upcoming-compiler-design-meeting.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "Planning meeting update"
+author: pnkfelix
+description: "Planning meeting update"
+team: the compiler team <https://www.rust-lang.org/governance/teams/compiler>
+---
+
+In our [planning meeting today], the compiler team has scheduled our
+next batch of upcoming design meetings:
+
+* On August, 14 ([calendar event][ce1]), we will discuss the results of the 2020 Contributor Survey. See [rust-lang/compiler-team#XXX] for more details.
+
+[planning meeting today]: https://zulip-archive.rust-lang.org/238009tcompilermeetings/09644planningmeeting20200731.html
+[ce1]: https://calendar.google.com/event?action=TEMPLATE&tmeid=Mzh2ZWlmNjlnbnBtM212OTI0dXN2aWNodG8gNnU1cnJ0Y2U2bHJ0djA3cGZpM2RhbWdqdXNAZw&tmsrc=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com
+[rust-lang/compiler-team#318]: https://github.com/rust-lang/compiler-team/issues/318
+
+### Did you know?
+
+Most weeks, the compiler team has some sort of design meeting. These
+meetings take place on Zulip and are open to all. Every 4 weeks, we do
+a planning meeting to pick the next few meetings from the list of open
+proposals. You can find [more details about how the compiler-team
+steering meeting process here][details].
+
+[details]: https://rust-lang.github.io/compiler-team/about/steering-meeting/
+[meeting calendar]: https://rust-lang.github.io/compiler-team/#meeting-calendar
+[compiler team]: https://www.rust-lang.org/governance/teams/compiler

--- a/posts/inside-rust/2020-07-31-upcoming-compiler-design-meeting.md
+++ b/posts/inside-rust/2020-07-31-upcoming-compiler-design-meeting.md
@@ -9,7 +9,7 @@ team: the compiler team <https://www.rust-lang.org/governance/teams/compiler>
 In our [planning meeting today], the compiler team has scheduled our
 next batch of upcoming design meetings:
 
-* On August, 14 ([calendar event][ce1]), we will discuss the results of the 2020 Contributor Survey. See [rust-lang/compiler-team#XXX] for more details.
+* On August, 14 ([calendar event][ce1]), we will discuss the results of the 2020 Contributor Survey. See [rust-lang/compiler-team#318] for more details.
 
 [planning meeting today]: https://zulip-archive.rust-lang.org/238009tcompilermeetings/09644planningmeeting20200731.html
 [ce1]: https://calendar.google.com/event?action=TEMPLATE&tmeid=Mzh2ZWlmNjlnbnBtM212OTI0dXN2aWNodG8gNnU1cnJ0Y2U2bHJ0djA3cGZpM2RhbWdqdXNAZw&tmsrc=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com


### PR DESCRIPTION
Followed structure suggested by https://forge.rust-lang.org/compiler/steering-meeting/how-to-run-planning.html#publish-a-blog-post ; got file name format by looking at past posts.