### PR TITLE
Remove superfluous 'on behalf of...'

### DIFF
--- a/posts/inside-rust/2021-01-26-ffi-unwind-longjmp.md
+++ b/posts/inside-rust/2021-01-26-ffi-unwind-longjmp.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Rust & the case of the disappearing stack frames"
-author: Kyle Strand on behalf of the FFI-unwind project group
+author: Kyle Strand
 description: "introducing an exploration of how `longjmp` and similar functions can be handled in Rust"
 team: the FFI-unwind project group <https://www.rust-lang.org/governance/teams/lang#wg-ffi-unwind>
 ---


### PR DESCRIPTION
Removes redundant team information accidentally introduced in #743.

![image](https://user-images.githubusercontent.com/2313807/105872217-03a51c80-5faf-11eb-944b-9359807d2d36.png)
