### PR TITLE
Cache the target directory based on the compiler version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache cargo
+
+      - name: Detect the installed Rust version
+        id: rustc
+        run: echo "::set-output name=version::$(rustc -V)"
+
+      - name: Cache Cargo's registry cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/registry/cache
+          key: cargo-registry-cache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-cache-
+
+      - name: Cache Cargo's registry index
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/registry/index
+          key: cargo-registry-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-index-
+
+      - name: Cache Cargo's target directory
         uses: actions/cache@v2
         with:
           path: target
-          key: cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-build-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            cargo-build-
+            cargo-build-${{ steps.rustc.outputs.version }}-
+
       - run: cargo run
       - run: cp CNAME ./site/
       - run: touch site/.nojekyll


### PR DESCRIPTION
While Travis CI dynamically updated the caches after builds finished (with a different cache for each branch), GitHub Actions identifies each cache with a key and never updates a cache with the same key, even if the contents of the cached directory changed.

Before this PR, we cached the target directory based on the hash of the `Cargo.lock` file, which means the cache was never updated as long as the `Cargo.lock` didn't change. Unfortunately this was not enough, as the existing target directory is useless after a Rust version update. We also did not cache the crates.io index nor the downloaded dependencies.

This PR changes the CI configuration to also include the Rust version in the cache key. This also adds caching for the crates.io index and the downloaded crates. This should speed up CI from 2.5 minutes to 30 seconds.