### PR TITLE
Fixed typo: about about

### DIFF
--- a/posts/2021-06-17-Rust-1.53.0.md
+++ b/posts/2021-06-17-Rust-1.53.0.md
@@ -103,7 +103,7 @@ struct 人 {
 let α = 1;
 ```
 
-The compiler will warn about about potentially confusing situations involving different scripts.
+The compiler will warn about potentially confusing situations involving different scripts.
 For example, using identifiers that look very similar will result in a warning.
 
 ```


### PR DESCRIPTION
Removed a typo where the word _about_ was used twice: 
> The compiler will warn about `about` potentially confusing situations involving different scripts.

![image](https://user-images.githubusercontent.com/6587811/122449680-2347dc00-cf74-11eb-95af-a8a11282dd5f.png)
