### PR TITLE
Fix the dev-static date for 1.54.0

### DIFF
--- a/posts/inside-rust/2021-07-26-1.54.0-prerelease.md
+++ b/posts/inside-rust/2021-07-26-1.54.0-prerelease.md
@@ -14,7 +14,7 @@ You can try it out locally by running:
 RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup update stable
 ```
 
-The index is <https://dev-static.rust-lang.org/dist/2021-07-29/index.html>. You
+The index is <https://dev-static.rust-lang.org/dist/2021-07-26/index.html>. You
 can leave feedback on the [internals thread][internals].
 
 [relnotes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1540-2021-07-29


### PR DESCRIPTION
The test artifacts are under today's date, 2021-07-26, not release day on the 29th.