### PR TITLE
Update blog description to match current practice

### DIFF
--- a/posts/blog.yml
+++ b/posts/blog.yml
@@ -2,9 +2,9 @@ title: Rust Blog
 index-title: The Rust Programming Language Blog
 link-text: the main Rust blog
 description: Empowering everyone to build reliable and efficient software.
-index-html: This is the <b>main Rust blog</b>. The
-            <a href="https://www.rust-lang.org/governance/teams/core">core team</a>
-            uses this blog to announce big developments in the world of Rust.
-maintained-by: the Rust Team
+index-html: This is the <b>main Rust blog</b>.
+            <a href="https://www.rust-lang.org/governance/">Rust teams</a>
+            use this blog to announce major developments in the world of Rust.
+maintained-by: the Rust Teams
 requires-team: false
 


### PR DESCRIPTION
The Rust teams collaboratively maintain the content of the main Rust
blog. Minimally tweak the description to reflect this.