### PR TITLE
Don't assume an extra newline exists after the yaml front matter

### DIFF
--- a/src/posts.rs
+++ b/src/posts.rs
@@ -77,7 +77,8 @@ impl Post {
             ..ComrakOptions::default()
         };
 
-        let contents = comrak::markdown_to_html(&contents[end_of_yaml + 5..], &options);
+        // Content starts after "---\n" (we don't assume an extra newline)
+        let contents = comrak::markdown_to_html(&contents[end_of_yaml + 4..], &options);
 
         // finally, the url.
         let mut url = PathBuf::from(&*filename);


### PR DESCRIPTION
Closes #878

---

I ran it locally to verify this works. The only (significant) changes were the leading letter for the posts called out in #878 