### PR TITLE
Tiny clarification about blog post template headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ Code of Conduct, see `CODE_OF_CONDUCT.md` for more.
 Please send pull requests to the master branch. If you're trying to do
 something big, please open an issue before working on it, so we can make sure
 that it's something that will eventually be accepted.
+
+When writing a new blog post, keep in mind the file headers:
+```
+---
+layout: post
+title: Title of the blog post
+author: Blog post author (or on behalf of which team)
+release: true (to be only used for official posts about Rust releases announcements)
+---
+```


### PR DESCRIPTION
Follow-up to [comment](https://github.com/rust-lang/blog.rust-lang.org/pull/686#issuecomment-692347644).

I had by mistake tagged a blog post with `release: true`, thought it refers to a publishing flag :)

Clearly I'm at fault but maybe a tiny little of clarification can save the next new contributor?

@pietroalbini how does it look? Sorry for pinging for such a tiny thing :)

thanks!