### PR TITLE
Use the right versions in the 1.49.0 blog post

### DIFF
--- a/posts/2020-12-31-Rust-1.49.0.md
+++ b/posts/2020-12-31-Rust-1.49.0.md
@@ -93,7 +93,7 @@ fn thready_pass() {
 Here's what running this test looks like before Rust 1.49.0:
 
 ```text
-❯ cargo test
+❯ cargo +1.48.0 test
    Compiling threadtest v0.1.0 (C:\threadtest)
     Finished test [unoptimized + debuginfo] target(s) in 0.38s
      Running target\debug\deps\threadtest-02f42ffd9836cae5.exe
@@ -118,7 +118,7 @@ if every `println!` worked like that one that prints "`fum`?" Well, [that's
 the behavior in Rust 1.49.0](https://github.com/rust-lang/rust/pull/78227):
 
 ```text
-❯ cargo +nightly test
+❯ cargo test
    Compiling threadtest v0.1.0 (C:\threadtest)
     Finished test [unoptimized + debuginfo] target(s) in 0.52s
      Running target\debug\deps\threadtest-40aabfaa345584be.exe
@@ -140,7 +140,7 @@ output. By adding a `panic!` to the end of the test, we can see what failure
 looks like:
 
 ```text
-❯ cargo +nightly test
+❯ cargo test
    Compiling threadtest v0.1.0 (C:\threadtest)
     Finished test [unoptimized + debuginfo] target(s) in 0.52s
      Running target\debug\deps\threadtest-40aabfaa345584be.exe


### PR DESCRIPTION
Noticed this while re-reading the post.

r? @Mark-Simulacrum 