### PR TITLE
Fix typo in CVE-2022-21658 post

### DIFF
--- a/posts/2022-01-20-cve-2022-21658.md
+++ b/posts/2022-01-20-cve-2022-21658.md
@@ -10,7 +10,7 @@ author: The Rust Security Response WG
 [advisory]: https://groups.google.com/g/rustlang-security-announcements/c/R1fZFDhnJVQ
 
 The Rust Security Response WG was notified that the `std::fs::remove_dir_all`
-standard library function is vulnerable a race condition enabling symlink
+standard library function is vulnerable to a race condition enabling symlink
 following (CWE-363). An attacker could use this security issue to trick a
 privileged program into deleting files and directories the attacker couldn't
 otherwise access or delete.
@@ -29,7 +29,7 @@ follow the symlink from `temp/foo` to `sensitive/` while recursively deleting,
 resulting in `sensitive/` being deleted.
 
 To prevent such attacks, `std::fs::remove_dir_all` already includes protection
-to avoid recursively deleting symlinks, as described in its documentation:
+to avoid recursively deleting symlinks, as described in [its documentation][4]:
 
 > This function does **not** follow symbolic links and it will simply remove
 > the symbolic link itself.
@@ -87,3 +87,4 @@ Crichton for writing the WASI fix, and Mara Bos for reviewing the patches.
 [1]: https://www.cve.org/CVERecord?id=CVE-2022-21658
 [2]: https://github.com/rust-lang/wg-security-response/tree/master/patches/CVE-2022-21658
 [3]: https://www.rust-lang.org/policies/security
+[4]: https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html


### PR DESCRIPTION
Also add a link to docs for `std::fs::remove_dir_all`