### PR TITLE
Add post for second 1.47.0 pre-release

### DIFF
--- a/posts/inside-rust/2020-10-07-1.47.0-prerelease-2.md
+++ b/posts/inside-rust/2020-10-07-1.47.0-prerelease-2.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: "1.47.0 second pre-release testing"
+author: Pietro Albini
+team: The Release Team <https://www.rust-lang.org/governance/teams/operations#release>
+---
+
+The second pre-release for 1.47.0 is ready for testing. The release is
+scheduled for this Thursday, October 8th. [Release notes can be found
+here.][relnotes]
+
+You can try it out locally by running:
+
+```plain
+RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup update stable
+```
+
+The index is <https://dev-static.rust-lang.org/dist/2020-10-07/index.html>. You
+can leave feedback on the [internals thread][internals].
+
+Compared to the first pre-release, this one contains a fix for issue [#76980],
+the last known regression of 1.47.0. We're interested in additional testing of
+this pre-release, as it includes that last-minute change.
+
+[#76980]: https://github.com/rust-lang/rust/issues/76980
+[relnotes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1470-2020-10-08
+[internals]: https://internals.rust-lang.org/t/1-47-0-pre-release-testing/


### PR DESCRIPTION
This adds another Inside Rust post to announce the second pre-release.