### PR TITLE
Try using real bidi in CVE-2021-42574.md

### DIFF
--- a/posts/2021-11-01-cve-2021-42574.md
+++ b/posts/2021-11-01-cve-2021-42574.md
@@ -38,7 +38,13 @@ codepoint `NNNN`):
 if access_level != "user{U+202E} {U+2066}// Check if admin{U+2069} {U+2066}" {
 ```
 
-...would be rendered by bidirectional-aware tools as:
+... looks like this:
+
+```rust
+if access_level != "user‮ ⁦// Check if admin⁩ ⁦" {
+```
+
+... which would be rendered by bidirectional-aware tools in this order:
 
 ```rust
 if access_level != "user" { // Check if admin


### PR DESCRIPTION
This wouldn't really matter, except that the syntax highlighting is different.
Alternative: just disable the highlighting.

[I can certainly see why you wouldn't want to include the bidi characters in the email :-).]