### PR TITLE
1.52.0 blog post fixes

### DIFF
--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -38,8 +38,6 @@ behavior independent of the order in which they run the two commands.
 The following methods were stabilized.
 
 - [`Arguments::as_str`]
-- [`Peekable::next_if_eq`]
-- [`Peekable::next_if`]
 - [`char::MAX`]
 - [`char::REPLACEMENT_CHARACTER`]
 - [`char::UNICODE_VERSION`]
@@ -69,8 +67,6 @@ The following previously stable APIs are now `const`.
 [`char::from_u32`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_u32
 [`char::from_u32_unchecked`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_u32_unchecked
 [`char::from_digit`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_digit
-[`Peekable::next_if`]: https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html#method.next_if
-[`Peekable::next_if_eq`]: https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html#method.next_if_eq
 [`Arguments::as_str`]: https://doc.rust-lang.org/stable/std/fmt/struct.Arguments.html#method.as_str
 [`str::split_once`]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.split_once
 [`str::rsplit_once`]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.rsplit_once

--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -21,7 +21,7 @@ from the appropriate page on our website, and check out the
 [detailed release notes for 1.52.0][notes] on GitHub.
 
 [install]: https://www.rust-lang.org/install.html
-[notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25
+[notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1520-2021-05-06
 
 ## What's in 1.52.0 stable
 


### PR DESCRIPTION
A relnotes link was pointing to 1.51.0, and the `Peekable::*` methods were stabilized in 1.51.0 (and are part of the 1.51.0 relnotes).

r? @Mark-Simulacrum 