### PR TITLE
Add initial 1.52.0 post

### DIFF
--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -1,0 +1,89 @@
+---
+layout: post
+title: "Announcing Rust 1.52.0"
+author: The Rust Release Team
+release: true
+---
+
+The Rust team is happy to announce a new version of Rust, 1.52.0. Rust is a
+programming language that is empowering everyone to build reliable and
+efficient software.
+
+If you have a previous version of Rust installed via rustup, getting Rust
+1.52.0 is as easy as:
+
+```console
+rustup update stable
+```
+
+If you don't have it already, you can [get `rustup`][install]
+from the appropriate page on our website, and check out the
+[detailed release notes for 1.52.0][notes] on GitHub.
+
+[install]: https://www.rust-lang.org/install.html
+[notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25
+
+## What's in 1.52.0 stable
+
+This release is fairly small, primarily containing stabilizations of various APIs in the standard library.
+
+This release also closes out a long-standing bug in the Rust compiler: forward progress is no longer assumed by LLVM, which means that some programs which used to compile incorrectly are now properly handled. This is due to changes in LLVM IR semantics, which no longer assume forward progress is guaranteed and optimize for that.
+
+### Stabilized APIs
+
+The following methods were stabilized.
+
+- [`Arguments::as_str`]
+- [`Peekable::next_if_eq`]
+- [`Peekable::next_if`]
+- [`char::MAX`]
+- [`char::REPLACEMENT_CHARACTER`]
+- [`char::UNICODE_VERSION`]
+- [`char::decode_utf16`]
+- [`char::from_digit`]
+- [`char::from_u32_unchecked`]
+- [`char::from_u32`]
+- [`slice::partition_point`]
+- [`str::rsplit_once`]
+- [`str::split_once`]
+
+The following previously stable APIs are now `const`.
+
+- [`char::len_utf8`]
+- [`char::len_utf16`]
+- [`char::to_ascii_uppercase`]
+- [`char::to_ascii_lowercase`]
+- [`char::eq_ignore_ascii_case`]
+- [`u8::to_ascii_uppercase`]
+- [`u8::to_ascii_lowercase`]
+- [`u8::eq_ignore_ascii_case`]
+
+[`char::MAX`]: https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.MAX
+[`char::REPLACEMENT_CHARACTER`]: https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.REPLACEMENT_CHARACTER
+[`char::UNICODE_VERSION`]: https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.UNICODE_VERSION
+[`char::decode_utf16`]: https://doc.rust-lang.org/std/primitive.char.html#method.decode_utf16
+[`char::from_u32`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_u32
+[`char::from_u32_unchecked`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_u32_unchecked
+[`char::from_digit`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_digit
+[`Peekable::next_if`]: https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html#method.next_if
+[`Peekable::next_if_eq`]: https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html#method.next_if_eq
+[`Arguments::as_str`]: https://doc.rust-lang.org/stable/std/fmt/struct.Arguments.html#method.as_str
+[`str::split_once`]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.split_once
+[`str::rsplit_once`]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.rsplit_once
+[`slice::partition_point`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.partition_point
+[`char::len_utf8`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.len_utf8
+[`char::len_utf16`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.len_utf16
+[`char::to_ascii_uppercase`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.to_ascii_uppercase
+[`char::to_ascii_lowercase`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.to_ascii_lowercase
+[`char::eq_ignore_ascii_case`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.eq_ignore_ascii_case
+[`u8::to_ascii_uppercase`]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.to_ascii_uppercase
+[`u8::to_ascii_lowercase`]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.to_ascii_lowercase
+[`u8::eq_ignore_ascii_case`]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.eq_ignore_ascii_case
+
+### Other changes
+
+There are other changes in the Rust 1.52.0 release: check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1520-2021-05-06), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-152-2021-05-06), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-152).
+
+### Contributors to 1.52.0
+
+Many people came together to create Rust 1.52.0. We couldn't have done it without all of you. [Thanks!](https://thanks.rust-lang.org/rust/1.52.0/)

--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -27,11 +27,15 @@ from the appropriate page on our website, and check out the
 
 This release is fairly small, primarily containing stabilizations of various APIs in the standard library.
 
-This release also closes out a long-standing [bug] in the Rust compiler. Previously, LLVM assumed that the program would make progress, and used this to optimize. This meant that certain constructs in safe Rust were removed or otherwise miscompiled, such as infinite loops (`loop {}`) or recursion which didn't terminate.
+We have also closed out a long-standing [bug] in the Rust compiler. Previously, LLVM assumed that the program would make progress, and used this to optimize. This meant that certain constructs in safe Rust were removed or otherwise miscompiled, such as infinite loops (`loop {}`) or recursion which didn't terminate.
 
 In Rust 1.49.0, we landed a [partial fix] to this bug specifically targeting
 `loop {}`, but this fix brings an LLVM upgrade which avoids needing workarounds
 for these cases, fixing the larger class of bug.
+
+Clippy has also gained a significant usability improvement: it no longer shares
+its build cache with `cargo check`, which means that errors and warnings will be
+properly reported when running it after `cargo check`.
 
 [bug]: https://github.com/rust-lang/rust/issues/28728
 [partial fix]: https://github.com/rust-lang/rust/pull/77972

--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -25,20 +25,13 @@ from the appropriate page on our website, and check out the
 
 ## What's in 1.52.0 stable
 
-This release is fairly small, primarily containing stabilizations of various APIs in the standard library.
+The most significant change in this release is not to the language or standard
+libraries, but rather an enhancement to tooling support for Clippy.
 
-We have also closed out a long-standing [bug] in the Rust compiler. Previously, LLVM assumed that the program would make progress, and used this to optimize. This meant that certain constructs in safe Rust were removed or otherwise miscompiled, such as infinite loops (`loop {}`) or recursion which didn't terminate.
-
-In Rust 1.49.0, we landed a [partial fix] to this bug specifically targeting
-`loop {}`, but this fix brings an LLVM upgrade which avoids needing workarounds
-for these cases, fixing the larger class of bug.
-
-Clippy has also gained a significant usability improvement: it no longer shares
-its build cache with `cargo check`, which means that errors and warnings will be
-properly reported when running it after `cargo check`.
-
-[bug]: https://github.com/rust-lang/rust/issues/28728
-[partial fix]: https://github.com/rust-lang/rust/pull/77972
+Previously, running `cargo check` followed by `cargo clippy` wouldn't actually
+run clippy: the build caching in Cargo didn't differentiate between the two. In
+1.52, however, this has been fixed, which means that users will get the expected
+behavior independent of the order in which they run the two commands.
 
 ### Stabilized APIs
 

--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -29,7 +29,7 @@ The most significant change in this release is not to the language or standard
 libraries, but rather an enhancement to tooling support for Clippy.
 
 Previously, running `cargo check` followed by `cargo clippy` wouldn't actually
-run clippy: the build caching in Cargo didn't differentiate between the two. In
+run Clippy: the build caching in Cargo didn't differentiate between the two. In
 1.52, however, this has been fixed, which means that users will get the expected
 behavior independent of the order in which they run the two commands.
 

--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -27,7 +27,14 @@ from the appropriate page on our website, and check out the
 
 This release is fairly small, primarily containing stabilizations of various APIs in the standard library.
 
-This release also closes out a long-standing bug in the Rust compiler: forward progress is no longer assumed by LLVM, which means that some programs which used to compile incorrectly are now properly handled. This is due to changes in LLVM IR semantics, which no longer assume forward progress is guaranteed and optimize for that.
+This release also closes out a long-standing [bug] in the Rust compiler. Previously, LLVM assumed that the program would make progress, and used this to optimize. This meant that certain constructs in safe Rust were removed or otherwise miscompiled, such as infinite loops (`loop {}`) or recursion which didn't terminate.
+
+In Rust 1.49.0, we landed a [partial fix] to this bug specifically targeting
+`loop {}`, but this fix brings an LLVM upgrade which avoids needing workarounds
+for these cases, fixing the larger class of bug.
+
+[bug]: https://github.com/rust-lang/rust/issues/28728
+[partial fix]: https://github.com/rust-lang/rust/pull/77972
 
 ### Stabilized APIs
 


### PR DESCRIPTION
This cycle didn't have a lot of notable stabilizations or changes in the language or standard library so I ended up keeping things pretty concise. If someone has particular things they'd like to highlight that seems positive - though I'd rather not devote too much time to something minor - we can definitely iterate further.

r? @rust-lang/release 
cc @rust-lang/core 