### PR TITLE
Fix link to point to strip_suffix

### DIFF
--- a/posts/2021-03-25-Rust-1.51.0.md
+++ b/posts/2021-03-25-Rust-1.51.0.md
@@ -181,7 +181,7 @@ The following methods were stabilised.
 [`sync::OnceState`]: https://doc.rust-lang.org/stable/std/sync/struct.OnceState.html
 [`panic::panic_any`]: https://doc.rust-lang.org/stable/std/panic/fn.panic_any.html
 [`slice::strip_prefix`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.strip_prefix
-[`slice::strip_suffix`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.strip_prefix
+[`slice::strip_suffix`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.strip_suffix
 [`Arc::increment_strong_count`]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#method.increment_strong_count
 [`Arc::decrement_strong_count`]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#method.decrement_strong_count
 [`slice::fill_with`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.fill_with


### PR DESCRIPTION
[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/f4e7d11e681c3ef74c67fc8c2c466332fe5d8a66/posts/2021-03-25-Rust-1.51.0.md#stabilized-apis)