### PR TITLE
Revert "break promise"

### DIFF
--- a/posts/2021-05-11-edition-2021.md
+++ b/posts/2021-05-11-edition-2021.md
@@ -340,6 +340,9 @@ You can expect another announcement about the new edition in July.
 At that point we expect all changes and automatic migrations to be implemented
 and ready for public testing.
 
+We'll be posting some more details about the process and rejected proposals on
+the "Inside Rust" blog soon.
+
 <!--
 If you really can't wait, many features are already available on
 Rust [Nightly](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)

--- a/posts/2021-05-11-edition-2021.md
+++ b/posts/2021-05-11-edition-2021.md
@@ -341,7 +341,8 @@ At that point we expect all changes and automatic migrations to be implemented
 and ready for public testing.
 
 We'll be posting some more details about the process and rejected proposals on
-the "Inside Rust" blog soon.
+the "Inside Rust" blog soon. (_Correction: This did not end up happening due
+to lack of bandwidth_)
 
 <!--
 If you really can't wait, many features are already available on


### PR DESCRIPTION
Reverts https://github.com/rust-lang/blog.rust-lang.org/pull/858, uses a correction to satisfy the same purpose.

In general we don't want to edit old posts to change what they say; and should use corrections like this instead.