### PR TITLE
Link "MVP" in "Announcing Rust 1.51.0"

### DIFF
--- a/posts/2021-03-25-Rust-1.51.0.md
+++ b/posts/2021-03-25-Rust-1.51.0.md
@@ -24,7 +24,9 @@ from the appropriate page on our website, and check out the
 [notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25
 
 ## What's in 1.51.0 stable
-This release represents one of the largest additions to the Rust language and Cargo in quite a while, stabilizing an MVP of const generics and a new feature resolver for Cargo. Let's dive right into it!
+This release represents one of the largest additions to the Rust language and Cargo in quite a while, stabilizing an [MVP] of const generics and a new feature resolver for Cargo. Let's dive right into it!
+
+[MVP]: https://en.wikipedia.org/wiki/Minimum_viable_product
 
 
 ### Const Generics MVP


### PR DESCRIPTION
I hope that's the right place to put the link's definition.