### PR TITLE
Make core owner of the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @rust-lang/website
+* @rust-lang/core
 posts/* @rust-lang/core
 posts/inside-rust/* @rust-lang/inside-rust-reviewers @rust-lang/core
 .github/CODEOWNERS @rust-lang/core


### PR DESCRIPTION
The website team has no active member. Potential changes to anything but posts are blocked on that team, which is not great.