### PR TITLE
lang-team march update

### DIFF
--- a/posts/inside-rust/2022-03-09-lang-team-mar-update.md
+++ b/posts/inside-rust/2022-03-09-lang-team-mar-update.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: "Lang team March update"
+author: Niko Matsakis
+description: "Lang team March update"
+team: the lang team <https://lang-team.rust-lang.org/>
+---
+Two weeks ago, the lang team held its March planning meeting ([minutes]). We hold these meetings on the first Wednesday of every month and we use them to schedule [design meetings] for the remainder of the month.
+
+[minutes]: https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2022-03-02-planning-meeting.md
+
+[active-initiatives]: https://lang-team.rust-lang.org/initiatives.html
+
+## Upcoming design meetings
+
+We have planned the following design meetings:
+
+* March 9: Draft lang team roadmap (this already happened! [minutes](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2022-03-09-lang-roadmap.md))
+* March 16: [Backlog bonanza](https://lang-team.rust-lang.org/meetings/backlog-bonanza.html)
+* March 23: Return Position Impl Trait in Dyn Trait (RPITIDT) [lang-team#144](https://github.com/rust-lang/lang-team/issues/144)
+* March 30: Lint policy [lang-team#132](https://github.com/rust-lang/lang-team/issues/132)
+
+## Design meeting expectations
+
+* The document for the meeting must be prepared by the triage meeting on Tuesday and posted to the tracking issue.
+    * If it is not sent out by then, the meeting will be canceled. This gives folks 24 hour notice.
+* There is no expectation that people will read the document before the meeting. The meeting will begin with a recap of the document.
+    * However, there is no rule **against** reading the document beforehand and providing feedback or advice on how to improve it.
+
+[lang-team-141]: https://github.com/rust-lang/lang-team/issues/141
+[backlog bonanza]: https://lang-team.rust-lang.org/meetings/backlog-bonanza.html
+[design meetings]: https://lang-team.rust-lang.org/meetings/design.html


### PR DESCRIPTION
cc @joshtriplett -- links to things added by https://github.com/rust-lang/lang-team/pull/145/, so we should land that first