### PR TITLE
Do not assign blame for the bidi issue to any particular entity

### DIFF
--- a/posts/2021-11-01-cve-2021-42574.md
+++ b/posts/2021-11-01-cve-2021-42574.md
@@ -14,10 +14,9 @@ source code containing "bidirectional override" Unicode codepoints: in some
 cases the use of those codepoints could lead to the reviewed code being
 different than the compiled code.
 
-This is a vulnerability in the Unicode specification, and its assigned
-identifier is [CVE-2021-42574]. While the vulnerability itself is not a rustc
-flaw, we're taking proactive measures to mitigate its impact on Rust
-developers.
+This is an issue with how source code may be rendered in certain contexts, and
+its assigned identifier is [CVE-2021-42574]. While the issue itself is not a flaw
+in rustc, we're taking proactive measures to mitigate its impact on Rust developers.
 
 ## Overview
 

--- a/posts/2021-11-01-cve-2021-42574.md
+++ b/posts/2021-11-01-cve-2021-42574.md
@@ -4,7 +4,7 @@ title: "Security advisory for rustc (CVE-2021-42574)"
 author: The Rust Security Response WG
 ---
 
-> This is a cross-post of [the official security advisory][advisory]. The
+> This is a ligtly edited cross-post of [the official security advisory][advisory]. The
 > official advisory contains a signed version with our PGP key, as well.
 
 [advisory]: https://groups.google.com/g/rustlang-security-announcements/c/bKPH8XYMvJU

--- a/posts/2021-11-01-cve-2021-42574.md
+++ b/posts/2021-11-01-cve-2021-42574.md
@@ -4,7 +4,7 @@ title: "Security advisory for rustc (CVE-2021-42574)"
 author: The Rust Security Response WG
 ---
 
-> This is a ligtly edited cross-post of [the official security advisory][advisory]. The
+> This is a lightly edited cross-post of [the official security advisory][advisory]. The
 > official advisory contains a signed version with our PGP key, as well.
 
 [advisory]: https://groups.google.com/g/rustlang-security-announcements/c/bKPH8XYMvJU


### PR DESCRIPTION
It's quite hyperbolic to say that this is a "vulnerability" in unicode, this is a by-design feature that I do not think Unicode intends to get rid of. It's also not quite a vulnerability in text editors. We're trying to clarify that it's not a Rust flaw but we don't need to assign the flaw to a different entity to do so, rather we can describe it as what it is and just say it's not quite a Rust flaw.