### PR TITLE
Add File::options to 1.58

### DIFF
--- a/posts/2022-01-13-Rust-1.58.0.md
+++ b/posts/2022-01-13-Rust-1.58.0.md
@@ -133,6 +133,7 @@ The following methods and trait implementations were stabilized.
 - [`Option::unwrap_unchecked`]
 - [`Result::unwrap_unchecked`]
 - [`Result::unwrap_err_unchecked`]
+- [`File::options`]
 
 The following previously stable functions are now `const`.
 
@@ -151,6 +152,7 @@ The following previously stable functions are now `const`.
 [`Option::unwrap_unchecked`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.unwrap_unchecked
 [`Result::unwrap_unchecked`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html#method.unwrap_unchecked
 [`Result::unwrap_err_unchecked`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html#method.unwrap_err_unchecked
+[`File::options`]: https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.options
 [`Duration::new`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.new
 [`Duration::checked_add`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.checked_add
 [`Duration::saturating_add`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.saturating_add


### PR DESCRIPTION
I missed this as a late addition to the release notes in rust-lang/rust#92703.