### PR TITLE
Make clear the Unicode standard is also not at fault

### DIFF
--- a/posts/2021-11-01-cve-2021-42574.md
+++ b/posts/2021-11-01-cve-2021-42574.md
@@ -14,9 +14,9 @@ source code containing "bidirectional override" Unicode codepoints: in some
 cases the use of those codepoints could lead to the reviewed code being
 different than the compiled code.
 
-This is a vulnerability in the Unicode specification, and its assigned
-identifier is [CVE-2021-42574]. While the vulnerability itself is not a rustc
-flaw, we're taking proactive measures to mitigate its impact on Rust
+This is a vulnerability due to the Unicode specification, and its assigned
+identifier is [CVE-2021-42574]. While the vulnerability itself is neither a rustc
+nor a Unicode flaw, we're taking proactive measures to mitigate its impact on Rust
 developers.
 
 ## Overview


### PR DESCRIPTION
This is in response to community feedback that this phrasing is a bit unfortunate as it appeared to blame the Unicode spec as having a vulnerability, while the flaw is of course in the exploitation of Unicode features which have good reason for existing — and Rust (I would think) makes no judgement on this being something to be addressed by Unicode.