### PR TITLE
Update 1.59.0 release post: Fix example

### DIFF
--- a/posts/2022-02-24-Rust-1.59.0.md
+++ b/posts/2022-02-24-Rust-1.59.0.md
@@ -126,7 +126,7 @@ fn cartesian_product<
     T, const N: usize,
     U, const M: usize,
     V, F
->(a: [T; N], b: [U; M]) -> [[V; N]; M]
+>(a: [T; N], b: [U; M], f: F) -> [[V; N]; M]
 where
     F: FnMut(&T, &U) -> V
 {


### PR DESCRIPTION
I think that function in the example should have the referenced function as an argument. 

(I am quite new to rust, so I might be easily missing something.)