### PR TITLE
Fix URL for internals thread on 1.47.0 post

### DIFF
--- a/posts/inside-rust/2020-10-06-1.47.0-prerelease.md
+++ b/posts/inside-rust/2020-10-06-1.47.0-prerelease.md
@@ -23,4 +23,4 @@ from the community in figuring out a resolution to that bug.
 
 [#76980]: https://github.com/rust-lang/rust/issues/76980
 [relnotes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1470-2020-10-08
-[internals]: https://internals.rust-lang.org/t/rust-1-47-0-pre-release-testing/
+[internals]: https://internals.rust-lang.org/t/1-47-0-pre-release-testing/


### PR DESCRIPTION
The current link 404s, this fixes the post so the URL points to the actual forum thread.