### PR TITLE
Compiler team 2022 ambitions

### DIFF
--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -1,24 +1,20 @@
 ---
-title: T-compiler Ambitions in 2022
-breaks: false
+layout: post
+title: Rust Compiler Ambitions for 2022
+author: Felix Klock, Wesley Wiser
+description: "The compiler team's concrete initiatives and hopeful aspirations for this year."
+team: The Compiler Team <https://www.rust-lang.org/governance/teams/compiler>
 ---
 
-# T-compiler Ambitions in 2022
-
-*Editor's note: Previously considered titles include: ~~T-compiler 2022 roadmap~~, ~~T-compiler astrological chart~~, ~~T-compiler horoscope~~, ~~T-compiler fortune cookies~~, ~~T-compiler crystal ball~~. Other suggestions welcome!* 
-
-*Editor's note: Our intent is to post this on the Inside Rust blog in the near future, circa February 18th. You can consider it an early preview; we want feedback from the members of T-compiler and T-compiler-contributors before we circulate it more broadly. You can post comments in the HackMD margin, or send us an email, or write in a [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/roadmap.20for.202022.20discussion/near/270258331).*
+# Rust Compiler Ambitions for 2022
 
 Some people have been wondering about what the Rust Compiler Team has planned for 2022. This note is to let you all know what activities the team plans to focus on this year.
 
 This document is structured into three parts: our [Overall Themes][] for this year, the [Concrete Initiatives][] we have resources to drive, and [Aspirations][] for what we could do if given more help.
 
-
 [Overall Themes]: #Overall-Themes
 [Concrete Initiatives]: #Concrete-Initiatives
 [Aspirations]: #Aspirations
-
-[toc]
 
 ## Introduction
 
@@ -119,6 +115,37 @@ Finally, improving the Compiler Contributor Workflow means technology enhancemen
 [Compiler Backend]: #Compiler-Backend
 [Review Queue Crew]: #Review-Queue-Crew
 
+Category  | [Concrete Initiatives] |  [Aspirations]
+----------|---------------------|-----------
+I-unsound | [Initiatives][I-unsound Issues]      |
+Async Rust| [Initiatives][Async Initiatives]     |
+Debugging | [Initiatives][Debugging Initiatives] | [Aspirations][Debugging Aspirations]
+Faster Builds | [Initiatives][Faster Builds Initiatives] | [Aspirations][Faster Builds Aspirations]
+Expressiveness     | [Initiatives][Expressiveness Initiatives] | [Aspirations][Expressiveness Aspirations]
+Librarification    | [Initiatives][Librarification Initiatives]                 | [Aspirations][Librarification Aspirations]
+Team Operations    |                             | [Aspirations][Team Operations]
+Backend            |                             | [Aspirations][Backend Aspirations]
+Diagnostics        |                             | [Aspirations][Diagnostics Aspirations]
+
+[Concrete Initiatives]: #concrete-initiatives
+[I-unsound Issues]: #i-unsound-issues-
+[Async Initiatives]: #async-rust-initiatives--
+[Debugging Initiatives]: #debugging-initiatives-
+[Faster Builds Initiatives]: #faster-builds-initiatives--
+[Expressiveness Initiatives]: #expressiveness-initatives--
+[Librarification Initiatives]: #librarification-initiatives-
+[Aspirations]: #aspirations
+[P-high Aspirations]: #p-high-aspirations-
+[Debugging Aspirations]: #debugging-aspirations-
+[Faster Builds Aspirations]: #faster-builds-aspirations--
+[Expressiveness Aspirations]: #expressiveness-aspirations--
+[Librarification Aspirations]: #librarification-aspirations-%EF%B8%8F
+[Team Operations]: #compiler-team-operations-aspirations-%EF%B8%8F
+[Backend Aspirations]: #compiler-backend-aspirations-%EF%B8%8F-
+[Diagnostics Aspirations]: #diagnostics-aspirations-
+
+<!-- end of manually made [toc] -->
+
 ## Concrete Initiatives
 
 This section is the closest thing to a "roadmap" we have for 2022. It is a list of important items with dedicated owners that have time allocated to make significant progress on the problem this year. 
