### PR TITLE
Upgrade http to https

### DIFF
--- a/posts/2014-09-15-Rust-1.0.md
+++ b/posts/2014-09-15-Rust-1.0.md
@@ -113,7 +113,7 @@ starting point. This is very true. The goal for Rust 1.0 is to be an
 flexible substrate for building efficient libraries -- but libraries
 aren't any good if nobody can find them or they are difficult to install.
 
-Enter [Cargo, the Rust package manager](http://crates.io). Cargo has
+Enter [Cargo, the Rust package manager](https://crates.io). Cargo has
 been undergoing rapid development lately and is already quite
 functional. By the time
 1.0 is released, we plan to also have a central repository up and
@@ -128,8 +128,8 @@ we don't plan on changing that. Once we start having stable releases,
 however, we'll also build up a bit more infrastructure. Our plan is to
 adopt the "channel" system used by many other projects such as
 [Firefox](https://www.mozilla.org/en-US/firefox/channel/),
-[Chrome](http://www.chromium.org/getting-involved/dev-channel), and
-[Ember.js](http://emberjs.com/builds/).
+[Chrome](https://www.chromium.org/getting-involved/dev-channel), and
+[Ember.js](https://emberjs.com/builds/).
 
 The idea is that there are three channels: Nightly, Beta, and
 Stable. The Nightly channel is what you use if you want the latest
@@ -165,7 +165,7 @@ it already has. I can't wait to see what comes out of it.
 [k2]: https://github.com/jvns/puddle
 [k3]: https://github.com/pczarn/rustboot
 [k4]: https://github.com/ryanra/RustOS
-[stability]: http://doc.rust-lang.org/std/stability.html
+[stability]: https://doc.rust-lang.org/std/stability.html
 [dst]: https://github.com/rust-lang/rust/commit/7932b719ec2b65acfa8c3e74aad29346d47ee992
 [cd]: https://github.com/rust-lang/rfcs/blob/master/text/0114-closures.md
 [wc]: https://github.com/rust-lang/rfcs/pull/135

--- a/posts/2014-10-30-Stability.md
+++ b/posts/2014-10-30-Stability.md
@@ -6,7 +6,7 @@ description: "The upcoming Rust 1.0 release means a lot, but most fundamentally 
 ---
 
 The upcoming Rust 1.0 release means
-[a lot](http://blog.rust-lang.org/2014/09/15/Rust-1.0.html), but most
+[a lot](https://blog.rust-lang.org/2014/09/15/Rust-1.0.html), but most
 fundamentally it is a commitment to stability, alongside our
 long-running commitment to safety.
 
@@ -93,7 +93,7 @@ After extensive discussion, we plan to release globs and macros as
 stable at 1.0. For globs, we believe we can address problems in a
 backwards-compatible way. For macros, we will likely provide an
 alternative way to define macros (with better
-[hygiene](http://en.wikipedia.org/wiki/Hygienic_macro)) at some later
+[hygiene](https://en.wikipedia.org/wiki/Hygienic_macro)) at some later
 date, and will incrementally improve the "macro rules" feature until
 then. The 1.0 release will stabilize all current macro support,
 including import/export.
@@ -131,7 +131,7 @@ standard library, but you can opt into experimental APIs from other
 libraries. The Rust release channels are about making upgrading *Rust
 itself* (the compiler and standard library) painless.
 
-Library authors should follow [semver](http://semver.org/); we will
+Library authors should follow [semver](https://semver.org/); we will
 soon publish an RFC defining how library stability attributes and
 semver interact.
 

--- a/posts/2014-11-20-Cargo.md
+++ b/posts/2014-11-20-Cargo.md
@@ -9,7 +9,7 @@ Today it is my pleasure to announce that [crates.io](https://crates.io/) is
 online and ready for action. The site is a central location to
 discover/download Rust crates, and Cargo is ready to start publishing to it
 today. For the next few months, we are asking that intrepid early adopters
-[help us](http://doc.crates.io/crates-io.html) get the registry battle-tested.
+[help us](https://doc.crates.io/crates-io.html) get the registry battle-tested.
 
 Until Rust itself is stable early next year, registry dependencies will need to
 be updated often. Production users may want to continue using git dependencies
@@ -17,12 +17,12 @@ until then.
 
 ## What is Cargo?
 
-Cargo is a package manager [for Rust](http://www.rust-lang.org/), [in
+Cargo is a package manager [for Rust](https://www.rust-lang.org/), [in
 Rust](https://github.com/rust-lang/cargo). Managing dependencies is a
 fundamentally difficult problem, but fortunately over the last decade there's
 been a lot of progress in the design of package managers. Designed by Carl
 Lerche and Yehuda Katz, Cargo follows the tradition of successes like
-[Bundler](http://bundler.io/) and [NPM](https://www.npmjs.org/):
+[Bundler](https://bundler.io/) and [NPM](https://www.npmjs.org/):
 
 1. Cargo leverages crates.io to foster a thriving community of crates that can
    easily interoperate with one another and last for years to come.
@@ -42,7 +42,7 @@ its core mechanics.
 
 Cargo makes depending on third-party code as easy as depending on the standard
 library. When using Cargo, each crate will have an associated
-[manifest](http://doc.crates.io/manifest.html) to describe itself and its
+[manifest](https://doc.crates.io/manifest.html) to describe itself and its
 dependencies. Adding a new dependency is now as simple as adding one line to the
 manifest, and this ease has allowed Cargo in just a few short months to enable a
 large and growing network of Rust projects and libraries which were simply
@@ -62,19 +62,19 @@ have largely just downloaded dependencies directly from the source GitHub
 repository, but the primary source will now be shifting to crates.io.
 
 Other programming language communities have been quite successful with this form
-of central repository. For example [rubygems.org](http://rubygems.org/) is your
-one-stop-shop for [Bundler](http://bundler.io/) dependencies and
+of central repository. For example [rubygems.org](https://rubygems.org/) is your
+one-stop-shop for [Bundler](https://bundler.io/) dependencies and
 [npmjs.org](https://www.npmjs.org/) has had over 600 million downloads in just
 this month alone! We intend for crates.io to serve a similar role for Rust as a
 critical piece of infrastructure for [Rust's long-term stability story at
 1.0][stab].
 
-[stab]: http://blog.rust-lang.org/2014/10/30/Stability.html
+[stab]: https://blog.rust-lang.org/2014/10/30/Stability.html
 
 ## Versioning and Reproducible Builds
 
 Over the past few years, the concept of [Semantic
-Versioning](http://semver.org/) has gained traction as a way for library
+Versioning](https://semver.org/) has gained traction as a way for library
 developers to easily and clearly communicate with users when they make breaking
 changes. The core idea of semantic versioning is simple: each new release is
 categorized as a minor or major release, and only major releases can introduce
@@ -93,7 +93,7 @@ then distributed to collaborators of applications to ensure that the crates
 being built remain the same from one build to the next, across times, machines,
 and environments.
 
-[lock]: http://doc.crates.io/guide.html#cargo.toml-vs-cargo.lock
+[lock]: https://doc.crates.io/guide.html#cargo.toml-vs-cargo.lock
 
 ## Building Code
 
@@ -114,7 +114,7 @@ provide some nice standard features as well as some Rust-specific features:
 
 * Cargo generates documentation for all crates in a dependency graph, and it can
   even run [Rust's documentation
-  tests](http://doc.rust-lang.org/rustdoc.html#testing-the-documentation) to
+  tests](https://doc.rust-lang.org/rustdoc.html#testing-the-documentation) to
   ensure examples in documentation stay up to date.
 
 * Cargo can run a [build script][build-scripts] before any crate is compiled to
@@ -125,7 +125,7 @@ provide some nice standard features as well as some Rust-specific features:
   simply specifying a `--target` options and Cargo will manage tasks such as
   compiling plugins and other build dependencies for the right platform.
 
-[build-scripts]: http://doc.crates.io/build-script.html
+[build-scripts]: https://doc.crates.io/build-script.html
 
 ## What else is in store?
 
@@ -135,7 +135,7 @@ stable compiler, which should be [coming soon][road-to-1]! There are also a
 number of extensions to crates.io such as a hosted documentation service or a CI
 build infrastructure hook which could be built out using the crates.io APIs.
 
-[road-to-1]: http://blog.rust-lang.org/2014/09/15/Rust-1.0.html
+[road-to-1]: https://blog.rust-lang.org/2014/09/15/Rust-1.0.html
 
 This is just the beginning for crates.io, and I'm excited to start finding all
 Rust crates from one location. I can't wait to see what the registry looks like

--- a/posts/2014-12-12-1.0-Timeline.md
+++ b/posts/2014-12-12-1.0-Timeline.md
@@ -61,7 +61,7 @@ Six weeks later, we will begin the beta period:
 
 * Release channels take effect: feature gates and `#[unstable]` APIs are
   available on nightly builds, but not on the beta. This change is part of
-  [our commitment to stability](http://blog.rust-lang.org/2014/10/30/Stability.html).
+  [our commitment to stability](https://blog.rust-lang.org/2014/10/30/Stability.html).
 
 Unlike the alpha cycle, where we still expect some minor breakage, the beta
 cycle should *not* involve breakage unless a very significant problem is
@@ -76,7 +76,7 @@ Finally, after one or more beta cycles, we will have produced a release
 candidate that is **ready for the world**:
 
 * We are ready to promise stability --
-  [hassle-free upgrades](http://blog.rust-lang.org/2014/10/30/Stability.html) --
+  [hassle-free upgrades](https://blog.rust-lang.org/2014/10/30/Stability.html) --
   for the duration of the 1.X series.
 
 * The core documentation (The Guide/Guides) is fully in sync with the language and
@@ -86,7 +86,7 @@ We are incredibly excited for Rust to reach this point.
 
 ### What this means for the ecosystem
 
-With the [launch](http://blog.rust-lang.org/2014/11/20/Cargo.html) of Cargo and
+With the [launch](https://blog.rust-lang.org/2014/11/20/Cargo.html) of Cargo and
 [crates.io](https://crates.io/), Rust's ecosystem has already seen significant expansion, but
 it still takes a lot of work to track Rust's nightly releases. Beginning with
 the alpha release, and especially approaching beta1, this will change
@@ -100,6 +100,6 @@ first time.
 
 Let's do this!
 
-[why Rust is reaching 1.0]: http://blog.rust-lang.org/2014/09/15/Rust-1.0.html
-[6-week train model]: http://blog.rust-lang.org/2014/10/30/Stability.html
-[pre-release]: http://semver.org/
+[why Rust is reaching 1.0]: https://blog.rust-lang.org/2014/09/15/Rust-1.0.html
+[6-week train model]: https://blog.rust-lang.org/2014/10/30/Stability.html
+[pre-release]: https://semver.org/

--- a/posts/2014-12-12-Core-Team.md
+++ b/posts/2014-12-12-Core-Team.md
@@ -32,15 +32,15 @@ situation.
 Thanks Yehuda and Steve for all your hard work, and welcome to the core team!
 
 [Rust core team]: https://github.com/rust-lang/rust/wiki/Note-core-team
-[Ember.js]: http://emberjs.com/team/
+[Ember.js]: https://emberjs.com/team/
 [Skylight]: https://www.skylight.io/
-[Tilde]: http://www.tilde.io/
-[Rust guide]: http://doc.rust-lang.org/guide.html
-[Rust for Rubyists]: http://www.rustforrubyists.com/
-[Reddit]: http://www.reddit.com/r/rust
+[Tilde]: https://www.tilde.io/
+[Rust guide]: https://doc.rust-lang.org/guide.html
+[Rust for Rubyists]: https://www.rustforrubyists.com/
+[Reddit]: https://www.reddit.com/r/rust
 [HackerNews]: https://news.ycombinator.com/
 [RFCs repo]: https://github.com/rust-lang/rfcs/
-[Ruby on Rails]: http://rubyonrails.org/
-[jQuery]: http://jquery.com/
-[Bundler]: http://bundler.io/
-[TC39 language committee]: http://www.ecma-international.org/memento/TC39.htm
+[Ruby on Rails]: https://rubyonrails.org/
+[jQuery]: https://jquery.com/
+[Bundler]: https://bundler.io/
+[TC39 language committee]: https://www.ecma-international.org/memento/TC39.htm

--- a/posts/2015-01-09-Rust-1.0-alpha.md
+++ b/posts/2015-01-09-Rust-1.0-alpha.md
@@ -94,7 +94,7 @@ A detailed list of possible breaking changes to *stable* features/APIs can be fo
 
 * **Improvements to generics:** We will explore [avenues](https://smallcultfollowing.com/babysteps/blog/2014/07/06/implied-bounds/) to cut down on the number of redundant trait bounds that are currently required.
 
-* **Path reform:** The `path` module will soon be [reformed](https://github.com/rust-lang/rfcs/pull/474) to make use of DST, to give a better account of platform differences, and to more closely align with the [new C++ standard](https://ghostarchive.org/archive/cJo6w). Implementation work is largely complete, and the rollout should occur soon after alpha.
+* **Path reform:** The `path` module will soon be [reformed](https://github.com/rust-lang/rfcs/pull/474) to make use of DST, to give a better account of platform differences, and to more closely align with the [new C++ standard](http://web.archive.org/web/20150427231422/http://article.gmane.org/gmane.comp.lib.boost.devel/256220). Implementation work is largely complete, and the rollout should occur soon after alpha.
 
 * **IO reform:** An [overhaul of the IO APIs](https://github.com/rust-lang/rfcs/pull/517/) is being planned; please join in the conversation! These changes will be landing throughout the alpha cycle.
 

--- a/posts/2015-01-09-Rust-1.0-alpha.md
+++ b/posts/2015-01-09-Rust-1.0-alpha.md
@@ -4,7 +4,7 @@ title: "Announcing Rust 1.0 Alpha"
 author: The Rust Core Team
 ---
 
-Today, we're excited to [release](http://www.rust-lang.org/install.html) the alpha version of Rust 1.0, a systems programming language with a focus on safety, performance and concurrency.
+Today, we're excited to [release](https://www.rust-lang.org/install.html) the alpha version of Rust 1.0, a systems programming language with a focus on safety, performance and concurrency.
 
 This release marks a huge milestone for Rust and its community:
 
@@ -15,12 +15,12 @@ This release marks a huge milestone for Rust and its community:
 * **The core libraries are feature-complete for 1.0**. API conventions have been
   firmly established, and core functionality -- basic types, traits, data
   structures and concurrency primitives -- has all been
-  [stabilized](http://blog.rust-lang.org/2014/10/30/Stability.html). Here again
+  [stabilized](https://blog.rust-lang.org/2014/10/30/Stability.html). Here again
   we do not expect major breaking changes before 1.0.
 
 The Rust community really rolled up their sleeves to help push this release over the finish line; thanks to everyone who participated, and especially to the [friends of the tree](https://github.com/rust-lang/rust/wiki/Doc-friends-of-the-tree)!
 
-While we've come a long way in [the last four months](http://blog.rust-lang.org/2014/09/15/Rust-1.0.html), there's a lot left to do before Rust hits 1.0 final. Read on for more.
+While we've come a long way in [the last four months](https://blog.rust-lang.org/2014/09/15/Rust-1.0.html), there's a lot left to do before Rust hits 1.0 final. Read on for more.
 
 ### What happens during the alpha cycle?
 
@@ -30,8 +30,8 @@ Most features and modules that will ship with Rust 1.0 are in place and will cha
 
 We need your help to iterate on those final libraries before the beta release, and to hammer out any remaining issues on the parts of Rust we have already marked as stable.  **During the alpha cycle, we recommend using the nightly releases, which will continue to evolve as these APIs take their final shape.**
 
-The alpha release is part of our [transition](http://blog.rust-lang.org/2014/12/12/1.0-Timeline.html) into [stability guarantees](http://blog.rust-lang.org/2014/10/30/Stability.html). While we're not ready to make full stability guarantees yet, this release cycle moves
-us much closer to that 1.0 goal. When 1.0-beta1 is released [six weeks from now](http://blog.rust-lang.org/2014/12/12/1.0-Timeline.html), these important remaining APIs will be stable. Code that compiles on the beta release should do so with minimal changes on 1.0 final as well.
+The alpha release is part of our [transition](https://blog.rust-lang.org/2014/12/12/1.0-Timeline.html) into [stability guarantees](https://blog.rust-lang.org/2014/10/30/Stability.html). While we're not ready to make full stability guarantees yet, this release cycle moves
+us much closer to that 1.0 goal. When 1.0-beta1 is released [six weeks from now](https://blog.rust-lang.org/2014/12/12/1.0-Timeline.html), these important remaining APIs will be stable. Code that compiles on the beta release should do so with minimal changes on 1.0 final as well.
 
 ### What's shipping in alpha?
 
@@ -40,7 +40,7 @@ few of the highlights here; the full details are in [the release notes](https://
 
 #### Language features
 
-* **Dynamically-sized types (DSTs):** [Types whose size is only known at runtime](http://smallcultfollowing.com/babysteps/blog/2014/01/05/dst-take-5/) (such as array slices and trait objects) are now largely integrated into the language, including basic integration with user-defined smart pointers. *Implemented by Nick Cameron; rolled out by Jorge Aparicio*.
+* **Dynamically-sized types (DSTs):** [Types whose size is only known at runtime](https://smallcultfollowing.com/babysteps/blog/2014/01/05/dst-take-5/) (such as array slices and trait objects) are now largely integrated into the language, including basic integration with user-defined smart pointers. *Implemented by Nick Cameron; rolled out by Jorge Aparicio*.
 
 * **Multidispatch traits:** Trait implementations can now be selected via [multiple types](https://github.com/rust-lang/rfcs/pull/195) (not just `Self`), which has opened the door to [many](https://github.com/rust-lang/rfcs/pull/201) [interesting](https://github.com/rust-lang/rfcs/pull/235) [APIs](https://github.com/rust-lang/rfcs/pull/529). *Implemented by Niko Matsakis; rolled out by Jorge Aparicio and Aaron Turon*.
 
@@ -67,7 +67,7 @@ All of these language features have been rolled out throughout the standard libr
 [of](https://github.com/rust-lang/rfcs/pull/344)
 [conventions](https://github.com/rust-lang/rfcs/pull/430)
 [RFCs](https://github.com/rust-lang/rfcs/pull/445)
-have been approved, and are largely summarized [in the Rust Guidelines](http://aturon.github.io/); these conventions have been rolled out through all `#[stable]` parts of `std`. *Led by Aaron Turon*.
+have been approved, and are largely summarized [in the Rust Guidelines](https://aturon.github.io/); these conventions have been rolled out through all `#[stable]` parts of `std`. *Led by Aaron Turon*.
 
 * **Stable core types and traits:** All of the primitive types and basic building blocks (like `char`, `String`, `Vec`, `Box`, `Arc`, `RefCell` and so on) are now `#[stable]`. *Stabilized by Aaron Turon, Alex Crichton, Brian Anderson, Brendan Zabarauskas and Huon Wilson*.
 
@@ -82,7 +82,7 @@ have been approved, and are largely summarized [in the Rust Guidelines](http://a
 
 * **The Rust Programming Language:** The previous split between "The Guide" and "The guides" has been rectified by combining them into ["The book"](https://github.com/rust-lang/rust/pull/19897). *Led by Steve Klabnik*.
 
-* **Rust by Example:** The lovely http://rustbyexample.com/ introduction to Rust is now part of the official documentation. *Initiated by Jorge Aparicio*.
+* **Rust by Example:** The lovely https://rustbyexample.com/ introduction to Rust is now part of the official documentation. *Initiated by Jorge Aparicio*.
 
 * **Additional API documentation:** A lot of work has gone into improving API documentation, both by expanding the overview text and adding examples throughout. *Credit goes to the entire community, who worked tirelessly to improve these docs*.
 
@@ -92,9 +92,9 @@ A detailed list of possible breaking changes to *stable* features/APIs can be fo
 
 * **Improvements to [associated types](https://github.com/rust-lang/rust/issues/17307) and [unboxed closures](https://github.com/rust-lang/rust/issues/18101):** Both of these features are functional, but we plan to make significant ergonomic improvements during the beta cycle, such as [more sophisticated capture-clause inference](https://github.com/rust-lang/rfcs/blob/master/text/0231-upvar-capture-inference.md) and more [uniform support for shorthands like `X::Type`](https://github.com/rust-lang/rust/issues/20300).
 
-* **Improvements to generics:** We will explore [avenues](http://smallcultfollowing.com/babysteps/blog/2014/07/06/implied-bounds/) to cut down on the number of redundant trait bounds that are currently required.
+* **Improvements to generics:** We will explore [avenues](https://smallcultfollowing.com/babysteps/blog/2014/07/06/implied-bounds/) to cut down on the number of redundant trait bounds that are currently required.
 
-* **Path reform:** The `path` module will soon be [reformed](https://github.com/rust-lang/rfcs/pull/474) to make use of DST, to give a better account of platform differences, and to more closely align with the [new C++ standard](http://article.gmane.org/gmane.comp.lib.boost.devel/256220). Implementation work is largely complete, and the rollout should occur soon after alpha.
+* **Path reform:** The `path` module will soon be [reformed](https://github.com/rust-lang/rfcs/pull/474) to make use of DST, to give a better account of platform differences, and to more closely align with the [new C++ standard](https://ghostarchive.org/archive/cJo6w). Implementation work is largely complete, and the rollout should occur soon after alpha.
 
 * **IO reform:** An [overhaul of the IO APIs](https://github.com/rust-lang/rfcs/pull/517/) is being planned; please join in the conversation! These changes will be landing throughout the alpha cycle.
 
@@ -102,7 +102,7 @@ A detailed list of possible breaking changes to *stable* features/APIs can be fo
 
 * **Integer type auditing:** During the alpha cycle, we will finalize formal conventions for choosing integer types and re-audit the use of these types in `std`. This auditing may cause some breakage to `#[stable]` APIs.
 
-* **Documentation for all features:** Some recent feature additions, such as associated types and unboxed closures, have their RFC as the only documentation. User-facing documentation for these features will be added during the alpha cycle. The [reference](http://doc.rust-lang.org/reference.html) will likewise be brought up to date and improved.
+* **Documentation for all features:** Some recent feature additions, such as associated types and unboxed closures, have their RFC as the only documentation. User-facing documentation for these features will be added during the alpha cycle. The [reference](https://doc.rust-lang.org/reference.html) will likewise be brought up to date and improved.
 
 * **Complete API documentation:** Everything marked stable will have _at least_ a usage example, and hopefully complete textual explanation, before beta.
 

--- a/posts/2015-02-13-Final-1.0-timeline.md
+++ b/posts/2015-02-13-Final-1.0-timeline.md
@@ -21,7 +21,7 @@ committing to a precise release schedule for 1.0:
 * Rust 1.0 -- May 15
 
 This schedule differs from the
-[previous one](http://blog.rust-lang.org/2014/12/12/1.0-Timeline.html)
+[previous one](https://blog.rust-lang.org/2014/12/12/1.0-Timeline.html)
 by nailing down an exact set of release cycles. It also opts for a
 second alpha release and only a single beta release.
 
@@ -37,7 +37,7 @@ weeks after alpha2 and six weeks before 1.0.
 ## What's shipping in alpha2?
 
 We've managed to land almost all of the features
-[previously expected](http://blog.rust-lang.org/2015/01/09/Rust-1.0-alpha.html)
+[previously expected](https://blog.rust-lang.org/2015/01/09/Rust-1.0-alpha.html)
 for this cycle.
 
 **The big headline here is that all major API revisions are
@@ -92,7 +92,7 @@ Other highlights are as follows:
   `collection.remove(..)` possible in the future.
 
 * **Trait system**: New coherence rules were
-  [finalized](http://internals.rust-lang.org/t/orphan-rules/1322),
+  [finalized](https://internals.rust-lang.org/t/orphan-rules/1322),
   providing both flexibility and soundness for trait implementations.
 
 * **Overflow semantics**: After a long debate, the final integer
@@ -120,9 +120,9 @@ and path, unstable for a few more weeks while we collect feedback --
 but the beta release is intended to disallow use of unstable features.
 
 In more detail, Rust is drawing a
-[difference between alpha and beta](http://blog.rust-lang.org/2014/12/12/1.0-Timeline.html)
+[difference between alpha and beta](https://blog.rust-lang.org/2014/12/12/1.0-Timeline.html)
 connected with our
-[stability system](http://blog.rust-lang.org/2014/10/30/Stability.html).
+[stability system](https://blog.rust-lang.org/2014/10/30/Stability.html).
 In alpha releases, it's possible to opt-in to unstable features, but
 after beta, this will be possible only when using nightly builds. The
 beta release will mark the point when a substantial portion of the
@@ -167,6 +167,6 @@ stable Rust, and to uncover any gaps in stabilization.
 By beta, we hope that a substantial part of the ecosystem will be off
 of nightlies and on to stable releases. Getting there will require a
 community-wide push toward stabilization, which we're coordinating via
-[discuss](http://users.rust-lang.org/t/using-unstable-apis-tell-us-about-it/157/26)
+[discuss](https://users.rust-lang.org/t/using-unstable-apis-tell-us-about-it/157/26)
 -- if you haven't, please drop by and tell us the key unstable APIs
 you're using.

--- a/posts/2015-04-03-Rust-1.0-beta.md
+++ b/posts/2015-04-03-Rust-1.0-beta.md
@@ -33,8 +33,8 @@ modified to install Beta by default. (However, it is easy to switch to
 the Nightly build if some of your dependencies aren't updated yet. See
 the [install page][ru] for details.)
 
-[ru]: http://www.rust-lang.org/install.html
-[as]: http://blog.rust-lang.org/2014/10/30/Stability.html
+[ru]: https://www.rust-lang.org/tools/install
+[as]: https://blog.rust-lang.org/2014/10/30/Stability.html
 
 ### What happens during the beta cycle?
 
@@ -63,7 +63,7 @@ the Nightly builds and detect regressions across the entire Rust
 ecosystem, not just our own test base. This infrastructure is still in
 the development phase, but you can see a [sample report][sr] here.
 
-[tm]: http://blog.rust-lang.org/2014/12/12/1.0-Timeline.html
+[tm]: https://blog.rust-lang.org/2014/12/12/1.0-Timeline.html
 [sr]: https://gist.github.com/brson/a30a77836fbec057cbee
 
 ### A community achievement

--- a/posts/2015-04-10-Fearless-Concurrency.md
+++ b/posts/2015-04-10-Fearless-Concurrency.md
@@ -64,9 +64,9 @@ The goal of this post is to give you some idea of how that's done.
 systems. If you're already familiar with these, you can skip the two
 "background" sections and jump straight into concurrency. If you want
 a deeper introduction, I can't recommend
-[Yehuda Katz's post](http://blog.skylight.io/rust-means-never-having-to-close-a-socket/)
+[Yehuda Katz's post](https://blog.skylight.io/rust-means-never-having-to-close-a-socket/)
 highly enough. And
-[the Rust book](http://doc.rust-lang.org/book/ownership.html) has all
+[the Rust book](https://doc.rust-lang.org/book/ownership.html) has all
 the details.
 
 In Rust, every value has an "owning scope," and passing or returning a
@@ -262,7 +262,7 @@ it ties together sharing and communication:
 > Do not communicate by sharing memory; instead, share memory by
 > communicating.
 >
-> --[Effective Go](http://golang.org/doc/effective_go.html)
+> --[Effective Go](https://golang.org/doc/effective_go.html)
 
 **Rust's ownership makes it easy to turn that advice into a
 compiler-checked rule**. Consider the following channel API
@@ -610,14 +610,14 @@ catch new classes of bugs. Libraries like [syncbox][syncbox] and
 and we expect to invest heavily in this space in the next few
 months. Stay tuned!
 
-[mpsc]: http://static.rust-lang.org/doc/master/std/sync/mpsc/index.html
-[mutex]: http://static.rust-lang.org/doc/master/std/sync/struct.Mutex.html
-[send]: http://static.rust-lang.org/doc/master/std/marker/trait.Send.html
-[sync]: http://static.rust-lang.org/doc/master/std/marker/trait.Sync.html
+[mpsc]: https://static.rust-lang.org/doc/master/std/sync/mpsc/index.html
+[mutex]: https://static.rust-lang.org/doc/master/std/sync/struct.Mutex.html
+[send]: https://static.rust-lang.org/doc/master/std/marker/trait.Send.html
+[sync]: https://static.rust-lang.org/doc/master/std/marker/trait.Sync.html
 [scoped]: https://doc.rust-lang.org/1.0.0/std/thread/fn.scoped.html
 [syncbox]: https://github.com/carllerche/syncbox
 [simple_parallel]: https://github.com/huonw/simple_parallel
 [crossbeam-crate]: https://crates.io/crates/crossbeam
 [crossbeam-doc]: https://docs.rs/crossbeam/0.8.0/crossbeam/fn.scope.html
 [scoped-threadpool-crate]: https://crates.io/crates/scoped_threadpool
-[scoped-threadpool-doc]: http://kimundi.github.io/scoped-threadpool-rs/scoped_threadpool/index.html#examples:
+[scoped-threadpool-doc]: https://kimundi.github.io/scoped-threadpool-rs/scoped_threadpool/index.html#examples:

--- a/posts/2015-04-17-Enums-match-mutation-and-moves.md
+++ b/posts/2015-04-17-Enums-match-mutation-and-moves.md
@@ -701,8 +701,8 @@ the [user group]).
 and Niko Matsakis, as well as
 `Mutabah`, `proc`, `libfud`, `asQuirrel`, and `annodomini` from `#rust`.)
 
-[structured data]: http://en.wikipedia.org/wiki/Record_%28computer_science%29
-[Algebraic data types]: http://en.wikipedia.org/wiki/Algebraic_data_type
+[structured data]: https://en.wikipedia.org/wiki/Record_%28computer_science%29
+[Algebraic data types]: https://en.wikipedia.org/wiki/Algebraic_data_type
 [rust_docs]: https://doc.rust-lang.org/
-[user group]: http://users.rust-lang.org/
+[user group]: https://users.rust-lang.org/
 [L_value]: https://doc.rust-lang.org/reference.html#lvalues,-rvalues-and-temporaries

--- a/posts/2015-04-24-Rust-Once-Run-Everywhere.md
+++ b/posts/2015-04-24-Rust-Once-Run-Everywhere.md
@@ -166,7 +166,7 @@ the tarball, statically preventing dangling pointer bugs that are easy to
 make when working directly with C. (If you're not familiar with this kind of
 borrowing in Rust, have a look at Yehuda Katz's [blog post on ownership].)
 
-[blog post]: http://blog.skylight.io/rust-means-never-having-to-close-a-socket/
+[blog post]: https://blog.skylight.io/rust-means-never-having-to-close-a-socket/
 
 A key aspect of the Rust binding here is that it is a safe function, meaning
 that callers do not have to use `unsafe` blocks to invoke it! Although it has an
@@ -184,7 +184,7 @@ and [libsodium][sodiumoxide]. This list is also growing quite rapidly on
 [crates.io][crates-io], so your favorite C library may already be bound or will
 be bound soon!
 
-[blog post on ownership]: http://blog.skylight.io/rust-means-never-having-to-close-a-socket/
+[blog post on ownership]: https://blog.skylight.io/rust-means-never-having-to-close-a-socket/
 [rust-openssl]: https://crates.io/crates/openssl
 [git2-rs]: https://crates.io/crates/git2
 [curl-rust]: https://crates.io/crates/curl
@@ -227,7 +227,7 @@ this is the keyword `extern`. This is a specialized form of specifying the [ABI
 for a function][abi-fn] which enables the function to be compatible with a C
 function call.
 
-[abi-fn]: http://doc.rust-lang.org/reference.html#extern-functions
+[abi-fn]: https://doc.rust-lang.org/reference.html#extern-functions
 
 Finally, if you [take a look at the `Cargo.toml`][cargo-toml] you'll see that
 this library is not compiled as a normal Rust library (rlib) but instead as a

--- a/posts/2015-05-11-traits.md
+++ b/posts/2015-05-11-traits.md
@@ -409,12 +409,12 @@ from influencing the design at this early stage, to working on implementation,
 to trying out different use cases in your own code -- we'd love to have your
 help!
 
-[zero-cost-cpp]: http://www.stroustrup.com/abstraction-and-machine.pdf
-[fearless]: http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
-[dst5]: http://smallcultfollowing.com/babysteps/blog/2014/01/05/dst-take-5/
-[adhoc]: http://dl.acm.org/citation.cfm?id=75283
-[socket]: http://blog.skylight.io/rust-means-never-having-to-close-a-socket/
-[post1]: http://internals.rust-lang.org/t/priorities-after-1-0/1901
-[virtual]: http://smallcultfollowing.com/babysteps/blog/2015/05/05/where-rusts-enum-shines/
-[closures]: http://huonw.github.io/blog/2015/05/finding-closure-in-rust/
+[zero-cost-cpp]: https://www.stroustrup.com/abstraction-and-machine.pdf
+[fearless]: https://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
+[dst5]: https://smallcultfollowing.com/babysteps/blog/2014/01/05/dst-take-5/
+[adhoc]: https://dl.acm.org/citation.cfm?id=75283
+[socket]: https://blog.skylight.io/rust-means-never-having-to-close-a-socket/
+[post1]: https://internals.rust-lang.org/t/priorities-after-1-0/1901
+[virtual]: https://smallcultfollowing.com/babysteps/blog/2015/05/05/where-rusts-enum-shines/
+[closures]: https://huonw.github.io/blog/2015/05/finding-closure-in-rust/
 [impl-trait]: https://github.com/rust-lang/rfcs/pull/105

--- a/posts/2015-05-15-Rust-1.0.md
+++ b/posts/2015-05-15-Rust-1.0.md
@@ -309,25 +309,25 @@ whom contributed changes since our previous release (the
 - `Łukasz Niemier`
 - `らいどっと`
 
-[stable]: http://blog.rust-lang.org/2014/10/30/Stability.html
-[train]: http://blog.rust-lang.org/2014/12/12/1.0-Timeline.html
-[traits]: http://blog.rust-lang.org/2015/05/11/traits.html
+[stable]: https://blog.rust-lang.org/2014/10/30/Stability.html
+[train]: https://blog.rust-lang.org/2014/12/12/1.0-Timeline.html
+[traits]: https://blog.rust-lang.org/2015/05/11/traits.html
 [rfcs]: https://github.com/rust-lang/rfcs/blob/master/README.md
 [1068]: https://github.com/rust-lang/rfcs/pull/1068
 [contributing]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md
-[hb]: http://en.wikipedia.org/wiki/Heisenbug
-[priorities]: http://internals.rust-lang.org/t/priorities-after-1-0/1901
+[hb]: https://en.wikipedia.org/wiki/Heisenbug
+[priorities]: https://internals.rust-lang.org/t/priorities-after-1-0/1901
 [crates.io]: https://crates.io/
-[cargo]: http://blog.rust-lang.org/2014/11/20/Cargo.html
+[cargo]: https://blog.rust-lang.org/2014/11/20/Cargo.html
 [relnotes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-100-may-2015
 [caveats]: https://github.com/rust-lang/rfcs/pull/1122
-[book]: http://doc.rust-lang.org/1.0.0/book/getting-started.html
-[ffi]: http://blog.rust-lang.org/2015/04/24/Rust-Once-Run-Everywhere.html
-[AUTHORS]: https://github.com/rust-lang/rust/blob/master/AUTHORS.txt
+[book]: https://doc.rust-lang.org/1.0.0/book/getting-started.html
+[ffi]: https://blog.rust-lang.org/2015/04/24/Rust-Once-Run-Everywhere.html
+[AUTHORS]: https://github.com/rust-lang/rust/graphs/contributors
 [23606]: https://github.com/rust-lang/rust/pull/23606/
 [1044]: https://github.com/rust-lang/rfcs/pull/1044
 [24965]: https://github.com/rust-lang/rust/pull/24965
 [24615]: https://github.com/rust-lang/rust/pull/24615
 [25323]: https://github.com/rust-lang/rust/pull/25323
-[ebook]: http://killercup.github.io/trpl-ebook/
+[ebook]: https://killercup.github.io/trpl-ebook/
 [minor]: https://github.com/rust-lang/rfcs/pull/1105

--- a/posts/2015-06-25-Rust-1.1.md
+++ b/posts/2015-06-25-Rust-1.1.md
@@ -11,7 +11,7 @@ We're happy to announce the completion of the first release cycle after Rust
 Read on for details the releases, as well as some exciting new developments
 within the Rust community.
 
-[install]: http://www.rust-lang.org/install.html
+[install]: https://www.rust-lang.org/install.html
 
 ### What's in 1.1 Stable
 
@@ -32,7 +32,7 @@ features:
   filesystem APIs, making it possible, for example, to compile Cargo on stable Rust.
 * *musl support*. It's
   [now possible](https://github.com/rust-lang/rust/pull/24777) to target
-  [musl](http://www.musl-libc.org/) on Linux. Binaries built this way are
+  [musl](https://www.musl-libc.org/) on Linux. Binaries built this way are
   statically linked and have zero dependencies. Nightlies are on the way.
 * *`cargo rustc`*. It's now possible to build a Cargo package while passing
   arbitrary flags to the final `rustc` invocation.
@@ -79,7 +79,7 @@ and awareness-raising, and working with our early production users and the core
 team to help guide prioritization.
 
 In addition, we'll soon be holding the first official Rust conference:
-[RustCamp](http://rustcamp.com/), on August 1, 2015, in Berkeley, CA, USA. We've
+[RustCamp](https://rustcamp.com/), on August 1, 2015, in Berkeley, CA, USA. We've
 received a number of excellent talk submissions, and are expecting a great
 program.
 

--- a/posts/2015-08-06-Rust-1.2.md
+++ b/posts/2015-08-06-Rust-1.2.md
@@ -9,13 +9,13 @@ Today marks the [completion][install] of the Rust 1.2 stable and 1.3 beta
 release cycles! Read on for the highlight, or check the [release notes][notes]
 for more detail.
 
-[install]: http://www.rust-lang.org/install.html
+[install]: https://www.rust-lang.org/install.html
 [notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-120-august-2015
 
 ### What's in 1.2 stable
 
 As we
-[previously announced](http://blog.rust-lang.org/2015/06/25/Rust-1.1.html), Rust
+[previously announced](https://blog.rust-lang.org/2015/06/25/Rust-1.1.html), Rust
 1.2 comes with two major performance improvements for the compiler:
 
 - **An across-the-board improvement** to real-world compiler
@@ -23,7 +23,7 @@ As we
   faster), [html5ever][html5ever] (1.62x faster), [regex][regex] (1.32x faster)
   and [rust-encoding][rust-encoding] (1.35x faster). You can explore some of this
   performance data at Nick Cameron's
-  [preliminary tracking site](http://www.ncameron.org/perf-rustc/), using dates
+  [preliminary tracking site](https://www.ncameron.org/perf-rustc/), using dates
   2015-05-15 to 2015-06-25.
 
 - **Parallel codegen** is
@@ -53,7 +53,7 @@ we are testing all rust-lang crates against MSVC. Unwinding support is not yet
 available (the process aborts on panic), but work is underway to land it.
 
 On the language side, Rust 1.2 marks the completion of the
-[dynamically-sized type (DST)](http://smallcultfollowing.com/babysteps/blog/2014/01/05/dst-take-5/)
+[dynamically-sized type (DST)](https://smallcultfollowing.com/babysteps/blog/2014/01/05/dst-take-5/)
 work, allowing smart pointers like `Rc` to seamless apply to arrays and trait
 objects, so that `Rc<[T]>` is fully usable. This final enhancement applies to
 all smart pointers in the standard library. Support for external smart pointer

--- a/posts/2015-08-14-Next-year.md
+++ b/posts/2015-08-14-Next-year.md
@@ -37,11 +37,11 @@ programming.
 
 That's Rust 1.0; but what comes next?
 
-[deliverable]: http://blog.rust-lang.org/2014/10/30/Stability.html
+[deliverable]: https://blog.rust-lang.org/2014/10/30/Stability.html
 [rfcs]: https://github.com/rust-lang/rfcs#when-you-need-to-follow-this-process
 [subteams]: https://github.com/rust-lang/rfcs/pull/1068
-[fearless]: http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
-[traits]: http://blog.rust-lang.org/2015/05/11/traits.html
+[fearless]: https://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
+[traits]: https://blog.rust-lang.org/2015/05/11/traits.html
 
 ### Where we go from here
 
@@ -246,11 +246,11 @@ that integrates with advanced VMs smoothly and easily. Naturally, the design
 will respect Rust's "pay for what you use" policy, so that code which does not
 integrate with a GC is unaffected.
 
-[skylight]: http://blog.skylight.io/bending-the-curve-writing-safe-fast-native-gems-with-rust/
+[skylight]: https://blog.skylight.io/bending-the-curve-writing-safe-fast-native-gems-with-rust/
 [crates.io]: https://crates.io
 [node.js]: https://nodejs.org/
 [Servo]: https://github.com/servo/servo
-[Firefox]: http://firefox.com/
+[Firefox]: https://firefox.com/
 
 ### Epilogue: RustCamp 2015, and Rust's community in 2016
 
@@ -261,10 +261,10 @@ spaces translate into a friendly and approachable in-person event. The
 day opened with a keynote from Nicholas Matsakis and Aaron Turon
 laying out the core team's view of where we are and where we're
 headed. The
-[slides are available online](http://rustcamp.com/schedule.html)
+[slides are available online](https://rustcamp.com/schedule.html)
 (along with several other talks), and the above serves as the missing
 soundtrack. **Update**: now you can see
-[the talks](http://confreaks.tv/events/rustcamp2015) as well!
+[the talks](https://confreaks.tv/events/rustcamp2015) as well!
 
 There was a definite theme of the day: Rust's greatest potential is to unlock a
 new generation of systems programmers. And that's not just because of the
@@ -279,4 +279,4 @@ backgrounds into the Rust community. So our greatest wish for the next year of
 Rust is that, as its community grows, it continues to retain the welcoming
 spirit that it has today.
 
-[rustcamp]: http://rustcamp.com/
+[rustcamp]: https://rustcamp.com/

--- a/posts/2015-09-17-Rust-1.3.md
+++ b/posts/2015-09-17-Rust-1.3.md
@@ -8,7 +8,7 @@ release: true
 The gear keeps turning: we're releasing Rust 1.3 stable today! As always, read
 on for the highlights and check the [release notes][notes] for more detail.
 
-[install]: http://www.rust-lang.org/install.html
+[install]: https://www.rust-lang.org/install.html
 [notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-130-september-2015
 
 ### What's in 1.3 stable

--- a/posts/2015-10-29-Rust-1.4.md
+++ b/posts/2015-10-29-Rust-1.4.md
@@ -13,7 +13,7 @@ As always, you can [install Rust 1.4][install] from the appropriate page on our
 website, and check out the [detailed release notes for 1.4][notes] on GitHub as
 well. About 1200 patches were landed in this release.
 
-[install]: http://www.rust-lang.org/install.html
+[install]: https://www.rust-lang.org/install.html
 [notes]: https://github.com/rust-lang/rust/blob/8ab8581f6921bc7a8e3fa4defffd2814372dcb15/RELEASES.md#version-140-october-2015
 
 ### What's in 1.4 stable

--- a/posts/2015-12-10-Rust-1.5.md
+++ b/posts/2015-12-10-Rust-1.5.md
@@ -9,7 +9,7 @@ Today we're releasing [Rust 1.5 stable][install]. This post gives the
 highlights, and you can find the full details in the
 [release notes][notes].
 
-[install]: http://www.rust-lang.org/install.html
+[install]: https://www.rust-lang.org/install.html
 [notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-150-2015-12-10
 
 ### What's in 1.5 stable

--- a/posts/2016-01-21-Rust-1.6.md
+++ b/posts/2016-01-21-Rust-1.6.md
@@ -13,7 +13,7 @@ As always, you can [install Rust 1.6][install] from the appropriate page on our
 website, and check out the [detailed release notes for 1.6][notes] on GitHub.
 About 1100 patches were landed in this release.
 
-[install]: http://www.rust-lang.org/install.html
+[install]: https://www.rust-lang.org/install.html
 [notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-160-2016-01-21
 
 ### What's in 1.6 stable
@@ -32,7 +32,7 @@ memory allocation, I/O, and concurrency. Applications using Rust in the
 embedded space, as well as those writing operating systems, often eschew
 `libstd`, using only `libcore`.
 
-[`libcore`]: http://doc.rust-lang.org/nightly/core/
+[`libcore`]: https://doc.rust-lang.org/nightly/core/
 
 `libcore` being stabilized is a major step towards being able to write the
 lowest levels of software using stable Rust. There’s still future work to be
@@ -73,7 +73,7 @@ Instead, you must actually specify [a specific version or range of
 versions][versions], using one of the `semver` crate’s various options: `^`,
 `~`, or `=`.
 
-[versions]: http://doc.crates.io/crates-io.html#using-cratesio-based-crates
+[versions]: https://doc.crates.io/crates-io.html#using-cratesio-based-crates
 
 A wildcard dependency means that you work with any possible version of your
 dependency. This is highly unlikely to be true, and causes unnecessary breakage

--- a/posts/2016-03-02-Rust-1.7.md
+++ b/posts/2016-03-02-Rust-1.7.md
@@ -35,7 +35,7 @@ there can be a significant speedup so long as the loss of DOS protection is
 acceptable.
 
 [Siphash]: https://en.wikipedia.org/wiki/SipHash
-[not very fast]: http://cglab.ca/~abeinges/blah/hash-rs/
+[not very fast]: https://cglab.ca/~abeinges/blah/hash-rs/
 [FNV hash algorithm]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
 
 To see this in action, you can check out the [fnv crate] on [crates.io] and
@@ -68,7 +68,7 @@ to get up to 2x faster hashes. It’s also worth pointing out that [`Hash`] trai
 is agnostic to the hashing algorithm used, so no changes are needed to the
 types being inserted into hash maps to reap the benefits!
 
-[`Hash`]: http://doc.rust-lang.org/std/hash/trait.Hash.html
+[`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
 
 Other notable improvements include:
 

--- a/posts/2016-04-19-MIR.md
+++ b/posts/2016-04-19-MIR.md
@@ -74,7 +74,7 @@ Needless to say, we're excited, and the Rust community has stepped up
 in a big way to make MIR a reality. The compiler can bootstrap and run
 its test suite using MIR, and these tests have to pass on every new
 commit. Once we're able to run [Crater][crater] with MIR enabled and
-see no regressions across the entire [crates.io](http://crates.io/)
+see no regressions across the entire [crates.io](https://crates.io/)
 ecosystem, we'll turn it on by default (or, you'll forgive a terrible
 (wonderful) pun, [launch MIR into orbit][orbit]).
 
@@ -414,9 +414,9 @@ be absent from the graph.
 
 At this point, we've reduced our example into something fairly close
 to what MIR actually looks like. If you'd like to see for yourself,
-you can [view the MIR for our example](http://is.gd/MOfDfg) on
+you can [view the MIR for our example](https://is.gd/MOfDfg) on
 [play.rust-lang.org](https://play.rust-lang.org/). Just
-[follow this link](http://is.gd/MOfDfg) and then press the "MIR"
+[follow this link](https://is.gd/MOfDfg) and then press the "MIR"
 button along the top. You'll wind up seeing the MIR for several
 functions, so you have to search through to find the start of the
 `example` fn. (I won't reproduce the output here, as it is fairly
@@ -596,7 +596,7 @@ interested in contributing, look for
 [ss]: https://en.wikipedia.org/wiki/Syntactic_sugar
 [CFG]: https://en.wikipedia.org/wiki/Control_flow_graph
 [AST]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
-[LLVM]: http://llvm.org/
+[LLVM]: https://llvm.org/
 [the code]: https://github.com/rust-lang/rust/blob/f7ec6873ccfbf7dcdbd1908c0857c866b3e7087a/src/librustc/mir/repr.rs
 [orbit]: https://en.wikipedia.org/wiki/Mir
 [crater]: https://github.com/brson/taskcluster-crater

--- a/posts/2016-05-05-cargo-pillars.md
+++ b/posts/2016-05-05-cargo-pillars.md
@@ -406,7 +406,7 @@ bench` defaults to release mode, which uses maximum optimizations. `cargo build
 --release` similarly builds in optimized mode by default.
 
 > As an aside, the default behavior of each command is configurable through
-> [profiles](http://doc.crates.io/manifest.html#the-profile-sections) in the
+> [profiles](https://doc.crates.io/manifest.html#the-profile-sections) in the
 > `Cargo.toml`. This allows you to configure things like the optimization level,
 > whether to include debug symbols and more. Rather than forcing you to use a
 > custom workflow if something doesn't precisely meet your needs, the profiles
@@ -469,7 +469,7 @@ wouldn't want it to!)
 
 Today, Cargo will automatically share dependencies between crates if they depend
 on the same *major* version (or minor version before 1.0), since Rust uses
-[semantic versioning](http://semver.org/). This means that if `nix` and `datetime`
+[semantic versioning](https://semver.org/). This means that if `nix` and `datetime`
 both depend on some version of `libc 0.2.x`, they will get the same version. In
 this case, they do, and the program compiles.
 

--- a/posts/2016-05-09-survey.md
+++ b/posts/2016-05-09-survey.md
@@ -11,7 +11,7 @@ team plans a post next week giving some of their perspective on the year. But we
 are also eager to hear from you.
 
 Thus, as part of the celebrations, the community team is pleased to announce the
-official [2016 State of Rust Survey](http://goo.gl/forms/HaesyIg73g)!  Whether
+official [2016 State of Rust Survey](https://goo.gl/forms/HaesyIg73g)!  Whether
 or not you use Rust today, we want to know your opinions. Your responses will
 help the project understand its strengths and weaknesses, and to establish
 development priorities for the future.
@@ -27,6 +27,6 @@ feeds, at meetups, around your office and in other communities.
 
 Thanks, everyone who helped develop, polish, and test the survey! Once it
 closes, we will summarize and visualize the results here on
-[http://blog.rust-lang.org/](http://blog.rust-lang.org).
+[https://blog.rust-lang.org/](https://blog.rust-lang.org).
 
 Happy birthday, Rust. Have another great year.

--- a/posts/2016-05-13-rustup.md
+++ b/posts/2016-05-13-rustup.md
@@ -18,7 +18,7 @@ description: "The rustup toolchain manager makes cross-compilation in Rust a bre
 
 * You want to target the browser with [Emscripten] or [WebAssembly].
 
-[Emscripten]: http://kripken.github.io/emscripten-site/
+[Emscripten]: https://kripken.github.io/emscripten-site/
 [WebAssembly]: https://webassembly.github.io/
 
 In other words, **you want to develop/build on one "host" platform, but get a
@@ -30,8 +30,8 @@ target! And indeed, intrepid hackers have put Rust on embedded systems
 [like the Raspberry Pi 3], [bare metal ARM], [MIPS routers running
 OpenWRT][OpenWRT], and many others.
 
-[LLVM]: http://llvm.org
-[like the Raspberry Pi 3]: http://mirrors.link/posts/cross-compiling-rust-on-os-x-for-raspberry-pi-3
+[LLVM]: https://llvm.org
+[like the Raspberry Pi 3]: https://mirrors.link/posts/cross-compiling-rust-on-os-x-for-raspberry-pi-3
 [bare metal ARM]: https://blog.thiago.me/raspberry-pi-bare-metal-programming-with-rust/
 [OpenWRT]: https://github.com/japaric/rust-on-openwrt
 
@@ -76,7 +76,7 @@ true push-button experience for cross-compilation, it needs to set up
 the C toolchain as well. That functionality is not shipping today, but
 it's something we hope to incorporate over the next few months.
 
-[channels]: http://blog.rust-lang.org/2014/10/30/Stability.html
+[channels]: https://blog.rust-lang.org/2014/10/30/Stability.html
 [Rust library]: https://github.com/rust-lang-nursery/rustup.rs/
 
 ## Basic toolchain management
@@ -190,7 +190,7 @@ implementation of libc that can be easily statically linked. Rust has been
 compatible with musl since version 1.1, but until recently developers
 have needed to build their own compiler to benefit from it.
 
-[musl]: http://www.musl-libc.org/
+[musl]: https://www.musl-libc.org/
 
 With that background, let's walk through compiling a statically-linked Linux
 executable. For this example you'll want to be running Linux &mdash; that is, your
@@ -351,7 +351,7 @@ output of which is not included here):
 rust:~/home$ cd
 rust:~$ curl -O https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
 rust:~$ tar xzf android-sdk_r24.4.1-linux.tgz
-rust:~$ curl -O http://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
+rust:~$ curl -O https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
 rust:~$ unzip android-ndk-r10e-linux-x86_64.zip
 ```
 
@@ -381,7 +381,7 @@ built against `r10e` and links to symbols that are no longer included
 in the NDK. So for now we have to use the older NDK.  Second, in
 building the standalone toolchain we passed `--platform=android-18` to
 `make-standalone-toolchain.sh`. The "18" here is the Android [API
-level](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels).
+level](https://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels).
 Today, Rust's `arm-linux-androideabi` target is built against Android
 API level 18, and should theoretically be forwards-compatible with
 subsequent Android API levels. So we're picking level 18 to get the
@@ -394,7 +394,7 @@ do that we configure the `arm-linux-androideabi` target in
 we'll go ahead and set the default target for this project to Android
 so we don't have to keep calling cargo with the `--target` option.
 
-[`.cargo/config`]: http://doc.crates.io/config.html
+[`.cargo/config`]: https://doc.crates.io/config.html
 
 ```toml
 [build]

--- a/posts/2016-05-16-rust-at-one-year.md
+++ b/posts/2016-05-16-rust-at-one-year.md
@@ -14,9 +14,9 @@ Rust is a language that gives you:
 It's a language for writing highly reliable, screamingly fast software&mdash;and
 having fun doing it.
 
-[classic concurrency pitfalls]: http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
-[Python]: http://lucumr.pocoo.org/2015/5/27/rust-for-pythonistas/
-[Ruby]: http://diesel.rs/
+[classic concurrency pitfalls]: https://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
+[Python]: https://lucumr.pocoo.org/2015/5/27/rust-for-pythonistas/
+[Ruby]: https://diesel.rs/
 
 And yesterday, Rust turned one year old.
 
@@ -46,16 +46,16 @@ will soon be launching a coordinated, global effort following the [Bridge] model
 (e.g. RailsBridge). If you want to get involved, or have other ideas for
 outreach, please let [the community team] know.
 
-[survey]: http://blog.rust-lang.org/2016/05/09/survey.html
+[survey]: https://blog.rust-lang.org/2016/05/09/survey.html
 
 [most loved]: https://stackoverflow.com/research/developer-survey-2016
 
 [commits]: https://github.com/rust-lang/rust/commits/master
 [RFCs]: https://github.com/rust-lang/rfcs
-[stability delivered]: http://blog.rust-lang.org/2014/10/30/Stability.html
+[stability delivered]: https://blog.rust-lang.org/2014/10/30/Stability.html
 [crates]: https://crates.io/
 
-[Bridge]: http://bridgefoundry.org/
+[Bridge]: https://bridgefoundry.org/
 [the community team]: mailto:community-team@rust-lang.org
 
 ### Rust in production
@@ -77,7 +77,7 @@ engineer for the project, "the advantages of Rust are many: really powerful
 abstractions, no null, no segfaults, no leaks, yet C-like performance and
 control over memory."
 
-[dropbox]: http://www.wired.com/2016/03/epic-story-dropboxs-exodus-amazon-cloud-empire/
+[dropbox]: https://www.wired.com/2016/03/epic-story-dropboxs-exodus-amazon-cloud-empire/
 [dropbox quote]: https://news.ycombinator.com/item?id=11283688
 
 Second, there's Mozilla. They've long been developing [Servo] as a research
@@ -94,14 +94,14 @@ Servo&mdash;and not just in test mode.
 [Servo]: https://github.com/servo/servo/
 [mp4 metadata parsing]: https://github.com/mozilla/mp4parse-rust
 [ff]: https://telemetry.mozilla.org/new-pipeline/dist.html#!cumulative=0&end_date=2016-04-07&keys=__none__!__none__!__none__&max_channel_version=release%252F45&measure=MEDIA_RUST_MP4PARSE_SUCCESS&min_channel_version=null&product=Firefox&sanitize=1&sort_keys=submissions&start_date=2016-03-03&table=0&trim=1&use_submission_date=0
-[groundwork for Rust integration]: http://wiki.mozilla.org/Oxidation
+[groundwork for Rust integration]: https://wiki.mozilla.org/Oxidation
 
 We're hearing [similar stories] from a range of other shops that are putting
 Rust into production: Rust helps a team punch above its weight. It gives many of
 the same benefits as traditional systems languages while being more
 approachable, safer and often more productive.
 
-[similar stories]: http://confreaks.tv/videos/rustcamp2015-using-rust-from-c-or-any-language
+[similar stories]: https://confreaks.tv/videos/rustcamp2015-using-rust-from-c-or-any-language
 
 These are just a few stories of Rust in production, but we'd love to [hear yours]!
 
@@ -126,20 +126,20 @@ has been growing and polishing its ecosystem and tooling:
   coherence&mdash;particularly around async IO and the web stack&mdash;will
   continue to be a major focus in the coming year.
 
-[filesystem access]: http://static.rust-lang.org/doc/master/std/fs/index.html
-[networking]: http://static.rust-lang.org/doc/master/std/net/index.html
-[time]: http://static.rust-lang.org/doc/master/std/time/index.html
-[collections]: http://static.rust-lang.org/doc/master/std/collections/index.html
+[filesystem access]: https://static.rust-lang.org/doc/master/std/fs/index.html
+[networking]: https://static.rust-lang.org/doc/master/std/net/index.html
+[time]: https://static.rust-lang.org/doc/master/std/time/index.html
+[collections]: https://static.rust-lang.org/doc/master/std/collections/index.html
 [libc]: https://github.com/rust-lang/libc
 [winapi]: https://github.com/retep998/winapi-rs
 [gcc]: https://github.com/alexcrichton/gcc-rs
 [mio]: https://github.com/carllerche/mio/
-[rayon]: http://smallcultfollowing.com/babysteps/blog/2015/12/18/rayon-data-parallelism-in-rust/
-[crossbeam]: http://aturon.github.io/blog/2015/08/27/epoch/
+[rayon]: https://smallcultfollowing.com/babysteps/blog/2015/12/18/rayon-data-parallelism-in-rust/
+[crossbeam]: https://aturon.github.io/blog/2015/08/27/epoch/
 [regex]: https://github.com/rust-lang-nursery/regex
-[diesel]: http://diesel.rs/
+[diesel]: https://diesel.rs/
 [nom]: https://github.com/Geal/nom
-[lalrpop]: http://smallcultfollowing.com/babysteps/blog/2015/09/14/lalrpop/
+[lalrpop]: https://smallcultfollowing.com/babysteps/blog/2015/09/14/lalrpop/
 [html5ever]: https://kmcallister.github.io/talks/rust/2014-rust-macros/slides.html
 
 - **Platforms and targets**. Rust's memory footprint is not much bigger than C's, which
@@ -151,7 +151,7 @@ has been growing and polishing its ecosystem and tooling:
   a breeze to manage and compile to these various targets. As of
   [Rust 1.6][no_std], you can use Rust without its full standard library,
   limiting to a core library that does not require any OS services (and hence is
-  suitable for [writing OSes](http://os.phil-opp.com/)
+  suitable for [writing OSes](https://os.phil-opp.com/)
   [in Rust][intermezzos]). Finally, there are an increasing number of libraries
   for embedding Rust code into other contexts, like [node.js][neon],
   [Ruby][helix] and [Go][rure-go].
@@ -159,11 +159,11 @@ has been growing and polishing its ecosystem and tooling:
 [MSVC toolchain]: https://github.com/rust-lang/rust/pull/25350
 [MUSL]: https://www.musl-libc.org/
 [platforms]: https://forge.rust-lang.org/platform-support.html
-[rustup tool]: http://blog.rust-lang.org/2016/05/13/rustup.html
-[no_std]: http://blog.rust-lang.org/2016/01/21/Rust-1.6.html
+[rustup tool]: https://blog.rust-lang.org/2016/05/13/rustup.html
+[no_std]: https://blog.rust-lang.org/2016/01/21/Rust-1.6.html
 [intermezzos]: https://intermezzos.github.io/
-[neon]: http://calculist.org/blog/2015/12/23/neon-node-rust/
-[helix]: http://blog.skylight.io/introducing-helix/
+[neon]: https://calculist.org/blog/2015/12/23/neon-node-rust/
+[helix]: https://blog.skylight.io/introducing-helix/
 [rure-go]: https://github.com/BurntSushi/rure-go
 
 - **Tools**. Because Rust looks just like C on the outside, it's instantly
@@ -180,21 +180,21 @@ has been growing and polishing its ecosystem and tooling:
   [Cargo], gained numerous abilities this year, most notably the
   [install subcommand].
 
-[lldb]: http://lldb.llvm.org/
+[lldb]: https://lldb.llvm.org/
 [gdb]: https://www.gnu.org/software/gdb/
 [perf]: https://perf.wiki.kernel.org/index.php/Main_Page
-[valgrind]: http://valgrind.org/
+[valgrind]: https://valgrind.org/
 [callgrind]: https://kcachegrind.github.io/html/Home.html
 [enrich the experience]: https://michaelwoerister.github.io/2015/03/27/rust-xxdb.html
 [gdb hooks]: https://sourceware.org/ml/gdb-patches/2016-04/msg00570.html
-[cargo profile]: http://www.suchin.co/2016/05/11/Introducing-Cargo-Profiler/
+[cargo profile]: https://www.suchin.co/2016/05/11/Introducing-Cargo-Profiler/
 [IDEs]: https://www.rust-lang.org/ides.html
 [Racer]: https://github.com/phildawes/racer
 [numerous IDE plugins]: https://areweideyet.com/
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 [official style]: https://github.com/rust-lang/rfcs/pull/1607
-[Cargo]: http://blog.rust-lang.org/2016/05/05/cargo-pillars.html
-[install subcommand]: http://blog.rust-lang.org/2015/12/10/Rust-1.5.html
+[Cargo]: https://blog.rust-lang.org/2016/05/05/cargo-pillars.html
+[install subcommand]: https://blog.rust-lang.org/2015/12/10/Rust-1.5.html
 
 - **Compiler**. We've seen some [across-the-board improvements] to compile
   times, and now offer [parallelized code generation][parallel codegen] for
@@ -207,10 +207,10 @@ has been growing and polishing its ecosystem and tooling:
   [improve the "at a glance" readability of errors][error format]. Expect to
   hear more on both fronts soon.
 
-[across-the-board improvements]: http://blog.rust-lang.org/2015/06/25/Rust-1.1.html
-[parallel codegen]: http://blog.rust-lang.org/2015/08/06/Rust-1.2.html
+[across-the-board improvements]: https://blog.rust-lang.org/2015/06/25/Rust-1.1.html
+[parallel codegen]: https://blog.rust-lang.org/2015/08/06/Rust-1.2.html
 [incremental compilation]: https://github.com/rust-lang/rfcs/pull/1298
-[MIR]: http://blog.rust-lang.org/2016/04/19/MIR.html
+[MIR]: https://blog.rust-lang.org/2016/04/19/MIR.html
 [error index]: https://doc.rust-lang.org/error-index.html
 [error format]: https://internals.rust-lang.org/t/new-error-format/3438
 
@@ -222,7 +222,7 @@ has been growing and polishing its ecosystem and tooling:
 
 [Rust users]: https://internals.rust-lang.org/t/production-user-research-summary/2530
 [improved error handling]: https://github.com/rust-lang/rfcs/pull/243
-[more flexible borrowing rules]: http://smallcultfollowing.com/babysteps/blog/2016/04/27/non-lexical-lifetimes-introduction/
+[more flexible borrowing rules]: https://smallcultfollowing.com/babysteps/blog/2016/04/27/non-lexical-lifetimes-introduction/
 [specialization]: https://github.com/rust-lang/rfcs/pull/1210
 
 There's a lot more to say about what's happened and what's coming up in the Rust
@@ -238,11 +238,11 @@ It turns out that people like to get together and talk Rust. We had a sold out
 - October 27-18, 2016: [Rust Belt Rust], a Rust conference in Pittsburgh, PA, USA;
 - 71 Rust-related [meetup] groups worldwide.
 
-[RustCamp]: http://rustcamp.com/
-[RustConf]: http://rustconf.com/
-[RustFest]: http://www.rustfest.eu/blog/happy-birthday-announcing-rustfest
-[Rust Belt Rust]: http://rust-belt-rust.com/
-[meetup]: http://rust.meetup.com/
+[RustCamp]: https://rustcamp.com/
+[RustConf]: https://rustconf.com/
+[RustFest]: https://www.rustfest.eu/blog/happy-birthday-announcing-rustfest
+[Rust Belt Rust]: https://rust-belt-rust.com/
+[meetup]: https://rust.meetup.com/
 
 And that's no surprise. From a personal perspective, the best part about working
 with Rust is its [community]. It's hard to explain quite what it's like to be
@@ -253,7 +253,7 @@ one of empowerment&mdash;you can [fearlessly] write safe, low-level systems
 code&mdash;and that's reflected in the community. We're all here to learn how to
 be better programmers, and support each other in doing so.
 
-[fearlessly]: http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
+[fearlessly]: https://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
 [This Week in Rust]: https://this-week-in-rust.org/
 [community]: https://www.rust-lang.org/community.html
 
@@ -263,7 +263,7 @@ attending a local [meetup], saying hello in the [users forum], watching
 glad to have you.
 
 [users forum]: https://users.rust-lang.org/
-[a talk]: http://www.infoq.com/presentations/rust-thread-safety
+[a talk]: https://www.infoq.com/presentations/rust-thread-safety
 [the book]: https://doc.rust-lang.org/book/
 
 Happy birthday, Rust!

--- a/posts/2016-05-26-Rust-1.9.md
+++ b/posts/2016-05-26-Rust-1.9.md
@@ -38,7 +38,7 @@ assert!(result.is_err());
 
 This new API was defined in [RFC 1236].
 
-[`std::panic`]: http://doc.rust-lang.org/stable/std/panic/index.html
+[`std::panic`]: https://doc.rust-lang.org/stable/std/panic/index.html
 [RFC 1236]: https://github.com/rust-lang/rfcs/pull/1236
 
 In general, Rust distinguishes between two ways that an operation can fail:
@@ -52,7 +52,7 @@ at it. In Rust, expected problems are handled via [the `Result` type][result],
 which allows a function to return information about the problem to its caller,
 which can then handle the error in a fine-grained way.
 
-[result]: http://static.rust-lang.org/doc/master/std/result/index.html
+[result]: https://static.rust-lang.org/doc/master/std/result/index.html
 
 Unexpected problems are *bugs*: they arise due to a contract or assertion being
 violated. Since they are unexpected, it doesn't make sense to handle them in a
@@ -116,7 +116,7 @@ We now publish standard library binaries for several new targets:
 The first two targets are particularly interesting from a cross-compilation
 perspective; see the [recent blog post on `rustup`][rustup] for more details.
 
-[rustup]: http://blog.rust-lang.org/2016/05/13/rustup.html
+[rustup]: https://blog.rust-lang.org/2016/05/13/rustup.html
 
 #### Compile time improvements
 
@@ -143,7 +143,7 @@ With this simple test of specialization under our belt, we have more performance
 improvements on the way in upcoming releases.
 
 [specialization]: https://github.com/rust-lang/rfcs/pull/1210
-[nightly]: http://blog.rust-lang.org/2014/10/30/Stability.html
+[nightly]: https://blog.rust-lang.org/2014/10/30/Stability.html
 [now equivalent]: https://github.com/rust-lang/rust/pull/32586
 
 #### Library stabilizations

--- a/posts/2016-06-30-State-of-Rust-Survey-2016.md
+++ b/posts/2016-06-30-State-of-Rust-Survey-2016.md
@@ -90,7 +90,7 @@ In total, **1 in 4** people commented on the learning curve when talking about R
 
 > "Steep learning curve at the beginning"
 
-The proverbial gauntlet has been thrown.  For Rust to do well, it will need to retain the power it has while also improving the experience of learning the language and mastering its ownership system.  There are a few early initiatives here, including a [new Rust book](http://rust-lang.github.io/book/), an [upcoming O'Reilly book](http://shop.oreilly.com/product/0636920040385.do), improvements to [Rust error messages](https://github.com/jonathandturner/rfcs/blob/master/text/0000-default-and-expanded-rustc-errors.md), as well as improvements to the borrow checker to [give fewer false warnings](http://smallcultfollowing.com/babysteps/blog/2016/05/04/non-lexical-lifetimes-based-on-liveness/). We expect learning curve and developer productivity to be an area of sustained focus.
+The proverbial gauntlet has been thrown.  For Rust to do well, it will need to retain the power it has while also improving the experience of learning the language and mastering its ownership system.  There are a few early initiatives here, including a [new Rust book](https://rust-lang.github.io/book/), an [upcoming O'Reilly book](https://shop.oreilly.com/product/0636920040385.do), improvements to [Rust error messages](https://github.com/jonathandturner/rfcs/blob/master/text/0000-default-and-expanded-rustc-errors.md), as well as improvements to the borrow checker to [give fewer false warnings](https://smallcultfollowing.com/babysteps/blog/2016/05/04/non-lexical-lifetimes-based-on-liveness/). We expect learning curve and developer productivity to be an area of sustained focus.
 
 # Immaturity of the Language and Libraries
 
@@ -124,7 +124,7 @@ Investing in IDE support not only helps new users but also helps enable teams mo
 
 Other languages have had years to build up their tooling muscle, and for Rust to stand on even footing, we'll also have to build up our own muscle.  There are some early experiments here, namely [Racer](https://github.com/phildawes/racer) and [rustw](https://github.com/nrc/rustw), as well as a [number of IDE plugins](https://areweideyet.com/).
 
-We've also been investing in other tooling muscles, including a [new installer with cross-compilation support](http://blog.rust-lang.org/2016/05/13/rustup.html).  These are just the first steps, and we'll be exploring more ideas in further blog posts.
+We've also been investing in other tooling muscles, including a [new installer with cross-compilation support](https://blog.rust-lang.org/2016/05/13/rustup.html).  These are just the first steps, and we'll be exploring more ideas in further blog posts.
 
 ## Survey Demographics
 

--- a/posts/2016-07-07-Rust-1.10.md
+++ b/posts/2016-07-07-Rust-1.10.md
@@ -28,7 +28,7 @@ ever-so-slightly faster. Some very rough numbers are 10% smaller binaries, and
 
 [`-C panic=abort` flag]: https://github.com/rust-lang/rust/pull/32900
 [setting in your `Cargo.toml`]: https://github.com/rust-lang/cargo/pull/2687
-[panics are for unexpected problems]: http://blog.rust-lang.org/2016/05/26/Rust-1.9.html
+[panics are for unexpected problems]: https://blog.rust-lang.org/2016/05/26/Rust-1.9.html
 [RFC 1513]: https://github.com/rust-lang/rfcs/blob/master/text/1513-less-unwinding.md
 
 The second big feature in 1.10 is a new crate type: [`cdylib`]. The existing
@@ -86,9 +86,9 @@ groups:
 
 [`std::os::windows::fs::OpenOptionsExt`]: https://github.com/rust-lang/rfcs/pull/1252
 [register and unregister panic hooks]: https://github.com/rust-lang/rfcs/pull/1328
-[`CStr::from_bytes_with_nul`]: http://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_bytes_with_nul
-[and an unchecked variant]: http://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_bytes_with_nul_unchecked
-[`std::fs::Metadata`]: http://doc.rust-lang.org/std/fs/struct.Metadata.html
+[`CStr::from_bytes_with_nul`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_bytes_with_nul
+[and an unchecked variant]: https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_bytes_with_nul_unchecked
+[`std::fs::Metadata`]: https://doc.rust-lang.org/std/fs/struct.Metadata.html
 [`compare_exchange` for various atomic types]: https://github.com/rust-lang/rfcs/pull/1443
 [UNIX-specific networking capabilities]: https://github.com/rust-lang/rfcs/pull/1479
 

--- a/posts/2016-07-25-conf-lineup.md
+++ b/posts/2016-07-25-conf-lineup.md
@@ -11,7 +11,7 @@ announced.
 
 ### Sept 9-10: RustConf
 
-[RustConf](http://rustconf.com/) is a two-day event held in **Portland, OR,
+[RustConf](https://rustconf.com/) is a two-day event held in **Portland, OR,
 USA** on September 9-10. The first day offers tutorials on Rust given directly
 by members of the Rust core team, ranging from absolute basics to advanced
 ownership techniques. The second day is the main event, with talks at every
@@ -26,7 +26,7 @@ Follow us on Twitter [@rustconf](https://twitter.com/rustconf).
 
 ### Sept 17-18: Rust Fest
 
-Join us at [RustFest](http://www.rustfest.eu/), Europe's first conference
+Join us at [RustFest](https://www.rustfest.eu/), Europe's first conference
 dedicated to the Rust programming language. Over the weekend 17-18th September
 we'll gather in **Berlin** to talk Rust, its ecosystem and community. All day
 Saturday will have talks with topics ranging from hardware and testing over
@@ -38,13 +38,13 @@ meet-n-greet-n-hack area provided.
 Thanks to the many awesome sponsors, we are able to offer affordable tickets to
 go on sale this week, with an optional combo—including both
 [Viewsource](https://viewsourceconf.org/berlin-2016/) and RustFest. Keep an eye
-on http://www.rustfest.eu/, get all the updates on the
-[blog](http://www.rustfest.eu/blog/) and don't forget to follow us on Twitter
+on https://www.rustfest.eu/, get all the updates on the
+[blog](https://www.rustfest.eu/blog/) and don't forget to follow us on Twitter
 [@rustfest](https://twitter.com/rustfest)
 
 ### Oct 27-28: Rust Belt Rust
 
-[Rust Belt Rust](http://www.rust-belt-rust.com/) is a two-day conference in
+[Rust Belt Rust](https://www.rust-belt-rust.com/) is a two-day conference in
 **Pittsburgh, PA, USA** on October 27 and 28, 2016, and people with any level of
 Rust experience are encouraged to attend. The first day of the conference has a
 wide variety of interactive workshops to choose from, covering topics like an

--- a/posts/2016-08-10-Shape-of-errors-to-come.md
+++ b/posts/2016-08-10-Shape-of-errors-to-come.md
@@ -8,7 +8,7 @@ There are changes afoot in the Rust world. If you've tried out the latest nightl
 something is *a little different*. For the past few months we've been working on new way of
 reporting errors that's easier to read and understand. This is part of an on-going campaign to
 improve Rust's usability across the board. We mentioned ways to help us
-[make the transition](http://www.jonathanturner.org/2016/08/helping-out-with-rust-errors.html)
+[make the transition](https://www.jonathanturner.org/2016/08/helping-out-with-rust-errors.html)
 to the new errors, and already many people have jumped in (and thank you to those volunteers!)
 
 Let's dive in and see what's changed.  We'll start with a simple example:
@@ -166,7 +166,7 @@ extended errors looks like, come jump into the #rust-cli channel on irc.mozilla.
 
 Great!  We love the enthusiasm. There's
 [a lot to do](https://github.com/rust-lang/rust/issues/35233), and a
-[lot of skills](http://www.jonathanturner.org/2016/08/helping-out-with-rust-errors.html) that could
+[lot of skills](https://www.jonathanturner.org/2016/08/helping-out-with-rust-errors.html) that could
 help us in different ways. Whether you're good at unit tests, writing docs,
 writing code, or working on designs, there are places to jump in.
 
@@ -188,4 +188,4 @@ improve the learning curve bit by bit, and we're looking forward to seeing how f
 [new_errors3]: /images/2016-08-09-Errors/new_errors3.png
 [new_errors4]: /images/2016-08-09-Errors/new_errors4.png
 [Dybuk]: https://github.com/ticki/dybuk
-[Elm]: http://elm-lang.org/blog/compiler-errors-for-humans
+[Elm]: https://elm-lang.org/blog/compiler-errors-for-humans

--- a/posts/2016-11-10-Rust-1.13.md
+++ b/posts/2016-11-10-Rust-1.13.md
@@ -24,9 +24,9 @@ users [tell us] they need.
 And even with all that going on, we put together a new release filled with fun
 new toys.
 
-[RustConf]: http://rustconf.com/
-[RustFest]: http://www.rustfest.eu/
-[Rust Belt Rust]: http://www.rust-belt-rust.com/
+[RustConf]: https://rustconf.com/
+[RustFest]: https://www.rustfest.eu/
+[Rust Belt Rust]: https://www.rust-belt-rust.com/
 [thinking a lot]: https://internals.rust-lang.org/t/setting-our-vision-for-the-2017-cycle/3958/47
 [roadmap for 2017]: https://github.com/rust-lang/rfcs/pull/1774
 [building the tools]: https://internals.rust-lang.org/t/introducing-rust-language-server-source-release/4209
@@ -222,7 +222,7 @@ pipeline for 1.14.
 [cache]: https://github.com/rust-lang/rust/pull/35761
 [graph]: https://goo.gl/6T69T2
 [statistics]: https://goo.gl/CLIAhi
-[perf.rust-lang.org]: http://perf.rust-lang.org
+[perf.rust-lang.org]: https://perf.rust-lang.org
 [rustc-benchmarks]: https://github.com/rust-lang-nursery/rustc-benchmarks
 [inline]: https://github.com/rust-lang/rust/pull/36524
 

--- a/posts/2016-12-15-Underhanded-Rust.md
+++ b/posts/2016-12-15-Underhanded-Rust.md
@@ -7,7 +7,7 @@ author: The Rust Community Team
 The [Rust Community Team](https://community.rs) is pleased to announce the
 first annual Underhanded Rust Contest, inspired by the [Underhanded
 C](http://www.underhanded-c.org/) and [Underhanded
-Crypto](https://underhandedcrypto.com/) contests. Our goal with
+Crypto](http://underhandedcrypto.com/) contests. Our goal with
 [Rust](https://www.rust-lang.org/) is to make it easy to write trustworthy
 low-level software that is resistant to accidental security vulnerabilities.
 Less often challenged has been Rust's ability to protect against

--- a/posts/2016-12-22-Rust-1.14.md
+++ b/posts/2016-12-22-Rust-1.14.md
@@ -50,7 +50,7 @@ $ node hello.js
 ```
 
 [wasm]: https://users.rust-lang.org/t/compiling-to-the-web-with-rust-and-emscripten/7627
-[emscripten]: http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html
+[emscripten]: https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html
 
 The community has been doing interesting, experimental work in this area: see
 [Jan-Erik's slides] for the workshop he ran at [Rust Belt Rust] for some
@@ -58,9 +58,9 @@ examples, or check out [Tim's example of the classic TodoMVC project][todomvc].
 This implementation builds off of his [webplatform
 crate](https://crates.io/crates/webplatform), which exposes the DOM to Rust.
 
-[Jan-Erik's slides]: http://www.hellorust.com/emscripten/
-[Rust Belt Rust]: http://www.rust-belt-rust.com/sessions/
-[todomvc]: http://timryan.org/rust-todomvc/
+[Jan-Erik's slides]: https://www.hellorust.com/emscripten/
+[Rust Belt Rust]: https://www.rust-belt-rust.com/sessions/
+[todomvc]: https://github.com/rust-webplatform/rust-todomvc
 
 Speaking of platforms, a large number of platforms have gained additional
 support:

--- a/posts/2017-02-02-Rust-1.15.md
+++ b/posts/2017-02-02-Rust-1.15.md
@@ -109,7 +109,7 @@ fn main() {
 
 For full instructions, see [the website][diesel].
 
-[diesel]: http://diesel.rs
+[diesel]: https://diesel.rs
 
 These kinds of libraries are extremely powerful, but rely on custom derive for
 ergonomics. While these libraries _worked_ on Rust stable previously, they were

--- a/posts/2017-02-06-roadmap.md
+++ b/posts/2017-02-06-roadmap.md
@@ -31,10 +31,10 @@ small complexities entail glossing over safety holes or performance cliffs?
 Our approach with Rust has always been to bend the curve around tradeoffs, as
 embodied in the various pillars we've talked about on this blog:
 
-- [Memory safety without garbage collection](http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html)
-- [Concurrency without data races](http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html)
-- [Abstraction without overhead](http://blog.rust-lang.org/2015/05/11/traits.html)
-- [Stability without stagnation](http://blog.rust-lang.org/2014/10/30/Stability.html)
+- [Memory safety without garbage collection](https://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html)
+- [Concurrency without data races](https://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html)
+- [Abstraction without overhead](https://blog.rust-lang.org/2015/05/11/traits.html)
+- [Stability without stagnation](https://blog.rust-lang.org/2014/10/30/Stability.html)
 
 In the core language we've sometimes been able to leverage things like Rust's
 ownership model to make features easier to use. For example, [closures in Rust],
@@ -44,12 +44,12 @@ into the closure, without sacrificing reliability or performance. We've also
 been working to make the language easier to learn by improving the
 [compiler's error messages]. And [Cargo] is an example of early focus on
 productivity that has only enhanced the power of systems programming with Rust,
-allowing for [OS](http://os.phil-opp.com/)
+allowing for [OS](https://os.phil-opp.com/)
 [projects](https://intermezzos.github.io/) to easily build and leverage an
 ecosystem of shared libraries. There's so much more we can do along these lines!
 
 [Cargo]: https://blog.rust-lang.org/2016/05/05/cargo-pillars.html
-[closures in Rust]: http://huonw.github.io/blog/2015/05/finding-closure-in-rust/
+[closures in Rust]: https://huonw.github.io/blog/2015/05/finding-closure-in-rust/
 [compiler's error messages]: https://blog.rust-lang.org/2016/08/10/Shape-of-errors-to-come.html
 
 In short, **productivity should be a core value of Rust**, and we should work
@@ -86,7 +86,7 @@ statement links to a corresponding tracker with more details:
   [guidelines for unsafe code](https://github.com/rust-lang/rfcs/pull/1643).
 
 * [**Rust should be well-equipped for writing robust, high-scale servers**](https://github.com/rust-lang/rust-roadmap/issues/10). Plans
-  mostly focus on the [Tokio project](http://tokio.rs/) for asynchronous I/O and
+  mostly focus on the [Tokio project](https://tokio.rs/) for asynchronous I/O and
   potentially
   [async/await notation](https://github.com/rust-lang/rfcs/pull/1823).
 

--- a/posts/2017-03-02-lang-ergonomics.md
+++ b/posts/2017-03-02-lang-ergonomics.md
@@ -193,7 +193,7 @@ those assumptions explicitly in the signature. This situation seems ripe for an
 ergonomic improvement.
 
 It's
-[straightforward](http://smallcultfollowing.com/babysteps/blog/2014/07/06/implied-bounds/)
+[straightforward](https://smallcultfollowing.com/babysteps/blog/2014/07/06/implied-bounds/)
 to assume bounds that are "implied" by the type, like assuming that `K` must be
 `Hash` and `Eq` above, by tying it to the type definition:
 

--- a/posts/2019-04-26-Mozilla-IRC-Sunset-and-the-Rust-Channel.md
+++ b/posts/2019-04-26-Mozilla-IRC-Sunset-and-the-Rust-Channel.md
@@ -17,8 +17,8 @@ We understand that not everyone wishes to switch to Discord for many reasons. Fo
 There are still a couple months before irc.mozilla.org shuts down — we’ll work at making this transition as smooth as possible in this time. Thanks to everyone who made #rust and #rust-beginners on Mozilla IRC a great place to hang out! We are sad to see it go. 😢
 
 
- [mhoye-post]: http://exple.tive.org/blarg/2019/04/26/synchronous-text/
+ [mhoye-post]: https://exple.tive.org/blarg/2019/04/26/synchronous-text/
  [new-platforms]: https://internals.rust-lang.org/t/exploring-new-communication-channels/7859
- [discord]: http://discord.gg/rust-lang
- [freenode]: http://webchat.freenode.net/?channels=##rust
+ [discord]: https://discord.gg/rust-lang
+ [freenode]: https://webchat.freenode.net/?channels=##rust
  [freenode-rules]: https://freenode.net/policies#off-topic-use

--- a/posts/2019-11-01-nll-hard-errors.md
+++ b/posts/2019-11-01-nll-hard-errors.md
@@ -106,4 +106,4 @@ or if you are seeing errors in your code that you need to fix -- take
 a look at this [excellent blog post by Felix Klock][nllpost], which
 goes into great detail.
 
-[nllpost]: http://blog.pnkfx.org/blog/2019/06/26/breaking-news-non-lexical-lifetimes-arrives-for-everyone/
+[nllpost]: https://blog.pnkfx.org/blog/2019/06/26/breaking-news-non-lexical-lifetimes-arrives-for-everyone/

--- a/posts/2020-04-17-Rust-survey-2019.md
+++ b/posts/2020-04-17-Rust-survey-2019.md
@@ -4,7 +4,7 @@ title: "Rust Survey 2019 Results"
 author: The Rust Survey Team
 ---
 
-> Translation available for [Chinese | 中文](http://www.secondstate.info/blog/rust-2019)
+> Translation available for [Chinese | 中文](https://ghostarchive.org/archive/uQ71A)
 
 Greetings Rustaceans!
 

--- a/posts/2020-04-17-Rust-survey-2019.md
+++ b/posts/2020-04-17-Rust-survey-2019.md
@@ -4,7 +4,7 @@ title: "Rust Survey 2019 Results"
 author: The Rust Survey Team
 ---
 
-> Translation available for [Chinese | 中文](https://ghostarchive.org/archive/uQ71A)
+> Translation available for [Chinese | 中文](https://web.archive.org/web/20200611004214/http://www.secondstate.info/blog/rust-2019)
 
 Greetings Rustaceans!
 

--- a/posts/2021-09-27-Core-team-membership-updates.md
+++ b/posts/2021-09-27-Core-team-membership-updates.md
@@ -46,7 +46,7 @@ Jan-Erik Rediger, and JT are joining the Core team. To give some context on
 their backgrounds and experiences, each new member has written up a brief
 introduction.
 
-* [Ryan Levick](http://github.com/rylev) began exploring Rust in 2014 always
+* [Ryan Levick](https://github.com/rylev) began exploring Rust in 2014 always
   looking for more and more ways to be involved in the community. Over time he
   participated more by co-organizing the Berlin Rust meetup, doing YouTube
   tutorials, helping with various project efforts, and more. In 2019, Ryan got


### PR DESCRIPTION
This is a minor patch that replaces all http links with https links, since HTTPS is more secure. HTTP displays "not secure" in chromium.

Some links were dead, so i used archived version. And some links dont have https support, so i left that as is.