### PR TITLE
Use the `disc` list style type

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -194,6 +194,10 @@ ul, ol {
   padding-left: 1.2em;
 }
 
+ul {
+  list-style-type: disc;
+}
+
 .posts {
   background-color: $gray;
   color: white;


### PR DESCRIPTION
Previously, it was the `circle` list style type, but it was determined
that the `disc` list style type is in many ways a better match for Rust.

See rust-lang/www.rust-lang.org#1252 and rust-lang/www.rust-lang.org#1254.