@@ -149,19 +176,19 @@ There is a ton of other work being done in the Async Rust space. Check out the [
 
 
 ### Debugging Initiatives (🦀)
- 
+
 [wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([mw], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]).
 
 The immediate goals for this initiative: establish the working group, determine priorities for the backlog of debugging issues, and find out what active users of debuggers miss most when they operate on Rust code.
 
-### Compilation Time Initiatives (👩‍💻, 🛠️)
+### Faster Builds Initiatives (👩‍💻, 🛠️)
  
 The Rust compiler's end-to-end latency is known to be a problem.
- 
+
 [lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation.
 
 [ISRG]: https://www.abetterinternet.org/
- 
+
 ### Expressiveness Initiatives (👩‍💻, 🦀)
 
 A common refrain we hear is: "I need feature X, but it's not implemented in rustc or stable." 
@@ -213,7 +240,7 @@ We want to revisit our debugger extension architecture for rendering Rust data s
 
 If you want to help out here, please reach out to [pnkfelix] and [wesleywiser].
 
-### Faster Compilation Aspirations (👩‍💻, 🛠️)
+### Faster Builds Aspirations (👩‍💻, 🛠️)
 
 #### Parallel Compilation
 
@@ -355,18 +382,6 @@ This is not a problem! Many members of our community learned about compilers by 
 [Contributing to the Compiler]: https://www.youtube.com/watch?v=vCODCbUSA_w
 
 In addition, there are areas in this project where people without compiler expertise can have impact. For example, as mentioned in the [Performance Dashboard](#Performance-Dashboard) section, some of our internal tools could use some web front-end work.
-
-## 2022-02-18 Meeting Questions/Comments/Issues
-
-- We should explicitly state that we are using emojis to categorize topics by the high-level area they relate to.
-- pnkfelix: there should be a FAQ entry for "why aren't you putting in Monads" (half joke), where answer is "The scope of this doc is largely restricted to Compiler Team issues. Language design work is done by the Language Design team."
-- jackh726: Nit `LendingItetator` instead of `StreamingIterator`
-- simulacrum: What are our goals for progress reporting, if any? Should we plan for a +1 year blog post, at least?
-    - This 'planning' might mean something as simple as asking folks working on things to add PRs, etc. to a list we can then reference, or something more involved.
-
-- pnkfelix: comments say we should highlight need for code quality benchmarks as part of performance work. What can/should we say on that front?
-
-
 
 
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -266,7 +266,7 @@ If you want to discuss more with us about past attempts and ideas for the future
 
 Incremental compilation performance and stability are both ongoing concerns to the team. We *know* there is significant room to improve the effectiveness of incremental compilation, in terms of reducing the amount of redundant work done by successive `rustc` invocations.
 
-In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compiliation which does not require deep knowledge of the compiler.
+In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compilation which does not require deep knowledge of the compiler.
 
 If you want to learn more, reach out to [cjgillot] and [Aaron Hill].
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -409,7 +409,7 @@ Owner | Zulip Username | Accepting sponsorships?
 [estebank] | `@Esteban Küber` | No: works on Rust at Amazon Web Services
 [jackh726] | `@Jack Huey` | No
 [jswrenn] | `@Jack Wrenn` | No: works on Rust at Amazon Web Services
-[lcnr] | `@lcnr` | Yes: https://lcnr.de/funding/
+[lcnr] | `@lcnr` | Yes: [https://lcnr.de/funding/](https://lcnr.de/funding/)
 [lqd] | `@lqd` | No: sponsored by the Internet Security Research Group
 [Mark-Simulacrum] | `@simulacrum` | Yes, [GitHub Sponsors](https://github.com/sponsors/Mark-Simulacrum)
 [michaelwoerister] | `@mw` | No: works on Rust at Microsoft

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -394,7 +394,7 @@ This is not a problem! Many members of our community learned about compilers by 
 
 In addition, there are areas in this project where people without compiler expertise can have impact. For example, as mentioned in the [Performance Dashboard](#Performance-Dashboard) section, some of our internal tools could use some web front-end work.
 
-### How can I contact an item's owners or sponsor their work on Rust?
+#### How can I contact an item's owners or sponsor their work on Rust?
 
 This table lists the item owners mentioned above, their [Zulip] username and if they are accepting sponsorships to help them work on Rust:
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -212,7 +212,7 @@ In Rust, we use an open Request-for-Comment (RFC) process for designing new feat
 
 [RFC tracking issue list]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AC-tracking-issue++label%3AB-RFC-approved+
 
-Generic Associated Types, or [GATs](https://github.com/rust-lang/generic-associated-types-initiative/issues/4), are an ongoing effort owned by [jackh726]. GATs have many applications, such as traits whose associated types have lifetimes tied to the local borrowing of the receiver type ([e.g. `StreamingIterator`][GAT-motivation]).
+Generic Associated Types, or [GATs](https://github.com/rust-lang/generic-associated-types-initiative/issues/4), are an ongoing effort owned by [jackh726]. GATs have many applications, such as traits whose associated types have lifetimes tied to the local borrowing of the receiver type ([e.g. `LendingIterator`][GAT-motivation]).
 
 [GAT-motivation]: https://github.com/rust-lang/rfcs/blob/master/text/1598-generic_associated_types.md#motivation
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -184,8 +184,8 @@ The immediate goals for this initiative: establish the working group, determine 
 ### Faster Builds Initiatives (👩‍💻, 🛠️)
  
 The Rust compiler's end-to-end latency is known to be a problem.
-
-[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation.
+ 
+[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA).
 
 [ISRG]: https://www.abetterinternet.org/
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -21,7 +21,7 @@ This document is structured into three parts: our [Overall Themes][] for this ye
 Part of the motivation for this note is to encourage new contributors to get involved. We have a lot of newcomers, from individuals to large organizations, who are very excited about Rust's potential, and we want to show all of them what they can do to help.
 
 This is a list of items, divided into a [Concrete Initiatives][] section and an [Aspirations][] section. We accumulated these items during discussions with the Compiler Team and the Compiler Contributors.
-The [Concrete Initiatives][] have owners assigned; each has  allocated time this year to attack the problem. The [Aspirations][], on the other hand, are items that the team agrees would be great areas for investment, but where we currently lack sufficient resources or experienced developers to make progress this year.
+The [Concrete Initiatives][] have owners assigned; each has allocated time this year to attack the problem. The [Aspirations][], on the other hand, are items that the team agrees would be great areas for investment but where we currently lack sufficient resources or experienced developers to make progress this year.
 
 This is *not* a list of everything we will do this year; at least, not without help.
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -1,0 +1,375 @@
+---
+title: T-compiler Ambitions in 2022
+breaks: false
+---
+
+# T-compiler Ambitions in 2022
+
+*Editor's note: Previously considered titles include: ~~T-compiler 2022 roadmap~~, ~~T-compiler astrological chart~~, ~~T-compiler horoscope~~, ~~T-compiler fortune cookies~~, ~~T-compiler crystal ball~~. Other suggestions welcome!* 
+
+*Editor's note: Our intent is to post this on the Inside Rust blog in the near future, circa February 18th. You can consider it an early preview; we want feedback from the members of T-compiler and T-compiler-contributors before we circulate it more broadly. You can post comments in the HackMD margin, or send us an email, or write in a [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/roadmap.20for.202022.20discussion/near/270258331).*
+
+Some people have been wondering about what the Rust Compiler Team has planned for 2022. This note is to let you all know what activities the team plans to focus on this year.
+
+This document is structured into three parts: our [Overall Themes][] for this year, the [Concrete Initiatives][] we have resources to drive, and [Aspirations][] for what we could do if given more help.
+
+
+[Overall Themes]: #Overall-Themes
+[Concrete Initiatives]: #Concrete-Initiatives
+[Aspirations]: #Aspirations
+
+[toc]
+
+## Introduction
+
+Part of the motivation for this note is to encourage new contributors to get involved. We have a lot of newcomers, from individuals to large organizations, who are very excited about Rust's potential, and we want to show all of them what they can do to help.
+
+This is a list of items, divided into a [Concrete Initiatives][] section and an [Aspirations][] section. We accumulated these items during discussions with the Compiler Team and the Compiler Contributors.
+The [Concrete Initiatives][] have owners assigned; each has  allocated time this year to attack the problem. The [Aspirations][], on the other hand, are items that the team agrees would be great areas for investment, but where we currently lack sufficient resources or experienced developers to make progress this year. 
+
+This is *not* a list of everything we will do this year; at least, not without help.
+
+You can think of the [Aspirations][] part of the doc as an explicit call to arms: If you see something there that interests you, please reach out to the owners listed in that section to find out how you might be able to help.
+
+As you read the document, it is useful to keep in mind that [Rust is not a company][mara-post]: The teams, and the leaders of the teams, do not establish goals in a top-down manner, nor do they hand out tasks in a round-robin fashion. Instead, we collectively (and iteratively) refine our a shared vision for the future, and take steps that hopefully move towards that future. Each contributor decides for themself how much time they can afford to contribute, and that can vary wildly between contributors. The goals that we set for the project must be aligned with the goals of our current and future contributors; otherwise, they just won't get done. We have processes (e.g. [RFCs](https://github.com/rust-lang/rfcs#readme), [MCPs](https://forge.rust-lang.org/compiler/mcp.html)) that try to ensure alignment; in some ways, a document like this one is just another tool for recalibrating alignment.
+
+<!-- 
+But the flip side of this is: if something really is important, then there almost certainly exists a contributor willing to work on it. The real hurdle then is *enabling* that contributor to succeed.
+(Note: this is hard! Its not just about mentorship/education; its just as much about achieving *alignment* amongst the whole group!)
+-->
+
+[mara-post]: https://blog.m-ou.se/rust-is-not-a-company/
+
+[antoyo]: https://github.com/antoyo
+<!-- antoyo sponsorship: https://github.com/sponsors/antoyo -->
+[Aaron Hill]: https://github.com/Aaron1011
+<!-- Aaron1011: no affiliation -->
+[bjorn3]: https://github.com/bjorn3
+<!-- bjorn3 donation page: https://liberapay.com/bjorn3 -->
+[cjgillot]: https://github.com/cjgillot
+<!-- no response from cjgillot re affiliation yet -->
+[davidtwco]: https://github.com/davidtwco
+<!-- davidtwco affiliation: "Huawei R&D UK"-->
+[estebank]: https://github.com/estebank
+<!-- estebank affiliation: AWS --> 
+[lcnr]: https://github.com/lcnr
+<!-- lcnr sponsorship: https://lcnr.de/funding/ -->
+[mw]: https://github.com/michaelwoerister
+<!-- mw affiliation: MS -->
+[nikomatsakis]: https://github.com/nikomatsakis
+<!-- nikomatsakis affiliation: AWS -->
+[oli-obk]: https://github.com/oli-obk
+<!-- oli affiliation: AWS --> 
+[jackh726]: https://github.com/jackh726
+<!-- jackh726: no affiliation -->
+[lqd]: https://github.com/lqd
+<!-- lqd affiliation: ISRG -->
+[nnethercote]: https://github.com/nnethercote
+<!-- nnethercote affiliation: Futurewei -->
+[tmandry]: https://github.com/tmandry
+<!-- tmandry affiliation: Google (TBD) -->
+[scottmcm]: https://github.com/scottmcm
+<!-- scottmcm: no affiliation -->
+[pnkfelix]: https://github.com/pnkfelix
+<!-- pnkfelix affiliation: AWS -->
+[wesleywiser]: https://github.com/wesleywiser
+<!-- wesleywiser affiliation: MS -->
+[jswrenn]: https://github.com/jswrenn
+<!-- jswrenn affiliation: AWS -->
+[apiraino]: https://github.com/apiraino
+<!-- apiraino: no affiliation -->
+[simulacrum]: https://github.com/Mark-simulacrum
+<!-- simulacrum sponsorship: https://github.com/sponsors/Mark-Simulacrum -->
+[rylev]: https://github.com/rylev
+<!-- rylev affiliation: MS -->
+[xldenis]: https://github.com/xldenis
+
+## Overall Themes
+
+### Fulfill Rust's Promise (🦀)
+
+Fulfilling Rust's Promise is a cross-cutting theme; it means identifying the gaps between expectation and reality for each of our three pillars: [Performance, Reliability, and Productivity][rust-lang], and then addressing those gaps.
+
+
+[rust-lang]: https://www.rust-lang.org
+
+### Developer Delight (👩‍💻)
+
+We have opportunities to improve the experience of writing, of compiling, and of running Rust code. We want answers to the question, "what would delight Rust developers?" This is not about meeting their expectations: It's about *surpassing* them.
+
+
+[Debugging concrete]: #Debugging-Initiatives
+[Debugging aspirational]: #Debugging-Aspirations
+[Debugging]: #Debugging-Object-Code
+[Faster concrete]: #Compilation-Time-Initiatives
+[Faster aspirational]: #Faster-Compilation-Aspirations
+[Expressiveness concrete]: #Language-Expressiveness-Initiatives
+[Expressiveness aspirational]: #Expressiveness-Aspirations
+
+### Contributor Workflow (🛠️)
+
+Finally, improving the Compiler Contributor Workflow means technology enhancements that benefit people maintaining and extending the Rust compiler itself.
+
+(We also make non-technical enhancements, such as changes to our social processes, but this document focuses on technology.)
+
+
+[Librarification Initiatives]: #Librarification-Initiatives
+[Librarification Aspirations]: #Librarification-Aspirations
+
+[Compiler Backend]: #Compiler-Backend
+[Review Queue Crew]: #Review-Queue-Crew
+
+## Concrete Initiatives
+
+This section is the closest thing to a "roadmap" we have for 2022. It is a list of important items with dedicated owners that have time allocated to make significant progress on the problem this year. 
+
+### I-unsound issues (🦀)
+
+As of this writing, we have 69 [open issues tagged I-unsound](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AI-unsound), and 44 of those are [also tagged T-compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AI-unsound++label%3AT-compiler).
+
+
+In theory, any unsoundness issue potentially undermines Rust's promise of reliability. We want, by the end of this year, to have a clear understanding of how each of those I-unsound issues came to be. We are looking into systematically detecting such issues and whether we can deploy mitigations or fixes for entire classes of issues, instead of addressing them on a case by case basis.
+
+[oli-obk], from Amazon Web Services, will be the primary owner of  work in this space. Please reach out to [oli-obk] and [pnkfelix] (also from Amazon Web Services) if you are interested in helping resolve these issues!
+
+
+### Async Rust Initiatives (🦀, 👩‍💻)
+
+There is significant overlap between async rust and other areas of this document, such as debugging and language expressiveness.
+
+#### async traits
+
+Rust today does not allow `async fn` in a trait, so Async Rust code usually ends up with components that are too tightly coupled; one cannot write reusable, general-purpose libraries without using workarounds like `#[async_trait]` that impose hidden costs. [nikomatsakis], from Amazon Web Services, and [tmandry], from Google, are driving the [async fn in traits initiative](https://github.com/rust-lang/async-fundamentals-initiative/issues/5), which will unlock the ability to write `async` methods in traits, natively.
+
+#### async crashdump dissection
+
+[mw], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs.
+
+There is a ton of other work being done in the Async Rust space. Check out the [Async Vision web site](https://rust-lang.github.io/wg-async/welcome.html) for more information.
+
+
+### Debugging Initiatives (🦀)
+ 
+[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([mw], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]).
+
+The immediate goals for this initiative: establish the working group, determine priorities for the backlog of debugging issues, and find out what active users of debuggers miss most when they operate on Rust code.
+
+### Compilation Time Initiatives (👩‍💻, 🛠️)
+ 
+The Rust compiler's end-to-end latency is known to be a problem.
+ 
+[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation.
+
+[ISRG]: https://www.abetterinternet.org/
+ 
+### Expressiveness Initiatives (👩‍💻, 🦀)
+
+A common refrain we hear is: "I need feature X, but it's not implemented in rustc or stable." 
+In Rust, we use an open Request-for-Comment (RFC) process for designing new features. Currently, we have [this set of RFCs approved][RFC tracking issue list]; here are some imporant features with dedicated owners that we expect forward movement on.
+
+[RFC tracking issue list]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AC-tracking-issue++label%3AB-RFC-approved+
+
+Generic Associated Types, or [GATs](https://github.com/rust-lang/generic-associated-types-initiative/issues/4), are an ongoing effort owned by [jackh726]. GATs have many applications, such as traits whose associated types have lifetimes tied to the local borrowing of the receiver type ([e.g. `StreamingIterator`][GAT-motivation]).
+
+[GAT-motivation]: https://github.com/rust-lang/rfcs/blob/master/text/1598-generic_associated_types.md#motivation
+
+[`async fn` in traits](https://github.com/rust-lang/async-fundamentals-initiative/issues/5) is an ongoing effort (already mentioned above) owned by [tmandry]. This is one of the most frequently requested features for async rust: supplying first class support for traits like `trait Foo { async fn bar(&self); }`
+
+The [safe transmute](https://github.com/rust-lang/lang-team/issues/21) project, led by [jswrenn] from Amazon Web Services, is expected to be feature-complete in summer 2022. It will enable a large class of types to be transmuted (i.e. zero-cost type conversion) without any risk of injecting undefined behavior.
+
+### Librarification Initiatives (🛠️)
+
+These are initiatives dedicated to the "librarification" of the compiler: breaking the monolithic code base of `rustc` into a set of decoupled parts that can be independently developed, and, ideally, repurposed for other kinds of tools besides `rustc` such as `rust-analyzer`.
+
+#### Chalk
+
+[Chalk] is a reimplementation of Rust's trait system using declarative logic rules, a la Prolog.
+
+[Chalk]: https://github.com/rust-lang/chalk
+
+Chalk has been years in development, and has been experimentally integrated into rustc in the past. This year, [jackh726] and [nikomatsakis] own the task of improving the chalk integration, to drive it to the point where the team can consider migrating to chalk as the implementation of the trait system. This will unlock many features that up until now have been too difficult to implement in the old trait system implementation, and its declarative structure will provide a proper foundation for people to reason about the *correctness* of the trait system.
+
+If you want to help out with this, reach out to [jackh726] and [nikomatsakis].
+
+## Aspirations
+
+We would love help with any of the areas listed on this document, but this section specifically lists areas where we know we lack resources today.
+
+If you are interested in helping with any items here, please do reach out to the owner listed; they will be thrilled to talk to you.
+
+### P-high Aspirations (🦀)
+
+[pnkfelix] and [wesleywiser], as team leads, are deploying processes to help us get a handle on the "high priority, but *not critical*" issues that the compiler has accumulated. We will be gradually identifying owners for each who will move progress forward, and in general working to keep better track of the set overall.
+
+If you would like to help with the task of reviewing or resolving such issues, reach out to [wesleywiser] and [apiraino], who are co-leads of WG-prioritization.
+
+### Debugging Aspirations (👩‍💻)
+
+We want better integration, at least with the popular debuggers. The command sequence to set up an idealized debugging experience is too obscure and therefore goes unused.
+
+We want to improve expression evaluation support: Today, most forms of method invocation do not work, because the debuggers do not know about Rust's method resolution rules.
+
+We want to revisit our debugger extension architecture for rendering Rust data structures, which is currently mostly independent sets of Python scripts.
+
+If you want to help out here, please reach out to [pnkfelix] and [wesleywiser].
+
+### Faster Compilation Aspirations (👩‍💻, 🛠️)
+
+#### Parallel Compilation
+
+Parallel Compilation is one avenue for improving compiler performance. It is also a very complex area, especially when it comes to the tradeoff of how much of a hit one is willing to take on single core builds in order to enable more parallel computation. This is an area we think needs long-term collaborative effort with the compiler team. We do not expect to deliver a solution here this year.
+
+If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser]. 
+
+#### Incremental Compilation Aspirations
+
+Incremental compilation performance and stability are both ongoing concerns to the team. We *know* there is significant room to improve the effectiveness of incremental compilation, in terms of reducing the amount of redundant work done by successive `rustc` invocations. 
+
+In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compiliation which does not require deep knowledge of the compiler. 
+
+If you want to learn more, reach out to [cjgillot] and [Aaron Hill].
+
+#### Inter-crate Sharing Aspirations
+
+nnethercote has noted that there may be opportunities
+to improve end-to-end compilation time for multi-crate builds by identifying redundant activity that can be shared between builds of distinct crates. (For example, the metadata from libstd is read and decoded on every single crate compile.)
+
+If you are interested in exploring this idea further, reach out to [nnethercote] and [lqd].
+
+### Expressiveness Aspirations (🦀, 👩‍💻)
+
+const generics and const eval are making steady progress. There are a *lot* of feature flags, which implies there's a lot of knobs that could be turned on and off.
+
+What we can probably use the most help with is in identifying what subset of the features we should be striving to stabilize in order to unlock specific use cases for Rust developers.
+
+So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] (supported via [sponsorship][sponsor-lcnr]) and [oli-obk].
+
+[sponsor-lcnr]: https://lcnr.de/funding/
+
+### Librarification Aspirations (🛠️)
+
+#### MIR tooling
+
+Various stakeholders, especially in the formal methods space, are making extensions to Rust that are based on analyzing MIR, the intermediate representation used by the compiler. Should we be trying to stabilize that as an interop format of some kind?
+
+For example, [Kani] is a bit-precise model-checker for Rust under development at Amazon Web Services. It is implemented as another backend on `rustc`; but it would be cleaner if rustc could just generate MIR and their compiler could consume MIR. [Prusti] and [Creusot] could likewise benefit from a stable MIR interop.
+
+[Kani]: https://github.com/model-checking/kani
+[Prusti]: https://github.com/viperproject/prusti-dev#prusti
+[Creusot]: https://github.com/xldenis/creusot#about
+
+Reach out to [xldenis], from the LMF at the University of Paris-Saclay (and co-lead of the Rust Formal Methods working group), and [pnkfelix] if you are interested in helping us here.
+
+### Compiler Team Operations Aspirations (🛠️)
+
+#### MCVE reduction tooling
+
+One common task for compiler developers is to create a [minimal complete verifiable example][E-needs-mcve]. This task is largely mechanical; pnkfelix has a [blog post][mcve blog post] about Rust source-to-source tranformations that accomplish this. But despite its mechanical nature, the current state of the art in automating this task is in tools like [creduce](https://github.com/csmith-project/creduce), which have some big limitations (such as only working on a single file at a time).
+
+This is an area where you do not need any knowledge of the `rustc` source code at all. Anyone with an interest in programming language technology can get involved; e.g. one might consider adding IDE commands for certain code reducing transformations.
+
+If you are interested in helping in this area, please reach out to [pnkfelix].
+
+[E-needs-mcve]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-needs-mcve+
+[mcve blog post]: https://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
+
+#### Performance Dashboard
+
+[perf.rust-lang.org][perf] is a dashboard that measures the performance of `rustc`, in terms of resources (time and memory) consumed during compilation. [@rust-timer] is a bot that summarizes whether a given Pull Request regressed or improved performance. 
+
+The performance working group has many ideas for things to improve in these tools, but limited resources. This is an area where you don't need any compiler expertise to make a huge impact; for example, our Web Front-end could use work. And Data Scientists might have useful insights into our problems. Beyond just measuring the compiler's own performance, we're also interested in measuring the runtime performance of produced binaries.
+
+Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help.
+
+[@rust-timer]: https://github.com/rust-timer
+[perf]: https://perf.rust-lang.org/
+
+### Compiler Backend Aspirations (🛠️, 👩‍💻)
+
+#### Ease writing new backends
+
+One source of tedium when defining a new Rust compiler backend is implementing the intrinsics that each backend must provide. But a small change to the intrinsic system: namely, allowing intrinsics to define a [fallback MIR implementation][], could ease that burden. Reach out to [scottmcm] if you are interested in helping out here.
+
+[fallback MIR implementation]: https://github.com/rust-lang/rust/issues/93145
+
+#### Cranelift
+
+The [Cranelift Code Generator][Cranelift] is getting a lot of attention from various parties. rustc has a [Cranelift backend][]. If you are interested in helping out with it, reach out to [bjorn3] (supported via [sponsorship][sponsor-bjorn3]).
+
+[sponsor-bjorn3]: https://liberapay.com/bjorn3
+
+[Cranelift]: https://github.com/bytecodealliance/wasmtime/tree/main/cranelift
+[Cranelift backend]: https://github.com/bjorn3/rustc_codegen_cranelift
+
+#### GCC backend
+
+In addition to the LLVM and Cranelift backends, there is also a new backend under development that uses `libgccjit` from GCC (which, as many have clarified, is usable for ahead-of-time as well as just-in-time compilation). This backend enables Rust to target more platforms that are not supported by LLVM.
+
+If you are interested in helping out with this project, reach out to [antoyo] (supported via [sponsorship](https://github.com/sponsors/antoyo)) and [bjorn3].
+
+
+### Diagnostics Aspirations (👩‍💻)
+
+The Rust compiler has pretty good diagnotics. But the good news is, there's a [full employment theorem](https://en.wikipedia.org/wiki/Full_employment_theorem) for diagnostics engineers which is supported by the 1,500+ [open diagnostics issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics) we have.
+
+Diagnostics improvements are an *excellent* first step for learning about how to contribute to the Rust compiler. If you're interested in helping out but don't have any idea where to start, fixing diagnostic bugs is a great jumping off point, and you can reach out to [estebank], at Amazon Web Services, to find out more about how to help.
+
+
+## Conclusion
+
+Reading over this list, the number of items on it seems quite daunting.
+
+Do we really think we can get all this stuff done in one year?
+
+No, we don't! :laughing:
+
+The introduction explicitly said the latter half are things that *don't* have resources attached to them. And the word "aspiration" was chosen to reinforce that.
+
+This is where you all, the Rust community (including *future members* of that community) come into the picture. Each item has one or two people listed with it; if you're feeling inspired, please do contact us!
+
+## FAQ
+
+#### How can I learn about progress on all this stuff? Will we see another post like this soon?
+
+The Rust project constantly  experiments with different ways to track progress on its on-going initiatives. We do not yet have a single place that summarizes the status of everything, though there is some effort towards making better use of Github Projects for this; see e.g. what the lang team is doing with its [initiatives](https://github.com/orgs/rust-lang/projects/16).
+
+The compiler team leadership plans to put out a post in June summarizing the progress so far on the items listed here, and another post in November with a retrospective on how the year went.
+
+#### I did not see any mention of monadic burritos (or other non-Rust language feature); why is that not part of your plan?
+
+The scope of this doc is largely restricted to Compiler Team issues. Language design work is done by the Language Design team. You can reach out to them about their initiatives for this year and beyond.
+
+#### What do I do if I'm interested in learning more about a specific item on this list?
+
+Each item in this list has one or more owners listed with it. The Rust Compiler team largely communicates via the [Zulip] chat platform.
+
+So: set up a Zulip account, sign into it, and then send a private message to the relevant owners, telling them that you want to help with their rustc initiatives. They'll help you get started from there.
+
+[Rustc Dev Guide]: https://rustc-dev-guide.rust-lang.org/
+[Zulip]: https://rust-lang.zulipchat.com/ 
+
+#### What do I do if I'm interested in compiler development but have no experience in compilers?
+
+This is not a problem! Many members of our community learned about compilers by working on rustc, and we encourage others to do so as well. You can start by reading the [Rustc Dev Guide] and by joining us on [Zulip]. You may also benefit from watching the RustConf 2021 presentation on [Contributing to the Compiler] by [estebank].
+
+[Contributing to the Compiler]: https://www.youtube.com/watch?v=vCODCbUSA_w
+
+In addition, there are areas in this project where people without compiler expertise can have impact. For example, as mentioned in the [Performance Dashboard](#Performance-Dashboard) section, some of our internal tools could use some web front-end work.
+
+## 2022-02-18 Meeting Questions/Comments/Issues
+
+- We should explicitly state that we are using emojis to categorize topics by the high-level area they relate to.
+- pnkfelix: there should be a FAQ entry for "why aren't you putting in Monads" (half joke), where answer is "The scope of this doc is largely restricted to Compiler Team issues. Language design work is done by the Language Design team."
+- jackh726: Nit `LendingItetator` instead of `StreamingIterator`
+- simulacrum: What are our goals for progress reporting, if any? Should we plan for a +1 year blog post, at least?
+    - This 'planning' might mean something as simple as asking folks working on things to add PRs, etc. to a list we can then reference, or something more involved.
+
+- pnkfelix: comments say we should highlight need for code quality benchmarks as part of performance work. What can/should we say on that front?
+
+
+
+
+
+
+
+

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -337,7 +337,7 @@ Reading over this list, the number of items on it seems quite daunting.
 
 Do we really think we can get all this stuff done in one year?
 
-No, we don't! :laughing:
+No, we don't! 😂
 
 The introduction explicitly said the latter half are things that *don't* have resources attached to them. And the word "aspiration" was chosen to reinforce that.
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -173,7 +173,7 @@ As of this writing, we have 69 [open issues tagged I-unsound](https://github.com
 
 In theory, any unsoundness issue potentially undermines Rust's promise of reliability. We want, by the end of this year, to have a clear understanding of how each of those I-unsound issues came to be. We are looking into systematically detecting such issues and whether we can deploy mitigations or fixes for entire classes of issues, instead of addressing them on a case by case basis.
 
-[oli-obk], from Amazon Web Services, will be the primary owner of  work in this space. Please reach out to [oli-obk] and [pnkfelix] (also from Amazon Web Services) if you are interested in helping resolve these issues! They are `@**oli**` and `@**pnkfelix**` on zulip.
+[oli-obk], from Amazon Web Services, will be the primary owner of  work in this space. Please reach out to [oli-obk] and [pnkfelix] (also from Amazon Web Services) if you are interested in helping resolve these issues! They are `@**oli**` and `@**pnkfelix**` [on zulip].
 
 
 ### Async Rust Initiatives (🦀, 👩‍💻)
@@ -182,18 +182,18 @@ There is significant overlap between async rust and other areas of this document
 
 #### async traits
 
-Rust today does not allow `async fn` in a trait, so Async Rust code usually ends up with components that are too tightly coupled; one cannot write reusable, general-purpose libraries without using workarounds like `#[async_trait]` that impose hidden costs. [nikomatsakis], from Amazon Web Services, and [tmandry], from Google, are driving the [async fn in traits initiative](https://github.com/rust-lang/async-fundamentals-initiative/issues/5), which will unlock the ability to write `async` methods in traits, natively. They are `@**nikomatsakis**` and `@**tmandry**` on zulip.
+Rust today does not allow `async fn` in a trait, so Async Rust code usually ends up with components that are too tightly coupled; one cannot write reusable, general-purpose libraries without using workarounds like `#[async_trait]` that impose hidden costs. [nikomatsakis], from Amazon Web Services, and [tmandry], from Google, are driving the [async fn in traits initiative](https://github.com/rust-lang/async-fundamentals-initiative/issues/5), which will unlock the ability to write `async` methods in traits, natively. They are `@**nikomatsakis**` and `@**tmandry**` [on zulip].
 
 #### async crashdump dissection
 
-[mw], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs. He is `@**mw**` on zulip.
+[mw], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs. He is `@**mw**` [on zulip].
 
 There is a ton of other work being done in the Async Rust space. Check out the [Async Vision web site](https://rust-lang.github.io/wg-async/welcome.html) for more information.
 
 
 ### Debugging Initiatives (🦀)
 
-[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([mw], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]). They are `@**Wesley Wiser**`, `@**pnkfelix**`, `@**mw**` and `@**davidtwco**` on zulip.
+[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([mw], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]). They are `@**Wesley Wiser**`, `@**pnkfelix**`, `@**mw**` and `@**davidtwco**` [on zulip].
 
 The immediate goals for this initiative: establish the working group, determine priorities for the backlog of debugging issues, and find out what active users of debuggers miss most when they operate on Rust code.
 
@@ -201,7 +201,7 @@ The immediate goals for this initiative: establish the working group, determine 
  
 The Rust compiler's end-to-end latency is known to be a problem.
  
-[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA). They are `@**lqd**` and `@**nnethercote**` on zulip.
+[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA). They are `@**lqd**` and `@**nnethercote**` [on zulip].
 
 [ISRG]: https://www.abetterinternet.org/
 
@@ -220,7 +220,7 @@ Generic Associated Types, or [GATs](https://github.com/rust-lang/generic-associa
 
 The [safe transmute](https://github.com/rust-lang/lang-team/issues/21) project, led by [jswrenn] from Amazon Web Services, is expected to be feature-complete in summer 2022. It will enable a large class of types to be transmuted (i.e. zero-cost type conversion) without any risk of injecting undefined behavior.
 
-You can reach these owners as `@**Jack Huey**`, `@**tmandry**`, and `@**Jack Wrenn**` on zulip.
+You can reach these owners as `@**Jack Huey**`, `@**tmandry**`, and `@**Jack Wrenn**` [on zulip].
 
 ### Librarification Initiatives (🛠️)
 
@@ -234,7 +234,7 @@ These are initiatives dedicated to the "librarification" of the compiler: breaki
 
 Chalk has been years in development, and has been experimentally integrated into rustc in the past. This year, [jackh726] and [nikomatsakis] own the task of improving the chalk integration, to drive it to the point where the team can consider migrating to chalk as the implementation of the trait system. This will unlock many features that up until now have been too difficult to implement in the old trait system implementation, and its declarative structure will provide a proper foundation for people to reason about the *correctness* of the trait system.
 
-If you want to help out with this, reach out to [jackh726] and [nikomatsakis]. They are `@**Jack Huey**` and `@**nikomatsakis**` on zulip.
+If you want to help out with this, reach out to [jackh726] and [nikomatsakis]. They are `@**Jack Huey**` and `@**nikomatsakis**` [on zulip].
 
 ## Aspirations
 
@@ -246,7 +246,7 @@ If you are interested in helping with any items here, please do reach out to the
 
 [pnkfelix] and [wesleywiser], as team leads, are deploying processes to help us get a handle on the "high priority, but *not critical*" issues that the compiler has accumulated. We will be gradually identifying owners for each who will move progress forward, and in general working to keep better track of the set overall.
 
-If you would like to help with the task of reviewing or resolving such issues, reach out to [wesleywiser] and [apiraino], who are co-leads of WG-prioritization. They are `@**Wesley Wiser**` and `@**apiraino**` on zulip.
+If you would like to help with the task of reviewing or resolving such issues, reach out to [wesleywiser] and [apiraino], who are co-leads of WG-prioritization. They are `@**Wesley Wiser**` and `@**apiraino**` [on zulip].
 
 ### Debugging Aspirations (👩‍💻)
 
@@ -256,7 +256,7 @@ We want to improve expression evaluation support: Today, most forms of method in
 
 We want to revisit our debugger extension architecture for rendering Rust data structures, which is currently mostly independent sets of Python scripts.
 
-If you want to help out here, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` on zulip.
+If you want to help out here, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` [on zulip].
 
 ### Faster Builds Aspirations (👩‍💻, 🛠️)
 
@@ -264,7 +264,7 @@ If you want to help out here, please reach out to [pnkfelix] and [wesleywiser]. 
 
 Parallel Compilation is one avenue for improving compiler performance. It is also a very complex area, especially when it comes to the tradeoff of how much of a hit one is willing to take on single core builds in order to enable more parallel computation. We already parallelize our LLVM invocations, but the parallelization of the rest of the compiler remains in an experimental state. This is an area we think needs long-term collaborative effort with the compiler team. We do not expect to deliver a solution here this year.
 
-If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` on zulip.
+If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` [on zulip].
 
 #### Incremental Compilation Aspirations
 
@@ -272,14 +272,14 @@ Incremental compilation performance and stability are both ongoing concerns to t
 
 In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compiliation which does not require deep knowledge of the compiler. 
 
-If you want to learn more, reach out to [cjgillot] and [Aaron Hill]. They are `@**cjgillot**` and `@**Aaron Hill**` on zulip.
+If you want to learn more, reach out to [cjgillot] and [Aaron Hill]. They are `@**cjgillot**` and `@**Aaron Hill**` [on zulip].
 
 #### Inter-crate Sharing Aspirations
 
 nnethercote has noted that there may be opportunities
 to improve end-to-end compilation time for multi-crate builds by identifying redundant activity that can be shared between builds of distinct crates. (For example, the metadata from libstd is read and decoded on every single crate compile.)
 
-If you are interested in exploring this idea further, reach out to [nnethercote] and [lqd]. They are `@**nnethercote**` and `@**lqd**` on zulip.
+If you are interested in exploring this idea further, reach out to [nnethercote] and [lqd]. They are `@**nnethercote**` and `@**lqd**` [on zulip].
 
 ### Expressiveness Aspirations (🦀, 👩‍💻)
 
@@ -287,7 +287,7 @@ const generics and const eval are making steady progress. There are a *lot* of f
 
 What we can probably use the most help with is in identifying what subset of the features we should be striving to stabilize in order to unlock specific use cases for Rust developers.
 
-So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] (supported via [sponsorship][sponsor-lcnr]) and [oli-obk]. They are `@**lcnr**` and `@**oli**` on zulip.
+So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] (supported via [sponsorship][sponsor-lcnr]) and [oli-obk]. They are `@**lcnr**` and `@**oli**` [on zulip].
 
 [sponsor-lcnr]: https://lcnr.de/funding/
 
@@ -303,7 +303,7 @@ For example, [Kani] is a bit-precise model-checker for Rust under development at
 [Prusti]: https://github.com/viperproject/prusti-dev#prusti
 [Creusot]: https://github.com/xldenis/creusot#about
 
-Reach out to [xldenis], from the LMF at the University of Paris-Saclay (and co-lead of the Rust Formal Methods working group), and [pnkfelix] if you are interested in helping us here. They are `@**Xavier Denis**` and `@**pnkfelix**` on zulip.
+Reach out to [xldenis], from the LMF at the University of Paris-Saclay (and co-lead of the Rust Formal Methods working group), and [pnkfelix] if you are interested in helping us here. They are `@**Xavier Denis**` and `@**pnkfelix**` [on zulip].
 
 ### Compiler Team Operations Aspirations (🛠️)
 
@@ -313,7 +313,7 @@ One common task for compiler developers is to create a [minimal complete verifia
 
 This is an area where you do not need any knowledge of the `rustc` source code at all. Anyone with an interest in programming language technology can get involved; e.g. one might consider adding IDE commands for certain code reducing transformations.
 
-If you are interested in helping in this area, please reach out to [pnkfelix]. They are `@**pnkfelix**` on zulip.
+If you are interested in helping in this area, please reach out to [pnkfelix]. They are `@**pnkfelix**` [on zulip].
 
 [E-needs-mcve]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-needs-mcve+
 [mcve blog post]: https://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
@@ -324,7 +324,7 @@ If you are interested in helping in this area, please reach out to [pnkfelix]. T
 
 The performance working group has many ideas for things to improve in these tools, but limited resources. This is an area where you don't need any compiler expertise to make a huge impact; for example, our Web Front-end could use work. And Data Scientists might have useful insights into our problems. Beyond just measuring the compiler's own performance, we're also interested in measuring the runtime performance of produced binaries.
 
-Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help. They are `@**rylev**` and `@**simulacrum**` on zulip.
+Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help. They are `@**rylev**` and `@**simulacrum**` [on zulip].
 
 [@rust-timer]: https://github.com/rust-timer
 [perf]: https://perf.rust-lang.org/
@@ -333,13 +333,13 @@ Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorsh
 
 #### Ease writing new backends
 
-One source of tedium when defining a new Rust compiler backend is implementing the intrinsics that each backend must provide. But a small change to the intrinsic system: namely, allowing intrinsics to define a [fallback MIR implementation][], could ease that burden. Reach out to [scottmcm] if you are interested in helping out here. They are `@**scottmcm**` on zulip.
+One source of tedium when defining a new Rust compiler backend is implementing the intrinsics that each backend must provide. But a small change to the intrinsic system: namely, allowing intrinsics to define a [fallback MIR implementation][], could ease that burden. Reach out to [scottmcm] if you are interested in helping out here. They are `@**scottmcm**` [on zulip].
 
 [fallback MIR implementation]: https://github.com/rust-lang/rust/issues/93145
 
 #### Cranelift
 
-The [Cranelift Code Generator][Cranelift] is getting a lot of attention from various parties. rustc has a [Cranelift backend][]. If you are interested in helping out with it, reach out to [bjorn3] (supported via [sponsorship][sponsor-bjorn3]). They are `@**bjorn3**` on zulip.
+The [Cranelift Code Generator][Cranelift] is getting a lot of attention from various parties. rustc has a [Cranelift backend][]. If you are interested in helping out with it, reach out to [bjorn3] (supported via [sponsorship][sponsor-bjorn3]). They are `@**bjorn3**` [on zulip].
 
 [sponsor-bjorn3]: https://liberapay.com/bjorn3
 
@@ -350,14 +350,14 @@ The [Cranelift Code Generator][Cranelift] is getting a lot of attention from var
 
 In addition to the LLVM and Cranelift backends, there is also a new backend under development that uses `libgccjit` from GCC (which, as many have clarified, is usable for ahead-of-time as well as just-in-time compilation). This backend enables Rust to target more platforms that are not supported by LLVM.
 
-If you are interested in helping out with this project, reach out to [antoyo] (supported via [sponsorship](https://github.com/sponsors/antoyo)) and [bjorn3]. They are `@**antoyo**` and `@**bjorn3**` on zulip.
+If you are interested in helping out with this project, reach out to [antoyo] (supported via [sponsorship](https://github.com/sponsors/antoyo)) and [bjorn3]. They are `@**antoyo**` and `@**bjorn3**` [on zulip].
 
 
 ### Diagnostics Aspirations (👩‍💻)
 
 The Rust compiler has pretty good diagnotics. But the good news is, there's a [full employment theorem](https://en.wikipedia.org/wiki/Full_employment_theorem) for diagnostics engineers which is supported by the 1,500+ [open diagnostics issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics) we have.
 
-Diagnostics improvements are an *excellent* first step for learning about how to contribute to the Rust compiler. If you're interested in helping out but don't have any idea where to start, fixing diagnostic bugs is a great jumping off point, and you can reach out to [estebank], at Amazon Web Services, to find out more about how to help. They are `@**Esteban Küber**` on zulip.
+Diagnostics improvements are an *excellent* first step for learning about how to contribute to the Rust compiler. If you're interested in helping out but don't have any idea where to start, fixing diagnostic bugs is a great jumping off point, and you can reach out to [estebank], at Amazon Web Services, to find out more about how to help. They are `@**Esteban Küber**` [on zulip].
 
 
 ## Conclusion
@@ -388,11 +388,11 @@ The scope of this doc is largely restricted to Compiler Team issues. Language de
 
 Each item in this list has one or more owners listed with it. The Rust Compiler team largely communicates via the [Zulip] chat platform.
 
-So: set up a Zulip account, sign into Zulip, and join the [#**new members>compiler 2022**][new members] topic. Tell the group which item you're interested in, and also mention the owners listed with that topic so that they know to join you in that conversation channel. We will help you get started from there.
+So: set up a Zulip account, sign into Zulip, and join the [#**new members>compiler 2022**][on zulip] topic. Tell the group which item you're interested in, and also mention the owners listed with that topic so that they know to join you in that conversation channel. We will help you get started from there.
 
 [Rustc Dev Guide]: https://rustc-dev-guide.rust-lang.org/
 [Zulip]: https://rust-lang.zulipchat.com/
-[new members]: https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members/topic/compiler.202022
+[on zulip]: https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members/topic/compiler.202022
 
 #### What do I do if I'm interested in compiler development but have no experience in compilers?
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -117,15 +117,16 @@ Finally, improving the Compiler Contributor Workflow means technology enhancemen
 
 Category  | [Concrete Initiatives] |  [Aspirations]
 ----------|---------------------|-----------
-I-unsound | [Initiatives][I-unsound Issues]      |
-Async Rust| [Initiatives][Async Initiatives]     |
-Debugging | [Initiatives][Debugging Initiatives] | [Aspirations][Debugging Aspirations]
-Faster Builds | [Initiatives][Faster Builds Initiatives] | [Aspirations][Faster Builds Aspirations]
-Expressiveness     | [Initiatives][Expressiveness Initiatives] | [Aspirations][Expressiveness Aspirations]
-Librarification    | [Initiatives][Librarification Initiatives]                 | [Aspirations][Librarification Aspirations]
-Team Operations    |                             | [Aspirations][Team Operations]
-Backend            |                             | [Aspirations][Backend Aspirations]
-Diagnostics        |                             | [Aspirations][Diagnostics Aspirations]
+I-unsound (🦀) | [Initiatives][I-unsound Issues]      |
+Async Rust (🦀, 👩‍💻)| [Initiatives][Async Initiatives]     |
+Debugging (🦀, 👩‍💻)| [Initiatives][Debugging Initiatives] | [Aspirations][Debugging Aspirations]
+Faster Builds (👩‍💻, 🛠️) | [Initiatives][Faster Builds Initiatives] | [Aspirations][Faster Builds Aspirations]
+Expressiveness (👩‍💻, 🦀) | [Initiatives][Expressiveness Initiatives] | [Aspirations][Expressiveness Aspirations]
+Librarification (🛠️) | [Initiatives][Librarification Initiatives]                 | [Aspirations][Librarification Aspirations]
+P-high Backlog (🦀) |                             | [Aspirations][P-high Aspirations]
+Team Operations (🛠️) |                             | [Aspirations][Team Operations]
+Backend (🛠️, 👩‍💻) |                             | [Aspirations][Backend Aspirations]
+Diagnostics  (👩‍💻) |                             | [Aspirations][Diagnostics Aspirations]
 
 [Concrete Initiatives]: #concrete-initiatives
 [I-unsound Issues]: #i-unsound-issues-

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -12,9 +12,9 @@ Some people have been wondering about what the Rust Compiler Team has planned fo
 
 This document is structured into three parts: our [Overall Themes][] for this year, the [Concrete Initiatives][] we have resources to drive, and [Aspirations][] for what we could do if given more help.
 
-[Overall Themes]: #Overall-Themes
-[Concrete Initiatives]: #Concrete-Initiatives
-[Aspirations]: #Aspirations
+[Overall Themes]: #overall-themes
+[Concrete Initiatives]: #concrete-initiatives
+[Aspirations]: #aspirations
 
 ## Introduction
 
@@ -132,13 +132,14 @@ Diagnostics  (👩‍💻) |                             | [Aspirations][Diagnos
 [I-unsound Issues]: #i-unsound-issues-
 [Async Initiatives]: #async-rust-initiatives--
 [Debugging Initiatives]: #debugging-initiatives-
-[Faster Builds Initiatives]: #faster-builds-initiatives--
-[Expressiveness Initiatives]: #expressiveness-initatives--
-[Librarification Initiatives]: #librarification-initiatives-
+[Faster Builds Initiatives]: #faster-builds-initiatives--%EF%B8%8F
+[Expressiveness Initiatives]: #expressiveness-initiatives--
+[Librarification Initiatives]: #librarification-initiatives-%EF%B8%8F
+
 [Aspirations]: #aspirations
 [P-high Aspirations]: #p-high-aspirations-
 [Debugging Aspirations]: #debugging-aspirations-
-[Faster Builds Aspirations]: #faster-builds-aspirations--
+[Faster Builds Aspirations]: #faster-builds-aspirations--%EF%B8%8F
 [Expressiveness Aspirations]: #expressiveness-aspirations--
 [Librarification Aspirations]: #librarification-aspirations-%EF%B8%8F
 [Team Operations]: #compiler-team-operations-aspirations-%EF%B8%8F

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -37,70 +37,70 @@ But the flip side of this is: if something really is important, then there almos
 [mara-post]: https://blog.m-ou.se/rust-is-not-a-company/
 
 [antoyo]: https://github.com/antoyo
-[antoyo zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/404242-user404242 <!-- @**antoyo** -->
+<!-- [antoyo zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/404242-user404242 --> <!-- @**antoyo** -->
 <!-- antoyo sponsorship: https://github.com/sponsors/antoyo -->
 [Aaron Hill]: https://github.com/Aaron1011
-[Aaron Hill zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083 <!-- @**Aaron Hill** -->
+<!-- [Aaron Hill zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083 --> <!-- @**Aaron Hill** -->
 <!-- Aaron1011: no affiliation -->
 [bjorn3]: https://github.com/bjorn3
-[bjorn3 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/133247-user133247 <!-- @**bjorn3**  -->
+<!-- [bjorn3 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/133247-user133247 --> <!-- @**bjorn3**  -->
 <!-- bjorn3 donation page: https://liberapay.com/bjorn3 -->
 [cjgillot]: https://github.com/cjgillot
-[cjgillot zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 <!-- @**cjgillot**  --> 
+<!-- [cjgillot zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 --> <!-- @**cjgillot**  --> 
 <!-- no response from cjgillot re affiliation yet -->
 [davidtwco]: https://github.com/davidtwco
-[davidtwco zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 <!-- @**davidtwco**  -->
+<!-- [davidtwco zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 --> <!-- @**davidtwco**  -->
 <!-- davidtwco affiliation: "Huawei R&D UK"-->
 [estebank]: https://github.com/estebank
-[estebank zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/119031-user119031 <!-- @**Esteban Küber** -->
+<!-- [estebank zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/119031-user119031 --> <!-- @**Esteban Küber** -->
 <!-- estebank affiliation: AWS --> 
 [lcnr]: https://github.com/lcnr
-[lcnr zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/216206-user216206 <!-- @**lcnr** -->
+<!-- [lcnr zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/216206-user216206 --> <!-- @**lcnr** -->
 <!-- lcnr sponsorship: https://lcnr.de/funding/ -->
 [mw]: https://github.com/michaelwoerister
-[mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287 <!-- @**mw** -->
+<!-- [mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287 --> <!-- @**mw** -->
 <!-- mw affiliation: MS -->
 [nikomatsakis]: https://github.com/nikomatsakis
-[nikomatsakis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116009-user116009 <!-- @**nikomatsakis** -->
+<!-- [nikomatsakis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116009-user116009 --> <!-- @**nikomatsakis** -->
 <!-- nikomatsakis affiliation: AWS -->
 [oli-obk]: https://github.com/oli-obk
-[oli-obk zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124288-user124288 <!-- @**oli** -->
+<!-- [oli-obk zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124288-user124288 --> <!-- @**oli** -->
 <!-- oli affiliation: AWS --> 
 [jackh726]: https://github.com/jackh726
-[jackh726 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/232957-user232957 <!-- @**Jack Huey** -->
+<!-- [jackh726 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/232957-user232957 --> <!-- @**Jack Huey** -->
 <!-- jackh726: no affiliation -->
 [lqd]: https://github.com/lqd
-[lqd zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116113-user116113 <!-- @**lqd**  -->
+<!-- [lqd zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116113-user116113 --> <!-- @**lqd**  -->
 <!-- lqd affiliation: ISRG -->
 [nnethercote]: https://github.com/nnethercote
-[nnethercote zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/120989-user120989 <!-- @**nnethercote**  -->
+<!-- [nnethercote zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/120989-user120989 --> <!-- @**nnethercote**  -->
 <!-- nnethercote affiliation: Futurewei -->
 [tmandry]: https://github.com/tmandry
-[tmandry zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116883-user116883 <!-- @**tmandry**  -->
+<!-- [tmandry zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116883-user116883 --> <!-- @**tmandry**  -->
 <!-- tmandry affiliation: Google (TBD) -->
 [scottmcm]: https://github.com/scottmcm
-[scottmcm zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125270-user125270 <!-- @**scottmcm**  -->
+<!-- [scottmcm zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125270-user125270 --> <!-- @**scottmcm**  -->
 <!-- scottmcm: no affiliation -->
 [pnkfelix]: https://github.com/pnkfelix
-[pnkfelix zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083  <!-- @**pnkfelix**  -->
+<!-- [pnkfelix zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083  --> <!-- @**pnkfelix**  -->
 <!-- pnkfelix affiliation: AWS -->
 [wesleywiser]: https://github.com/wesleywiser
-[wesleywiser zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125250-user125250 <!-- @**Wesley Wiser**  -->
+<!-- [wesleywiser zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125250-user125250 --> <!-- @**Wesley Wiser**  -->
 <!-- wesleywiser affiliation: MS -->
 [jswrenn]: https://github.com/jswrenn
-[jswrenn zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/219211-user219211 <!-- @**Jack Wrenn** -->
+<!-- [jswrenn zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/219211-user219211 --> <!-- @**Jack Wrenn** -->
 <!-- jswrenn affiliation: AWS -->
 [apiraino]: https://github.com/apiraino
-[apiraino zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/250987-user250987 <!-- @**apiraino**  -->
+<!-- [apiraino zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/250987-user250987 --> <!-- @**apiraino**  -->
 <!-- apiraino: no affiliation -->
 [simulacrum]: https://github.com/Mark-simulacrum
-[simulacrum zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116122-user116122 <!-- @**simulacrum**  -->
+<!-- [simulacrum zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116122-user116122 --> <!-- @**simulacrum**  -->
 <!-- simulacrum sponsorship: https://github.com/sponsors/Mark-Simulacrum -->
 [rylev]: https://github.com/rylev
-[rylev zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/224872-user224872 <!-- @**rylev**  -->
+<!-- [rylev zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/224872-user224872 --> <!-- @**rylev**  -->
 <!-- rylev affiliation: MS -->
 [xldenis]: https://github.com/xldenis
-[xldenis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/312719-user312719 <!-- @**Xavier Denis**  -->
+<!-- [xldenis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/312719-user312719 --> <!-- @**Xavier Denis**  -->
 
 ## Overall Themes
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -244,7 +244,7 @@ If you want to help out here, please reach out to [pnkfelix] and [wesleywiser].
 
 #### Parallel Compilation
 
-Parallel Compilation is one avenue for improving compiler performance. It is also a very complex area, especially when it comes to the tradeoff of how much of a hit one is willing to take on single core builds in order to enable more parallel computation. This is an area we think needs long-term collaborative effort with the compiler team. We do not expect to deliver a solution here this year.
+Parallel Compilation is one avenue for improving compiler performance. It is also a very complex area, especially when it comes to the tradeoff of how much of a hit one is willing to take on single core builds in order to enable more parallel computation. We already parallelize our LLVM invocations, but the parallelization of the rest of the compiler remains in an experimental state. This is an area we think needs long-term collaborative effort with the compiler team. We do not expect to deliver a solution here this year.
 
 If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser]. 
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -283,7 +283,7 @@ const generics and const eval are making steady progress. There are a *lot* of f
 
 What we can probably use the most help with is in identifying what subset of the features we should be striving to stabilize in order to unlock specific use cases for Rust developers.
 
-So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] and [oli-obk].
+So, if you or your team is enthusiastically awaiting const generics or const eval, reach out to [lcnr] and [oli-obk].
 
 [sponsor-lcnr]: https://lcnr.de/funding/
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -173,7 +173,7 @@ As of this writing, we have 69 [open issues tagged I-unsound](https://github.com
 
 In theory, any unsoundness issue potentially undermines Rust's promise of reliability. We want, by the end of this year, to have a clear understanding of how each of those I-unsound issues came to be. We are looking into systematically detecting such issues and whether we can deploy mitigations or fixes for entire classes of issues, instead of addressing them on a case by case basis.
 
-[oli-obk], from Amazon Web Services, will be the primary owner of  work in this space. Please reach out to [oli-obk] and [pnkfelix] (also from Amazon Web Services) if you are interested in helping resolve these issues!
+[oli-obk], from Amazon Web Services, will be the primary owner of  work in this space. Please reach out to [oli-obk] and [pnkfelix] (also from Amazon Web Services) if you are interested in helping resolve these issues! They are `@**oli**` and `@**pnkfelix**` on zulip.
 
 
 ### Async Rust Initiatives (🦀, 👩‍💻)
@@ -182,18 +182,18 @@ There is significant overlap between async rust and other areas of this document
 
 #### async traits
 
-Rust today does not allow `async fn` in a trait, so Async Rust code usually ends up with components that are too tightly coupled; one cannot write reusable, general-purpose libraries without using workarounds like `#[async_trait]` that impose hidden costs. [nikomatsakis], from Amazon Web Services, and [tmandry], from Google, are driving the [async fn in traits initiative](https://github.com/rust-lang/async-fundamentals-initiative/issues/5), which will unlock the ability to write `async` methods in traits, natively.
+Rust today does not allow `async fn` in a trait, so Async Rust code usually ends up with components that are too tightly coupled; one cannot write reusable, general-purpose libraries without using workarounds like `#[async_trait]` that impose hidden costs. [nikomatsakis], from Amazon Web Services, and [tmandry], from Google, are driving the [async fn in traits initiative](https://github.com/rust-lang/async-fundamentals-initiative/issues/5), which will unlock the ability to write `async` methods in traits, natively. They are `@**nikomatsakis**` and `@**tmandry**` on zulip.
 
 #### async crashdump dissection
 
-[mw], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs.
+[mw], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs. He is `@**mw**` on zulip.
 
 There is a ton of other work being done in the Async Rust space. Check out the [Async Vision web site](https://rust-lang.github.io/wg-async/welcome.html) for more information.
 
 
 ### Debugging Initiatives (🦀)
 
-[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([mw], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]).
+[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([mw], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]). They are `@**Wesley Wiser**`, `@**pnkfelix**`, `@**mw**` and `@**davidtwco**` on zulip.
 
 The immediate goals for this initiative: establish the working group, determine priorities for the backlog of debugging issues, and find out what active users of debuggers miss most when they operate on Rust code.
 
@@ -201,7 +201,7 @@ The immediate goals for this initiative: establish the working group, determine 
  
 The Rust compiler's end-to-end latency is known to be a problem.
  
-[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA).
+[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA). They are `@**lqd**` and `@**nnethercote**` on zulip.
 
 [ISRG]: https://www.abetterinternet.org/
 
@@ -220,6 +220,8 @@ Generic Associated Types, or [GATs](https://github.com/rust-lang/generic-associa
 
 The [safe transmute](https://github.com/rust-lang/lang-team/issues/21) project, led by [jswrenn] from Amazon Web Services, is expected to be feature-complete in summer 2022. It will enable a large class of types to be transmuted (i.e. zero-cost type conversion) without any risk of injecting undefined behavior.
 
+You can reach these owners as `@**Jack Huey**`, `@**tmandry**`, and `@**Jack Wrenn**` on zulip.
+
 ### Librarification Initiatives (🛠️)
 
 These are initiatives dedicated to the "librarification" of the compiler: breaking the monolithic code base of `rustc` into a set of decoupled parts that can be independently developed, and, ideally, repurposed for other kinds of tools besides `rustc` such as `rust-analyzer`.
@@ -232,7 +234,7 @@ These are initiatives dedicated to the "librarification" of the compiler: breaki
 
 Chalk has been years in development, and has been experimentally integrated into rustc in the past. This year, [jackh726] and [nikomatsakis] own the task of improving the chalk integration, to drive it to the point where the team can consider migrating to chalk as the implementation of the trait system. This will unlock many features that up until now have been too difficult to implement in the old trait system implementation, and its declarative structure will provide a proper foundation for people to reason about the *correctness* of the trait system.
 
-If you want to help out with this, reach out to [jackh726] and [nikomatsakis].
+If you want to help out with this, reach out to [jackh726] and [nikomatsakis]. They are `@**Jack Huey**` and `@**nikomatsakis**` on zulip.
 
 ## Aspirations
 
@@ -244,7 +246,7 @@ If you are interested in helping with any items here, please do reach out to the
 
 [pnkfelix] and [wesleywiser], as team leads, are deploying processes to help us get a handle on the "high priority, but *not critical*" issues that the compiler has accumulated. We will be gradually identifying owners for each who will move progress forward, and in general working to keep better track of the set overall.
 
-If you would like to help with the task of reviewing or resolving such issues, reach out to [wesleywiser] and [apiraino], who are co-leads of WG-prioritization.
+If you would like to help with the task of reviewing or resolving such issues, reach out to [wesleywiser] and [apiraino], who are co-leads of WG-prioritization. They are `@**Wesley Wiser**` and `@**apiraino**` on zulip.
 
 ### Debugging Aspirations (👩‍💻)
 
@@ -254,7 +256,7 @@ We want to improve expression evaluation support: Today, most forms of method in
 
 We want to revisit our debugger extension architecture for rendering Rust data structures, which is currently mostly independent sets of Python scripts.
 
-If you want to help out here, please reach out to [pnkfelix] and [wesleywiser].
+If you want to help out here, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` on zulip.
 
 ### Faster Builds Aspirations (👩‍💻, 🛠️)
 
@@ -262,7 +264,7 @@ If you want to help out here, please reach out to [pnkfelix] and [wesleywiser].
 
 Parallel Compilation is one avenue for improving compiler performance. It is also a very complex area, especially when it comes to the tradeoff of how much of a hit one is willing to take on single core builds in order to enable more parallel computation. We already parallelize our LLVM invocations, but the parallelization of the rest of the compiler remains in an experimental state. This is an area we think needs long-term collaborative effort with the compiler team. We do not expect to deliver a solution here this year.
 
-If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser]. 
+If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` on zulip.
 
 #### Incremental Compilation Aspirations
 
@@ -270,14 +272,14 @@ Incremental compilation performance and stability are both ongoing concerns to t
 
 In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compiliation which does not require deep knowledge of the compiler. 
 
-If you want to learn more, reach out to [cjgillot] and [Aaron Hill].
+If you want to learn more, reach out to [cjgillot] and [Aaron Hill]. They are `@**cjgillot**` and `@**Aaron Hill**` on zulip.
 
 #### Inter-crate Sharing Aspirations
 
 nnethercote has noted that there may be opportunities
 to improve end-to-end compilation time for multi-crate builds by identifying redundant activity that can be shared between builds of distinct crates. (For example, the metadata from libstd is read and decoded on every single crate compile.)
 
-If you are interested in exploring this idea further, reach out to [nnethercote] and [lqd].
+If you are interested in exploring this idea further, reach out to [nnethercote] and [lqd]. They are `@**nnethercote**` and `@**lqd**` on zulip.
 
 ### Expressiveness Aspirations (🦀, 👩‍💻)
 
@@ -285,7 +287,7 @@ const generics and const eval are making steady progress. There are a *lot* of f
 
 What we can probably use the most help with is in identifying what subset of the features we should be striving to stabilize in order to unlock specific use cases for Rust developers.
 
-So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] (supported via [sponsorship][sponsor-lcnr]) and [oli-obk].
+So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] (supported via [sponsorship][sponsor-lcnr]) and [oli-obk]. They are `@**lcnr**` and `@**oli**` on zulip.
 
 [sponsor-lcnr]: https://lcnr.de/funding/
 
@@ -301,7 +303,7 @@ For example, [Kani] is a bit-precise model-checker for Rust under development at
 [Prusti]: https://github.com/viperproject/prusti-dev#prusti
 [Creusot]: https://github.com/xldenis/creusot#about
 
-Reach out to [xldenis], from the LMF at the University of Paris-Saclay (and co-lead of the Rust Formal Methods working group), and [pnkfelix] if you are interested in helping us here.
+Reach out to [xldenis], from the LMF at the University of Paris-Saclay (and co-lead of the Rust Formal Methods working group), and [pnkfelix] if you are interested in helping us here. They are `@**Xavier Denis**` and `@**pnkfelix**` on zulip.
 
 ### Compiler Team Operations Aspirations (🛠️)
 
@@ -311,7 +313,7 @@ One common task for compiler developers is to create a [minimal complete verifia
 
 This is an area where you do not need any knowledge of the `rustc` source code at all. Anyone with an interest in programming language technology can get involved; e.g. one might consider adding IDE commands for certain code reducing transformations.
 
-If you are interested in helping in this area, please reach out to [pnkfelix].
+If you are interested in helping in this area, please reach out to [pnkfelix]. They are `@**pnkfelix**` on zulip.
 
 [E-needs-mcve]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-needs-mcve+
 [mcve blog post]: https://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
@@ -322,7 +324,7 @@ If you are interested in helping in this area, please reach out to [pnkfelix].
 
 The performance working group has many ideas for things to improve in these tools, but limited resources. This is an area where you don't need any compiler expertise to make a huge impact; for example, our Web Front-end could use work. And Data Scientists might have useful insights into our problems. Beyond just measuring the compiler's own performance, we're also interested in measuring the runtime performance of produced binaries.
 
-Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help.
+Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help. They are `@**rylev**` and `@**simulacrum**` on zulip.
 
 [@rust-timer]: https://github.com/rust-timer
 [perf]: https://perf.rust-lang.org/
@@ -331,13 +333,13 @@ Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorsh
 
 #### Ease writing new backends
 
-One source of tedium when defining a new Rust compiler backend is implementing the intrinsics that each backend must provide. But a small change to the intrinsic system: namely, allowing intrinsics to define a [fallback MIR implementation][], could ease that burden. Reach out to [scottmcm] if you are interested in helping out here.
+One source of tedium when defining a new Rust compiler backend is implementing the intrinsics that each backend must provide. But a small change to the intrinsic system: namely, allowing intrinsics to define a [fallback MIR implementation][], could ease that burden. Reach out to [scottmcm] if you are interested in helping out here. They are `@**scottmcm**` on zulip.
 
 [fallback MIR implementation]: https://github.com/rust-lang/rust/issues/93145
 
 #### Cranelift
 
-The [Cranelift Code Generator][Cranelift] is getting a lot of attention from various parties. rustc has a [Cranelift backend][]. If you are interested in helping out with it, reach out to [bjorn3] (supported via [sponsorship][sponsor-bjorn3]).
+The [Cranelift Code Generator][Cranelift] is getting a lot of attention from various parties. rustc has a [Cranelift backend][]. If you are interested in helping out with it, reach out to [bjorn3] (supported via [sponsorship][sponsor-bjorn3]). They are `@**bjorn3**` on zulip.
 
 [sponsor-bjorn3]: https://liberapay.com/bjorn3
 
@@ -348,14 +350,14 @@ The [Cranelift Code Generator][Cranelift] is getting a lot of attention from var
 
 In addition to the LLVM and Cranelift backends, there is also a new backend under development that uses `libgccjit` from GCC (which, as many have clarified, is usable for ahead-of-time as well as just-in-time compilation). This backend enables Rust to target more platforms that are not supported by LLVM.
 
-If you are interested in helping out with this project, reach out to [antoyo] (supported via [sponsorship](https://github.com/sponsors/antoyo)) and [bjorn3].
+If you are interested in helping out with this project, reach out to [antoyo] (supported via [sponsorship](https://github.com/sponsors/antoyo)) and [bjorn3]. They are `@**antoyo**` and `@**bjorn3**` on zulip.
 
 
 ### Diagnostics Aspirations (👩‍💻)
 
 The Rust compiler has pretty good diagnotics. But the good news is, there's a [full employment theorem](https://en.wikipedia.org/wiki/Full_employment_theorem) for diagnostics engineers which is supported by the 1,500+ [open diagnostics issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics) we have.
 
-Diagnostics improvements are an *excellent* first step for learning about how to contribute to the Rust compiler. If you're interested in helping out but don't have any idea where to start, fixing diagnostic bugs is a great jumping off point, and you can reach out to [estebank], at Amazon Web Services, to find out more about how to help.
+Diagnostics improvements are an *excellent* first step for learning about how to contribute to the Rust compiler. If you're interested in helping out but don't have any idea where to start, fixing diagnostic bugs is a great jumping off point, and you can reach out to [estebank], at Amazon Web Services, to find out more about how to help. They are `@**Esteban Küber**` on zulip.
 
 
 ## Conclusion
@@ -386,10 +388,11 @@ The scope of this doc is largely restricted to Compiler Team issues. Language de
 
 Each item in this list has one or more owners listed with it. The Rust Compiler team largely communicates via the [Zulip] chat platform.
 
-So: set up a Zulip account, sign into it, and then send a private message to the relevant owners, telling them that you want to help with their rustc initiatives. They'll help you get started from there.
+So: set up a Zulip account, sign into Zulip, and join the [#**new members>compiler 2022**][new members] topic. Tell the group which item you're interested in, and also mention the owners listed with that topic so that they know to join you in that conversation channel. We will help you get started from there.
 
 [Rustc Dev Guide]: https://rustc-dev-guide.rust-lang.org/
-[Zulip]: https://rust-lang.zulipchat.com/ 
+[Zulip]: https://rust-lang.zulipchat.com/
+[new members]: https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members/topic/compiler.202022
 
 #### What do I do if I'm interested in compiler development but have no experience in compilers?
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -58,8 +58,8 @@ But the flip side of this is: if something really is important, then there almos
 <!-- [lcnr zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/216206-user216206 --> <!-- @**lcnr** -->
 <!-- lcnr sponsorship: https://lcnr.de/funding/ -->
 [michaelwoerister]: https://github.com/michaelwoerister
-<!-- [mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287 --> <!-- @**michaelwoerister** -->
-<!-- mw affiliation: MS -->
+<!-- [michaelwoerister zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287 --> <!-- @**mw** -->
+<!-- michaelwoerister affiliation: MS -->
 [nikomatsakis]: https://github.com/nikomatsakis
 <!-- [nikomatsakis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116009-user116009 --> <!-- @**nikomatsakis** -->
 <!-- nikomatsakis affiliation: AWS -->
@@ -192,7 +192,7 @@ There is a ton of other work being done in the Async Rust space. Check out the [
 
 ### Debugging Initiatives (🦀)
 
-[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([mw], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]). They are `@**Wesley Wiser**`, `@**pnkfelix**`, `@**mw**` and `@**davidtwco**` [on zulip].
+[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([michaelwoerister], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]). They are `@**Wesley Wiser**`, `@**pnkfelix**`, `@**mw**` and `@**davidtwco**` [on zulip].
 
 The immediate goals for this initiative: establish the working group, determine priorities for the backlog of debugging issues, and find out what active users of debuggers miss most when they operate on Rust code.
 
@@ -363,7 +363,7 @@ Diagnostics improvements are an *excellent* first step for learning about how to
 
 Reading over this list, the number of items on it seems quite daunting! We believe these initiatives will provide the highest impact to the Rust community by helping to fulfill Rust's promise, delighting Rust developers and improving our contributor workflows and aligns well with the results of the [2021 Rust Survey](https://blog.rust-lang.org/2022/02/15/Rust-Survey-2021.html).
 
-While we think we will be able to make signficant progress on these initiatives this year, project estimation is a difficult and inexact science, especially for open source projects. What we will achieve is ultimately a result of who decides to contribute. Our aspirational goals are currently just that: aspriations.
+While we think we will be able to make signficant progress on these initiatives this year, project estimation is a difficult and inexact science, especially for open source projects. What we will achieve is ultimately a result of who decides to contribute. Our aspirational goals are currently just that: aspirations.
 
 This is where you all, the Rust community (including *future members* of that community) come into the picture. Each item has one or two people listed with it; if you're feeling inspired, please do contact us!
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -94,26 +94,13 @@ Fulfilling Rust's Promise is a cross-cutting theme; it means identifying the gap
 We have opportunities to improve the experience of writing, of compiling, and of running Rust code. We want answers to the question, "what would delight Rust developers?" This is not about meeting their expectations: It's about *surpassing* them.
 
 
-[Debugging concrete]: #Debugging-Initiatives
-[Debugging aspirational]: #Debugging-Aspirations
-[Debugging]: #Debugging-Object-Code
-[Faster concrete]: #Compilation-Time-Initiatives
-[Faster aspirational]: #Faster-Compilation-Aspirations
-[Expressiveness concrete]: #Language-Expressiveness-Initiatives
-[Expressiveness aspirational]: #Expressiveness-Aspirations
-
 ### Contributor Workflow (🛠️)
 
 Finally, improving the Compiler Contributor Workflow means technology enhancements that benefit people maintaining and extending the Rust compiler itself.
 
 (We also make non-technical enhancements, such as changes to our social processes, but this document focuses on technology.)
 
-
-[Librarification Initiatives]: #Librarification-Initiatives
-[Librarification Aspirations]: #Librarification-Aspirations
-
-[Compiler Backend]: #Compiler-Backend
-[Review Queue Crew]: #Review-Queue-Crew
+## Work Items
 
 Category  | [Concrete Initiatives] |  [Aspirations]
 ----------|---------------------|-----------

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -21,7 +21,7 @@ This document is structured into three parts: our [Overall Themes][] for this ye
 Part of the motivation for this note is to encourage new contributors to get involved. We have a lot of newcomers, from individuals to large organizations, who are very excited about Rust's potential, and we want to show all of them what they can do to help.
 
 This is a list of items, divided into a [Concrete Initiatives][] section and an [Aspirations][] section. We accumulated these items during discussions with the Compiler Team and the Compiler Contributors.
-The [Concrete Initiatives][] have owners assigned; each has  allocated time this year to attack the problem. The [Aspirations][], on the other hand, are items that the team agrees would be great areas for investment, but where we currently lack sufficient resources or experienced developers to make progress this year. 
+The [Concrete Initiatives][] have owners assigned; each has  allocated time this year to attack the problem. The [Aspirations][], on the other hand, are items that the team agrees would be great areas for investment, but where we currently lack sufficient resources or experienced developers to make progress this year.
 
 This is *not* a list of everything we will do this year; at least, not without help.
 
@@ -29,7 +29,7 @@ You can think of the [Aspirations][] part of the doc as an explicit call to arms
 
 As you read the document, it is useful to keep in mind that [Rust is not a company][mara-post]: The teams, and the leaders of the teams, do not establish goals in a top-down manner, nor do they hand out tasks in a round-robin fashion. Instead, we collectively (and iteratively) refine our a shared vision for the future, and take steps that hopefully move towards that future. Each contributor decides for themself how much time they can afford to contribute, and that can vary wildly between contributors. The goals that we set for the project must be aligned with the goals of our current and future contributors; otherwise, they just won't get done. We have processes (e.g. [RFCs](https://github.com/rust-lang/rfcs#readme), [MCPs](https://forge.rust-lang.org/compiler/mcp.html)) that try to ensure alignment; in some ways, a document like this one is just another tool for recalibrating alignment.
 
-<!-- 
+<!--
 But the flip side of this is: if something really is important, then there almost certainly exists a contributor willing to work on it. The real hurdle then is *enabling* that contributor to succeed.
 (Note: this is hard! Its not just about mentorship/education; its just as much about achieving *alignment* amongst the whole group!)
 -->
@@ -46,26 +46,26 @@ But the flip side of this is: if something really is important, then there almos
 <!-- [bjorn3 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/133247-user133247 --> <!-- @**bjorn3**  -->
 <!-- bjorn3 donation page: https://liberapay.com/bjorn3 -->
 [cjgillot]: https://github.com/cjgillot
-<!-- [cjgillot zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 --> <!-- @**cjgillot**  --> 
+<!-- [cjgillot zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 --> <!-- @**cjgillot**  -->
 <!-- no response from cjgillot re affiliation yet -->
 [davidtwco]: https://github.com/davidtwco
 <!-- [davidtwco zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 --> <!-- @**davidtwco**  -->
 <!-- davidtwco affiliation: "Huawei R&D UK"-->
 [estebank]: https://github.com/estebank
 <!-- [estebank zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/119031-user119031 --> <!-- @**Esteban Küber** -->
-<!-- estebank affiliation: AWS --> 
+<!-- estebank affiliation: AWS -->
 [lcnr]: https://github.com/lcnr
 <!-- [lcnr zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/216206-user216206 --> <!-- @**lcnr** -->
 <!-- lcnr sponsorship: https://lcnr.de/funding/ -->
-[mw]: https://github.com/michaelwoerister
-<!-- [mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287 --> <!-- @**mw** -->
+[michaelwoerister]: https://github.com/michaelwoerister
+<!-- [mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287 --> <!-- @**michaelwoerister** -->
 <!-- mw affiliation: MS -->
 [nikomatsakis]: https://github.com/nikomatsakis
 <!-- [nikomatsakis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116009-user116009 --> <!-- @**nikomatsakis** -->
 <!-- nikomatsakis affiliation: AWS -->
 [oli-obk]: https://github.com/oli-obk
 <!-- [oli-obk zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124288-user124288 --> <!-- @**oli** -->
-<!-- oli affiliation: AWS --> 
+<!-- oli affiliation: AWS -->
 [jackh726]: https://github.com/jackh726
 <!-- [jackh726 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/232957-user232957 --> <!-- @**Jack Huey** -->
 <!-- jackh726: no affiliation -->
@@ -93,7 +93,7 @@ But the flip side of this is: if something really is important, then there almos
 [apiraino]: https://github.com/apiraino
 <!-- [apiraino zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/250987-user250987 --> <!-- @**apiraino**  -->
 <!-- apiraino: no affiliation -->
-[simulacrum]: https://github.com/Mark-simulacrum
+[Mark-Simulacrum]: https://github.com/Mark-Simulacrum
 <!-- [simulacrum zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116122-user116122 --> <!-- @**simulacrum**  -->
 <!-- simulacrum sponsorship: https://github.com/sponsors/Mark-Simulacrum -->
 [rylev]: https://github.com/rylev
@@ -164,7 +164,7 @@ Diagnostics  (👩‍💻) |                             | [Aspirations][Diagnos
 
 ## Concrete Initiatives
 
-This section is the closest thing to a "roadmap" we have for 2022. It is a list of important items with dedicated owners that have time allocated to make significant progress on the problem this year. 
+This section is the closest thing to a "roadmap" we have for 2022. It is a list of important items with dedicated owners that have time allocated to make significant progress on the problem this year.
 
 ### I-unsound issues (🦀)
 
@@ -186,10 +186,9 @@ Rust today does not allow `async fn` in a trait, so Async Rust code usually ends
 
 #### async crashdump dissection
 
-[mw], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs. He is `@**mw**` [on zulip].
+[michaelwoerister], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs. He is `@**mw**` [on zulip].
 
 There is a ton of other work being done in the Async Rust space. Check out the [Async Vision web site](https://rust-lang.github.io/wg-async/welcome.html) for more information.
-
 
 ### Debugging Initiatives (🦀)
 
@@ -198,16 +197,16 @@ There is a ton of other work being done in the Async Rust space. Check out the [
 The immediate goals for this initiative: establish the working group, determine priorities for the backlog of debugging issues, and find out what active users of debuggers miss most when they operate on Rust code.
 
 ### Faster Builds Initiatives (👩‍💻, 🛠️)
- 
+
 The Rust compiler's end-to-end latency is known to be a problem.
- 
+
 [lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA). They are `@**lqd**` and `@**nnethercote**` [on zulip].
 
 [ISRG]: https://www.abetterinternet.org/
 
 ### Expressiveness Initiatives (👩‍💻, 🦀)
 
-A common refrain we hear is: "I need feature X, but it's not implemented in rustc or stable." 
+A common refrain we hear is: "I need feature X, but it's not implemented in rustc or stable."
 In Rust, we use an open Request-for-Comment (RFC) process for designing new features. Currently, we have [this set of RFCs approved][RFC tracking issue list]; here are some imporant features with dedicated owners that we expect forward movement on.
 
 [RFC tracking issue list]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AC-tracking-issue++label%3AB-RFC-approved+
@@ -268,9 +267,9 @@ If you want to discuss more with us about past attempts and ideas for the future
 
 #### Incremental Compilation Aspirations
 
-Incremental compilation performance and stability are both ongoing concerns to the team. We *know* there is significant room to improve the effectiveness of incremental compilation, in terms of reducing the amount of redundant work done by successive `rustc` invocations. 
+Incremental compilation performance and stability are both ongoing concerns to the team. We *know* there is significant room to improve the effectiveness of incremental compilation, in terms of reducing the amount of redundant work done by successive `rustc` invocations.
 
-In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compiliation which does not require deep knowledge of the compiler. 
+In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compiliation which does not require deep knowledge of the compiler.
 
 If you want to learn more, reach out to [cjgillot] and [Aaron Hill]. They are `@**cjgillot**` and `@**Aaron Hill**` [on zulip].
 
@@ -320,11 +319,11 @@ If you are interested in helping in this area, please reach out to [pnkfelix]. T
 
 #### Performance Dashboard
 
-[perf.rust-lang.org][perf] is a dashboard that measures the performance of `rustc`, in terms of resources (time and memory) consumed during compilation. [@rust-timer] is a bot that summarizes whether a given Pull Request regressed or improved performance. 
+[perf.rust-lang.org][perf] is a dashboard that measures the performance of `rustc`, in terms of resources (time and memory) consumed during compilation. [@rust-timer] is a bot that summarizes whether a given Pull Request regressed or improved performance.
 
 The performance working group has many ideas for things to improve in these tools, but limited resources. This is an area where you don't need any compiler expertise to make a huge impact; for example, our Web Front-end could use work. And Data Scientists might have useful insights into our problems. Beyond just measuring the compiler's own performance, we're also interested in measuring the runtime performance of produced binaries.
 
-Reach out to [rylev], from Microsoft, and [simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help. They are `@**rylev**` and `@**simulacrum**` [on zulip].
+Reach out to [rylev], from Microsoft, and [Mark-Simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help. They are `@**rylev**` and `@**simulacrum**` [on zulip].
 
 [@rust-timer]: https://github.com/rust-timer
 [perf]: https://perf.rust-lang.org/
@@ -362,13 +361,9 @@ Diagnostics improvements are an *excellent* first step for learning about how to
 
 ## Conclusion
 
-Reading over this list, the number of items on it seems quite daunting.
+Reading over this list, the number of items on it seems quite daunting! We believe these initiatives will provide the highest impact to the Rust community by helping to fulfill Rust's promise, delighting Rust developers and improving our contributor workflows and aligns well with the results of the [2021 Rust Survey](https://blog.rust-lang.org/2022/02/15/Rust-Survey-2021.html).
 
-Do we really think we can get all this stuff done in one year?
-
-No, we don't! 😂
-
-The introduction explicitly said the latter half are things that *don't* have resources attached to them. And the word "aspiration" was chosen to reinforce that.
+While we think we will be able to make signficant progress on these initiatives this year, project estimation is a difficult and inexact science, especially for open source projects. What we will achieve is ultimately a result of who decides to contribute. Our aspirational goals are currently just that: aspriations.
 
 This is where you all, the Rust community (including *future members* of that community) come into the picture. Each item has one or two people listed with it; if you're feeling inspired, please do contact us!
 
@@ -382,7 +377,7 @@ The compiler team leadership plans to put out a post in June summarizing the pro
 
 #### I did not see any mention of monadic burritos (or other non-Rust language feature); why is that not part of your plan?
 
-The scope of this doc is largely restricted to Compiler Team issues. Language design work is done by the Language Design team. You can reach out to them about their initiatives for this year and beyond.
+The scope of this doc is largely restricted to Compiler Team issues. Language design work is done by the Language Team. You can reach out to them about their initiatives for this year and beyond.
 
 #### What do I do if I'm interested in learning more about a specific item on this list?
 
@@ -401,9 +396,3 @@ This is not a problem! Many members of our community learned about compilers by 
 [Contributing to the Compiler]: https://www.youtube.com/watch?v=vCODCbUSA_w
 
 In addition, there are areas in this project where people without compiler expertise can have impact. For example, as mentioned in the [Performance Dashboard](#Performance-Dashboard) section, some of our internal tools could use some web front-end work.
-
-
-
-
-
-

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -266,7 +266,7 @@ If you want to discuss more with us about past attempts and ideas for the future
 
 Incremental compilation performance and stability are both ongoing concerns to the team. We *know* there is significant room to improve the effectiveness of incremental compilation, in terms of reducing the amount of redundant work done by successive `rustc` invocations.
 
-In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compilation which does not require deep knowledge of the compiler.
+In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compilation which does not require deep knowledge of the compiler. We have had to disable and subsequently reenable incremental compilation on the stable release; we want to expand our validation strategies so that we get alerted to problems in incremental compilation well before they come close to the stable channel.
 
 If you want to learn more, reach out to [cjgillot] and [Aaron Hill].
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -173,8 +173,7 @@ As of this writing, we have 69 [open issues tagged I-unsound](https://github.com
 
 In theory, any unsoundness issue potentially undermines Rust's promise of reliability. We want, by the end of this year, to have a clear understanding of how each of those I-unsound issues came to be. We are looking into systematically detecting such issues and whether we can deploy mitigations or fixes for entire classes of issues, instead of addressing them on a case by case basis.
 
-[oli-obk], from Amazon Web Services, will be the primary owner of  work in this space. Please reach out to [oli-obk] and [pnkfelix] (also from Amazon Web Services) if you are interested in helping resolve these issues! They are `@**oli**` and `@**pnkfelix**` [on zulip].
-
+[oli-obk] will be the primary owner of work in this space. Please reach out to [oli-obk] and [pnkfelix] if you are interested in helping resolve these issues!
 
 ### Async Rust Initiatives (🦀, 👩‍💻)
 
@@ -182,17 +181,17 @@ There is significant overlap between async rust and other areas of this document
 
 #### async traits
 
-Rust today does not allow `async fn` in a trait, so Async Rust code usually ends up with components that are too tightly coupled; one cannot write reusable, general-purpose libraries without using workarounds like `#[async_trait]` that impose hidden costs. [nikomatsakis], from Amazon Web Services, and [tmandry], from Google, are driving the [async fn in traits initiative](https://github.com/rust-lang/async-fundamentals-initiative/issues/5), which will unlock the ability to write `async` methods in traits, natively. They are `@**nikomatsakis**` and `@**tmandry**` [on zulip].
+Rust today does not allow `async fn` in a trait, so Async Rust code usually ends up with components that are too tightly coupled; one cannot write reusable, general-purpose libraries without using workarounds like `#[async_trait]` that impose hidden costs. [nikomatsakis] and [tmandry] are driving the [async fn in traits initiative](https://github.com/rust-lang/async-fundamentals-initiative/issues/5), which will unlock the ability to write `async` methods in traits, natively.
 
 #### async crashdump dissection
 
-[michaelwoerister], from Microsoft, is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs. He is `@**mw**` [on zulip].
+[michaelwoerister] is driving the [async crashdump initiative](https://rust-lang.github.io/async-crashdump-debugging-initiative/), which will enable developers to understand the control-flow stacks encoded in crashdumps for their async Rust programs.
 
 There is a ton of other work being done in the Async Rust space. Check out the [Async Vision web site](https://rust-lang.github.io/wg-async/welcome.html) for more information.
 
 ### Debugging Initiatives (🦀)
 
-[wesleywiser], from Microsoft, and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([michaelwoerister], [wesleywiser]), supporting split debuginfo ([davidtwco], from Huawei R&D UK), and better integration with trace-based debuggers like `rr` ([pnkfelix]). They are `@**Wesley Wiser**`, `@**pnkfelix**`, `@**mw**` and `@**davidtwco**` [on zulip].
+[wesleywiser] and [pnkfelix] are spinning up a wg-debugging working group. It will cover at least the following sub-items: improving Rust's debuginfo quality ([michaelwoerister], [wesleywiser]), supporting split debuginfo ([davidtwco]), and better integration with trace-based debuggers like `rr` ([pnkfelix]).
 
 The immediate goals for this initiative: establish the working group, determine priorities for the backlog of debugging issues, and find out what active users of debuggers miss most when they operate on Rust code.
 
@@ -200,7 +199,7 @@ The immediate goals for this initiative: establish the working group, determine 
 
 The Rust compiler's end-to-end latency is known to be a problem.
 
-[lqd], sponsored by the Internet Security Research Group, is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote] (from Futurewei Technologies). [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA). They are `@**lqd**` and `@**nnethercote**` [on zulip].
+[lqd] is dedicating the majority of 2022 to working on this, partnering with Rust's compiler-performance working group as well as performance experts like [nnethercote]. [lqd] has their own [living document](https://hackmd.io/3Dp68rTDSpWvRDfWF6lbMw?view) that lists areas under investigation, and [nnethercote] has a [roadmap under development](https://hackmd.io/YJQSj_nLSZWl2sbI84R1qA).
 
 [ISRG]: https://www.abetterinternet.org/
 
@@ -217,9 +216,7 @@ Generic Associated Types, or [GATs](https://github.com/rust-lang/generic-associa
 
 [`async fn` in traits](https://github.com/rust-lang/async-fundamentals-initiative/issues/5) is an ongoing effort (already mentioned above) owned by [tmandry]. This is one of the most frequently requested features for async rust: supplying first class support for traits like `trait Foo { async fn bar(&self); }`
 
-The [safe transmute](https://github.com/rust-lang/lang-team/issues/21) project, led by [jswrenn] from Amazon Web Services, is expected to be feature-complete in summer 2022. It will enable a large class of types to be transmuted (i.e. zero-cost type conversion) without any risk of injecting undefined behavior.
-
-You can reach these owners as `@**Jack Huey**`, `@**tmandry**`, and `@**Jack Wrenn**` [on zulip].
+The [safe transmute](https://github.com/rust-lang/lang-team/issues/21) project, led by [jswrenn], is expected to be feature-complete in summer 2022. It will enable a large class of types to be transmuted (i.e. zero-cost type conversion) without any risk of injecting undefined behavior.
 
 ### Librarification Initiatives (🛠️)
 
@@ -233,7 +230,7 @@ These are initiatives dedicated to the "librarification" of the compiler: breaki
 
 Chalk has been years in development, and has been experimentally integrated into rustc in the past. This year, [jackh726] and [nikomatsakis] own the task of improving the chalk integration, to drive it to the point where the team can consider migrating to chalk as the implementation of the trait system. This will unlock many features that up until now have been too difficult to implement in the old trait system implementation, and its declarative structure will provide a proper foundation for people to reason about the *correctness* of the trait system.
 
-If you want to help out with this, reach out to [jackh726] and [nikomatsakis]. They are `@**Jack Huey**` and `@**nikomatsakis**` [on zulip].
+If you want to help out with this, reach out to [jackh726] and [nikomatsakis].
 
 ## Aspirations
 
@@ -243,9 +240,9 @@ If you are interested in helping with any items here, please do reach out to the
 
 ### P-high Aspirations (🦀)
 
-[pnkfelix] and [wesleywiser], as team leads, are deploying processes to help us get a handle on the "high priority, but *not critical*" issues that the compiler has accumulated. We will be gradually identifying owners for each who will move progress forward, and in general working to keep better track of the set overall.
+[pnkfelix] and [wesleywiser], as Compiler Team leads, are deploying processes to help us get a handle on the "high priority, but *not critical*" issues that the compiler has accumulated. We will be gradually identifying owners for each who will move progress forward, and in general working to keep better track of the set overall.
 
-If you would like to help with the task of reviewing or resolving such issues, reach out to [wesleywiser] and [apiraino], who are co-leads of WG-prioritization. They are `@**Wesley Wiser**` and `@**apiraino**` [on zulip].
+If you would like to help with the task of reviewing or resolving such issues, reach out to [wesleywiser] and [apiraino], who are co-leads of WG-prioritization.
 
 ### Debugging Aspirations (👩‍💻)
 
@@ -255,7 +252,7 @@ We want to improve expression evaluation support: Today, most forms of method in
 
 We want to revisit our debugger extension architecture for rendering Rust data structures, which is currently mostly independent sets of Python scripts.
 
-If you want to help out here, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` [on zulip].
+If you want to help out here, please reach out to [pnkfelix] and [wesleywiser].
 
 ### Faster Builds Aspirations (👩‍💻, 🛠️)
 
@@ -263,7 +260,7 @@ If you want to help out here, please reach out to [pnkfelix] and [wesleywiser]. 
 
 Parallel Compilation is one avenue for improving compiler performance. It is also a very complex area, especially when it comes to the tradeoff of how much of a hit one is willing to take on single core builds in order to enable more parallel computation. We already parallelize our LLVM invocations, but the parallelization of the rest of the compiler remains in an experimental state. This is an area we think needs long-term collaborative effort with the compiler team. We do not expect to deliver a solution here this year.
 
-If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser]. They are `@**pnkfelix**` and `@**Wesley Wiser**` [on zulip].
+If you want to discuss more with us about past attempts and ideas for the future, please reach out to [pnkfelix] and [wesleywiser].
 
 #### Incremental Compilation Aspirations
 
@@ -271,14 +268,14 @@ Incremental compilation performance and stability are both ongoing concerns to t
 
 In addition, there is a significant amount of work that could be done to improve our testing infrastructure for incremental compiliation which does not require deep knowledge of the compiler.
 
-If you want to learn more, reach out to [cjgillot] and [Aaron Hill]. They are `@**cjgillot**` and `@**Aaron Hill**` [on zulip].
+If you want to learn more, reach out to [cjgillot] and [Aaron Hill].
 
 #### Inter-crate Sharing Aspirations
 
 nnethercote has noted that there may be opportunities
 to improve end-to-end compilation time for multi-crate builds by identifying redundant activity that can be shared between builds of distinct crates. (For example, the metadata from libstd is read and decoded on every single crate compile.)
 
-If you are interested in exploring this idea further, reach out to [nnethercote] and [lqd]. They are `@**nnethercote**` and `@**lqd**` [on zulip].
+If you are interested in exploring this idea further, reach out to [nnethercote] and [lqd].
 
 ### Expressiveness Aspirations (🦀, 👩‍💻)
 
@@ -286,7 +283,7 @@ const generics and const eval are making steady progress. There are a *lot* of f
 
 What we can probably use the most help with is in identifying what subset of the features we should be striving to stabilize in order to unlock specific use cases for Rust developers.
 
-So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] (supported via [sponsorship][sponsor-lcnr]) and [oli-obk]. They are `@**lcnr**` and `@**oli**` [on zulip].
+So, if you or your team is enthuastically awaiting const generics or const eval, reach out to [lcnr] and [oli-obk].
 
 [sponsor-lcnr]: https://lcnr.de/funding/
 
@@ -302,7 +299,7 @@ For example, [Kani] is a bit-precise model-checker for Rust under development at
 [Prusti]: https://github.com/viperproject/prusti-dev#prusti
 [Creusot]: https://github.com/xldenis/creusot#about
 
-Reach out to [xldenis], from the LMF at the University of Paris-Saclay (and co-lead of the Rust Formal Methods working group), and [pnkfelix] if you are interested in helping us here. They are `@**Xavier Denis**` and `@**pnkfelix**` [on zulip].
+Reach out to [xldenis], from the LMF at the University of Paris-Saclay (and co-lead of the Rust Formal Methods working group), and [pnkfelix] if you are interested in helping us here.
 
 ### Compiler Team Operations Aspirations (🛠️)
 
@@ -312,7 +309,7 @@ One common task for compiler developers is to create a [minimal complete verifia
 
 This is an area where you do not need any knowledge of the `rustc` source code at all. Anyone with an interest in programming language technology can get involved; e.g. one might consider adding IDE commands for certain code reducing transformations.
 
-If you are interested in helping in this area, please reach out to [pnkfelix]. They are `@**pnkfelix**` [on zulip].
+If you are interested in helping in this area, please reach out to [pnkfelix].
 
 [E-needs-mcve]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-needs-mcve+
 [mcve blog post]: https://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
@@ -323,7 +320,7 @@ If you are interested in helping in this area, please reach out to [pnkfelix]. T
 
 The performance working group has many ideas for things to improve in these tools, but limited resources. This is an area where you don't need any compiler expertise to make a huge impact; for example, our Web Front-end could use work. And Data Scientists might have useful insights into our problems. Beyond just measuring the compiler's own performance, we're also interested in measuring the runtime performance of produced binaries.
 
-Reach out to [rylev], from Microsoft, and [Mark-Simulacrum] (supported via [sponsorship](https://github.com/sponsors/Mark-Simulacrum)), performance working group lead, if you want to help. They are `@**rylev**` and `@**simulacrum**` [on zulip].
+Reach out to [rylev] and [Mark-Simulacrum], performance working group lead, if you want to help.
 
 [@rust-timer]: https://github.com/rust-timer
 [perf]: https://perf.rust-lang.org/
@@ -332,13 +329,13 @@ Reach out to [rylev], from Microsoft, and [Mark-Simulacrum] (supported via [spon
 
 #### Ease writing new backends
 
-One source of tedium when defining a new Rust compiler backend is implementing the intrinsics that each backend must provide. But a small change to the intrinsic system: namely, allowing intrinsics to define a [fallback MIR implementation][], could ease that burden. Reach out to [scottmcm] if you are interested in helping out here. They are `@**scottmcm**` [on zulip].
+One source of tedium when defining a new Rust compiler backend is implementing the intrinsics that each backend must provide. But a small change to the intrinsic system: namely, allowing intrinsics to define a [fallback MIR implementation][], could ease that burden. Reach out to [scottmcm] if you are interested in helping out here.
 
 [fallback MIR implementation]: https://github.com/rust-lang/rust/issues/93145
 
 #### Cranelift
 
-The [Cranelift Code Generator][Cranelift] is getting a lot of attention from various parties. rustc has a [Cranelift backend][]. If you are interested in helping out with it, reach out to [bjorn3] (supported via [sponsorship][sponsor-bjorn3]). They are `@**bjorn3**` [on zulip].
+The [Cranelift Code Generator][Cranelift] is getting a lot of attention from various parties. rustc has a [Cranelift backend][]. If you are interested in helping out with it, reach out to [bjorn3].
 
 [sponsor-bjorn3]: https://liberapay.com/bjorn3
 
@@ -349,14 +346,14 @@ The [Cranelift Code Generator][Cranelift] is getting a lot of attention from var
 
 In addition to the LLVM and Cranelift backends, there is also a new backend under development that uses `libgccjit` from GCC (which, as many have clarified, is usable for ahead-of-time as well as just-in-time compilation). This backend enables Rust to target more platforms that are not supported by LLVM.
 
-If you are interested in helping out with this project, reach out to [antoyo] (supported via [sponsorship](https://github.com/sponsors/antoyo)) and [bjorn3]. They are `@**antoyo**` and `@**bjorn3**` [on zulip].
+If you are interested in helping out with this project, reach out to [antoyo] and [bjorn3].
 
 
 ### Diagnostics Aspirations (👩‍💻)
 
 The Rust compiler has pretty good diagnotics. But the good news is, there's a [full employment theorem](https://en.wikipedia.org/wiki/Full_employment_theorem) for diagnostics engineers which is supported by the 1,500+ [open diagnostics issues](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-diagnostics) we have.
 
-Diagnostics improvements are an *excellent* first step for learning about how to contribute to the Rust compiler. If you're interested in helping out but don't have any idea where to start, fixing diagnostic bugs is a great jumping off point, and you can reach out to [estebank], at Amazon Web Services, to find out more about how to help. They are `@**Esteban Küber**` [on zulip].
+Diagnostics improvements are an *excellent* first step for learning about how to contribute to the Rust compiler. If you're interested in helping out but don't have any idea where to start, fixing diagnostic bugs is a great jumping off point, and you can reach out to [estebank] to find out more about how to help.
 
 
 ## Conclusion
@@ -396,3 +393,32 @@ This is not a problem! Many members of our community learned about compilers by 
 [Contributing to the Compiler]: https://www.youtube.com/watch?v=vCODCbUSA_w
 
 In addition, there are areas in this project where people without compiler expertise can have impact. For example, as mentioned in the [Performance Dashboard](#Performance-Dashboard) section, some of our internal tools could use some web front-end work.
+
+### How can I contact an item's owners or sponsor their work on Rust?
+
+This table lists the item owners mentioned above, their [Zulip] username and if they are accepting sponsorships to help them work on Rust:
+
+Owner | Zulip Username | Accepting sponsorships?
+-|-|-
+[Aaron Hill] | `@Aaron Hill` | No
+[antoyo] | `@antoyo` | Yes: [GitHub Sponsors](https://github.com/sponsors/antoyo)
+[apiraino] | `@apiraino` | No
+[bjorn3] | `@bjorn3` | Yes: [Librapay](https://liberapay.com/bjorn3)
+[cjgillot] | `@cjgillot` | No
+[davidtwco] | `@davidtwco` | No: works on Rust at Huawei R&D UK
+[estebank] | `@Esteban Küber` | No: works on Rust at Amazon Web Services
+[jackh726] | `@Jack Huey` | No
+[jswrenn] | `@Jack Wrenn` | No: works on Rust at Amazon Web Services
+[lcnr] | `@lcnr` | Yes: https://lcnr.de/funding/
+[lqd] | `@lqd` | No: sponsored by the Internet Security Research Group
+[Mark-Simulacrum] | `@simulacrum` | Yes, [GitHub Sponsors](https://github.com/sponsors/Mark-Simulacrum)
+[michaelwoerister] | `@mw` | No: works on Rust at Microsoft
+[nikomatsakis] | `@nikomatsakis` | No: works on Rust at Amazon Web Services
+[nnethercote] | `@nnethercote` | No: works on Rust at Futurewei
+[oli-obk] | `@oli` | No: works on Rust at Amazon Web Services
+[pnkfelix] | `@pnkfelix` | No: works on Rust at Amazon Web Services
+[rylev] | `@rylev` | No: works on Rust at Microsoft
+[scottmcm] | `@scottmcm` | No
+[tmandry] | `@tmandry` | No: works on Rust at Google
+[wesleywiser] | `@Wesley Wiser` | No: works on Rust at Microsoft
+[xldenis] | `@Xavier Denis` | No

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -374,7 +374,7 @@ The compiler team leadership plans to put out a post in June summarizing the pro
 
 #### I did not see any mention of monadic burritos (or other non-Rust language feature); why is that not part of your plan?
 
-The scope of this doc is largely restricted to Compiler Team issues. Language design work is done by the Language Team. You can reach out to them about their initiatives for this year and beyond.
+The scope of this doc is largely restricted to Compiler Team issues. The Language Team is planning to write more about their initiatives for this year and beyond in another post. Stay tuned for that!
 
 #### What do I do if I'm interested in learning more about a specific item on this list?
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -403,7 +403,7 @@ Owner | Zulip Username | Accepting sponsorships?
 [Aaron Hill] | `@Aaron Hill` | No
 [antoyo] | `@antoyo` | Yes: [GitHub Sponsors](https://github.com/sponsors/antoyo)
 [apiraino] | `@apiraino` | No
-[bjorn3] | `@bjorn3` | Yes: [Librapay](https://liberapay.com/bjorn3)
+[bjorn3] | `@bjorn3` | Yes: [Liberapay](https://liberapay.com/bjorn3)
 [cjgillot] | `@cjgillot` | No
 [davidtwco] | `@davidtwco` | No: works on Rust at Huawei R&D UK
 [estebank] | `@Esteban Küber` | No: works on Rust at Amazon Web Services

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -37,70 +37,70 @@ But the flip side of this is: if something really is important, then there almos
 [mara-post]: https://blog.m-ou.se/rust-is-not-a-company/
 
 [antoyo]: https://github.com/antoyo
-[antoyo zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/404242-user404242
+[antoyo zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/404242-user404242 <!-- @**antoyo** -->
 <!-- antoyo sponsorship: https://github.com/sponsors/antoyo -->
 [Aaron Hill]: https://github.com/Aaron1011
-[Aaron Hill zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083
+[Aaron Hill zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083 <!-- @**Aaron Hill** -->
 <!-- Aaron1011: no affiliation -->
 [bjorn3]: https://github.com/bjorn3
-[bjorn3 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/133247-user133247
+[bjorn3 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/133247-user133247 <!-- @**bjorn3**  -->
 <!-- bjorn3 donation page: https://liberapay.com/bjorn3 -->
 [cjgillot]: https://github.com/cjgillot
-[cjgillot zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906
+[cjgillot zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 <!-- @**cjgillot**  --> 
 <!-- no response from cjgillot re affiliation yet -->
 [davidtwco]: https://github.com/davidtwco
-[davidtwco zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906
+[davidtwco zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906 <!-- @**davidtwco**  -->
 <!-- davidtwco affiliation: "Huawei R&D UK"-->
 [estebank]: https://github.com/estebank
-[estebank zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/119031-user119031
+[estebank zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/119031-user119031 <!-- @**Esteban Küber** -->
 <!-- estebank affiliation: AWS --> 
 [lcnr]: https://github.com/lcnr
-[lcnr zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/216206-user216206
+[lcnr zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/216206-user216206 <!-- @**lcnr** -->
 <!-- lcnr sponsorship: https://lcnr.de/funding/ -->
 [mw]: https://github.com/michaelwoerister
-[mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287
+[mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287 <!-- @**mw** -->
 <!-- mw affiliation: MS -->
 [nikomatsakis]: https://github.com/nikomatsakis
-[nikomatsakis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116009-user116009
+[nikomatsakis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116009-user116009 <!-- @**nikomatsakis** -->
 <!-- nikomatsakis affiliation: AWS -->
 [oli-obk]: https://github.com/oli-obk
-[oli-obk zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124288-user124288
+[oli-obk zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124288-user124288 <!-- @**oli** -->
 <!-- oli affiliation: AWS --> 
 [jackh726]: https://github.com/jackh726
-[jackh726 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/232957-user232957
+[jackh726 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/232957-user232957 <!-- @**Jack Huey** -->
 <!-- jackh726: no affiliation -->
 [lqd]: https://github.com/lqd
-[lqd zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116113-user116113
+[lqd zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116113-user116113 <!-- @**lqd**  -->
 <!-- lqd affiliation: ISRG -->
 [nnethercote]: https://github.com/nnethercote
-[nnethercote zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/120989-user120989
+[nnethercote zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/120989-user120989 <!-- @**nnethercote**  -->
 <!-- nnethercote affiliation: Futurewei -->
 [tmandry]: https://github.com/tmandry
-[tmandry zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116883-user116883
+[tmandry zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116883-user116883 <!-- @**tmandry**  -->
 <!-- tmandry affiliation: Google (TBD) -->
 [scottmcm]: https://github.com/scottmcm
-[scottmcm zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125270-user125270
+[scottmcm zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125270-user125270 <!-- @**scottmcm**  -->
 <!-- scottmcm: no affiliation -->
 [pnkfelix]: https://github.com/pnkfelix
-[pnkfelix zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083 -->
+[pnkfelix zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083  <!-- @**pnkfelix**  -->
 <!-- pnkfelix affiliation: AWS -->
 [wesleywiser]: https://github.com/wesleywiser
-[wesleywiser zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125250-user125250
+[wesleywiser zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125250-user125250 <!-- @**Wesley Wiser**  -->
 <!-- wesleywiser affiliation: MS -->
 [jswrenn]: https://github.com/jswrenn
-[jswrenn zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/219211-user219211
+[jswrenn zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/219211-user219211 <!-- @**Jack Wrenn** -->
 <!-- jswrenn affiliation: AWS -->
 [apiraino]: https://github.com/apiraino
-[apiraino zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/250987-user250987
+[apiraino zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/250987-user250987 <!-- @**apiraino**  -->
 <!-- apiraino: no affiliation -->
 [simulacrum]: https://github.com/Mark-simulacrum
-[simulacrum zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116122-user116122
+[simulacrum zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116122-user116122 <!-- @**simulacrum**  -->
 <!-- simulacrum sponsorship: https://github.com/sponsors/Mark-Simulacrum -->
 [rylev]: https://github.com/rylev
-[rylev zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/224872-user224872
+[rylev zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/224872-user224872 <!-- @**rylev**  -->
 <!-- rylev affiliation: MS -->
 [xldenis]: https://github.com/xldenis
-[xldenis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/312719-user312719
+[xldenis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/312719-user312719 <!-- @**Xavier Denis**  -->
 
 ## Overall Themes
 

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -82,6 +82,11 @@ But the flip side of this is: if something really is important, then there almos
 
 ## Overall Themes
 
+There are three themes associated with the work we are planning; this section describes those themes, and attaches an
+emoji to each one which may help you when looking at the [tabular overview][Work Items].
+
+[Work Items]: #work-items
+
 ### Fulfill Rust's Promise (🦀)
 
 Fulfilling Rust's Promise is a cross-cutting theme; it means identifying the gaps between expectation and reality for each of our three pillars: [Performance, Reliability, and Productivity][rust-lang], and then addressing those gaps.

--- a/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
+++ b/posts/inside-rust/2022-02-22-compiler-team-ambitions-2022.md
@@ -37,48 +37,70 @@ But the flip side of this is: if something really is important, then there almos
 [mara-post]: https://blog.m-ou.se/rust-is-not-a-company/
 
 [antoyo]: https://github.com/antoyo
+[antoyo zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/404242-user404242
 <!-- antoyo sponsorship: https://github.com/sponsors/antoyo -->
 [Aaron Hill]: https://github.com/Aaron1011
+[Aaron Hill zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083
 <!-- Aaron1011: no affiliation -->
 [bjorn3]: https://github.com/bjorn3
+[bjorn3 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/133247-user133247
 <!-- bjorn3 donation page: https://liberapay.com/bjorn3 -->
 [cjgillot]: https://github.com/cjgillot
+[cjgillot zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906
 <!-- no response from cjgillot re affiliation yet -->
 [davidtwco]: https://github.com/davidtwco
+[davidtwco zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/248906-user248906
 <!-- davidtwco affiliation: "Huawei R&D UK"-->
 [estebank]: https://github.com/estebank
+[estebank zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/119031-user119031
 <!-- estebank affiliation: AWS --> 
 [lcnr]: https://github.com/lcnr
+[lcnr zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/216206-user216206
 <!-- lcnr sponsorship: https://lcnr.de/funding/ -->
 [mw]: https://github.com/michaelwoerister
+[mw zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124287-user124287
 <!-- mw affiliation: MS -->
 [nikomatsakis]: https://github.com/nikomatsakis
+[nikomatsakis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116009-user116009
 <!-- nikomatsakis affiliation: AWS -->
 [oli-obk]: https://github.com/oli-obk
+[oli-obk zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/124288-user124288
 <!-- oli affiliation: AWS --> 
 [jackh726]: https://github.com/jackh726
+[jackh726 zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/232957-user232957
 <!-- jackh726: no affiliation -->
 [lqd]: https://github.com/lqd
+[lqd zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116113-user116113
 <!-- lqd affiliation: ISRG -->
 [nnethercote]: https://github.com/nnethercote
+[nnethercote zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/120989-user120989
 <!-- nnethercote affiliation: Futurewei -->
 [tmandry]: https://github.com/tmandry
+[tmandry zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116883-user116883
 <!-- tmandry affiliation: Google (TBD) -->
 [scottmcm]: https://github.com/scottmcm
+[scottmcm zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125270-user125270
 <!-- scottmcm: no affiliation -->
 [pnkfelix]: https://github.com/pnkfelix
+[pnkfelix zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116083-user116083 -->
 <!-- pnkfelix affiliation: AWS -->
 [wesleywiser]: https://github.com/wesleywiser
+[wesleywiser zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/125250-user125250
 <!-- wesleywiser affiliation: MS -->
 [jswrenn]: https://github.com/jswrenn
+[jswrenn zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/219211-user219211
 <!-- jswrenn affiliation: AWS -->
 [apiraino]: https://github.com/apiraino
+[apiraino zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/250987-user250987
 <!-- apiraino: no affiliation -->
 [simulacrum]: https://github.com/Mark-simulacrum
+[simulacrum zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/116122-user116122
 <!-- simulacrum sponsorship: https://github.com/sponsors/Mark-Simulacrum -->
 [rylev]: https://github.com/rylev
+[rylev zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/224872-user224872
 <!-- rylev affiliation: MS -->
 [xldenis]: https://github.com/xldenis
+[xldenis zulip PM]: https://rust-lang.zulipchat.com/#narrow/pm-with/312719-user312719
 
 ## Overall Themes
 


### PR DESCRIPTION
Adapted from https://hackmd.io/Hrl30lX9Q0mbLIT4VkR_UA

See also the original zulip thread: https://zulip-archive.rust-lang.org/stream/131828-t-compiler/topic/roadmap.20for.202022.20discussion.html

the meeting proposal: https://github.com/rust-lang/compiler-team/issues/483

and the actual meeting zulip thread: https://zulip-archive.rust-lang.org/stream/238009-t-compiler/meetings/topic/.5Bsteering.20meeting.5D.202022-02-18.20compiler-team.23483.html