### PR TITLE
Add 1.46.0 pre-release post

### DIFF
--- a/posts/inside-rust/2020-08-24-1.46.0-prerelease.md
+++ b/posts/inside-rust/2020-08-24-1.46.0-prerelease.md
@@ -14,6 +14,8 @@ You can try it out locally by running:
 RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup update stable
 ```
 
-The index is <https://dev-static.rust-lang.org/dist/2020-08-24/index.html>.
+The index is <https://dev-static.rust-lang.org/dist/2020-08-24/index.html>. You
+can leave feedback on the [internals thread][internals].
 
 [relnotes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1460-2020-08-27
+[internals]: https://internals.rust-lang.org/t/rust-1-46-0-pre-release-testing/12957

--- a/posts/inside-rust/2020-08-24-1.46.0-prerelease.md
+++ b/posts/inside-rust/2020-08-24-1.46.0-prerelease.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: "1.46.0 pre-release testing"
+author: Pietro Albini
+team: The Release Team <https://www.rust-lang.org/governance/teams/operations#release>
+---
+
+The 1.46.0 pre-release is ready for testing. The release is scheduled for this
+Thursday, August 27th. [Release notes can be found here.][relnotes]
+
+You can try it out locally by running:
+
+```plain
+RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup update stable
+```
+
+The index is <https://dev-static.rust-lang.org/dist/2020-08-24/index.html>.
+
+[relnotes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1460-2020-08-27


### PR DESCRIPTION
The pre-release is not yet out, but I expect it to be available in less than 30 minutes (looking at the current logs on RCS). Once it's out we can publish this.

r? @Mark-Simulacrum 