### PR TITLE
Style: Add left margin for columns on all screen sizes

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -163,6 +163,11 @@ ul.nav, ul.nav li {
   margin-bottom: 0;
 }
 
+// TODO:  remove when switching to Tachyons -- these are overrides for Skeleton.
+.column, .columns {
+  margin-left: 4%;
+}
+
 .nav a {
   color: var(--gray);
   color: var(--nav-links-a);


### PR DESCRIPTION
Previously, `.column` and `.columns` only had a `margin-left` of `4%` when the viewport satisfied `min-width:550px`. On mobile, this led to the columns in the footer abutting each other with no space in between (see "Before" screenshot, in particular the "Contact the Rust Team" and "Licenses" lines). This change gives `.column` and `.columns` a left margin of `4%` at all screen widths, giving the columns a bit of breathing room. Before and after screenshots are given below, as rendered by Firefox's Responsive Design Mode using the Pixel 2 template.

Before:
![before](https://user-images.githubusercontent.com/304273/109382261-6b4fcf80-78ad-11eb-88c8-7af2a2bfa563.png)

After:
![after](https://user-images.githubusercontent.com/304273/109382260-6ab73900-78ad-11eb-8c07-89f9a9a693bc.png)

