### PR TITLE
Fix 2022-01-18-jan-steering-cycle.md

### DIFF
--- a/posts/inside-rust/2022-01-18-jan-steering-cycle.md
+++ b/posts/inside-rust/2022-01-18-jan-steering-cycle.md
@@ -5,6 +5,7 @@ author: Felix Klock
 description: "The compiler team's January 2022 steering cycle"
 team: The Compiler Team <https://www.rust-lang.org/governance/teams/compiler>
 ---
+
 On [Friday, January 14th][jan-14-zulip-archive], the Rust Compiler team had a planning meeting for the January steering cycle.
 
 [jan-14-zulip-archive]: https://zulip-archive.rust-lang.org/stream/238009-t-compiler/meetings/topic/.5Bplanning.20meeting.5D.202022-01-14.html


### PR DESCRIPTION
I think due to the missing new line, the first letter of `On Friday...` is not rendered correctly. See screenshot:
![Screen Shot 2022-01-20 at 3 11 53 PM](https://user-images.githubusercontent.com/5137691/150436944-f5ec1c8c-53a6-41e8-a7be-3c261aaf7852.png)

I checked another blog post, and it has the new line before the main body: https://raw.githubusercontent.com/rust-lang/blog.rust-lang.org/master/posts/inside-rust/2022-01-11-1.58.0-prerelease.md
