### PR TITLE
Fix link to source-based code coverage guide

### DIFF
--- a/posts/inside-rust/2020-11-12-source-based-code-coverage.md
+++ b/posts/inside-rust/2020-11-12-source-based-code-coverage.md
@@ -69,7 +69,7 @@ request].
 
 [MCP]: https://github.com/rust-lang/compiler-team/issues/278
 [PRs]: https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Arichkadel+is%3Aclosed+closed%3A%3C2020-11-06
-[guide]: https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html
+[guide]: https://doc.rust-lang.org/nightly/rustc/instrument-coverage.html
 [report them]: https://github.com/rust-lang/rust/issues/new/choose
 [Zulip stream]: https://rust-lang.zulipchat.com/#narrow/stream/233931-t-compiler.2Fmajor-changes/topic/Implement.20LLVM-compatible.20source-based.20cod.20compiler-team.23278
 [feature request]: https://github.com/rust-lang/rust/issues/34701


### PR DESCRIPTION
When I searched for "rust code coverage", this blog post was the very first result in Google. The "Take a look at the guide" link, however, 404'd. I've found what I *think* is the best replacement link, but I'm happy to correct it if there is a better source of info.