### PR TITLE
Fix first letter being cut off in latest blog post

### DIFF
--- a/posts/inside-rust/2022-03-09-lang-team-mar-update.md
+++ b/posts/inside-rust/2022-03-09-lang-team-mar-update.md
@@ -5,6 +5,7 @@ author: Niko Matsakis
 description: "Lang team March update"
 team: the lang team <https://lang-team.rust-lang.org/>
 ---
+
 Two weeks ago, the lang team held its March planning meeting ([minutes]). We hold these meetings on the first Wednesday of every month and we use them to schedule [design meetings] for the remainder of the month.
 
 [minutes]: https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2022-03-02-planning-meeting.md


### PR DESCRIPTION
I don't get why a missing newline would cause this kind of issue, but according to #878 that's why the first letter doesn't appear.