### PR TITLE
Make code ownership more fine grained

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-* @rust-lang/website
-posts/* @rust-lang/core
-posts/inside-rust/* @rust-lang/website @rust-lang/core
+src/* @rust-lang/website
+static/* @rust-lang/website
+templates/* @rust-lang/website
+posts/*.md @rust-lang/core


### PR DESCRIPTION
Trying to reduce the amount of notifications I and core team members get.

 - Core only needs to own the toplevel posts. Inside-rust posts can and should be reviewed by the relevant team, and they can ask someone on core to merge.
 - The website team probably should not own post contents, those are reviewed by core or the relevant team.
