### PR TITLE
Fixed broken link to nightly rustdoc

### DIFF
--- a/posts/inside-rust/2020-09-17-stabilizing-intra-doc-links.md
+++ b/posts/inside-rust/2020-09-17-stabilizing-intra-doc-links.md
@@ -173,7 +173,7 @@ In particular, there have been a ton of people who stepped up to help [convert t
 
 [`javadoc`]: https://www.oracle.com/java/technologies/javase/javadoc-tool.html
 [`rustdoc`]: https://doc.rust-lang.org/rustdoc/
-[Intra-doc links]: https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#linking-to-items-by-name
+[Intra-doc links]: https://doc.rust-lang.org/nightly/rustdoc/linking-to-items-by-name.html
 [items]: https://doc.rust-lang.org/reference/items.html
 [broken-string-links]: https://github.com/rust-lang/rust/issues/32129
 [tracking-issue]: https://github.com/rust-lang/rust/issues/43466


### PR DESCRIPTION
In the blog post titled [Intra-doc links close to stabilization](https://blog.rust-lang.org/inside-rust/2020/09/17/stabilizing-intra-doc-links.html), the link to `intra-doc links` documentation from `rustdoc` nightly book is broken. The blog post points to https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#linking-to-items-by-name when it's present in https://doc.rust-lang.org/nightly/rustdoc/linking-to-items-by-name.html

This PR fixes it.