### PR TITLE
Inside Rust: April CTCFT agenda

### DIFF
--- a/posts/inside-rust/2022-04-12-CTCFT-april.md
+++ b/posts/inside-rust/2022-04-12-CTCFT-april.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: CTCFT 2022-04-18 Agenda
+author: Rust CTCFT Team
+---
+
+The next ["Cross Team Collaboration Fun Times" (CTCFT)][CTCFT] meeting will take
+place on Monday, 2022-04-18 at **9pm US Eastern Time** ([click to see in your
+time zone][timezone]). You’ll find the full details (along with a calendar
+event, zoom details, etc) [on the CTCFT website][CTCFT-meeting].
+
+[CTCFT]: https://rust-lang.github.io/ctcft/
+[timezone]: https://everytimezone.com/s/497ef0a9
+[CTCFT-meeting]: https://rust-lang.github.io/ctcft/meetings/2022-04-18.html
+
+## Agenda
+
+The theme of April's CTCFT is "learning". Doc Jones will speak about the Rustc
+Reading Club Phase II, and what was learned from the first iteration of the
+club. Jon Gjengset will talk about teaching advanced Rust concepts.
+
+- (5 min) Opening remarks 👋 ([angelonfira])
+- (15 min) Rustc Reading Club Phase II ([doc-jones])
+- (15 min) Teaching Advanced Rust ([jonhoo])
+
+## Afterwards: Social Hour
+
+Like always, we'll be running a social hour after the CTCFT. The idea is really
+simple: for the hour after the meeting, we will create breakout rooms in Zoom
+with different themes. You can join any breakout room you like and hangout.


### PR DESCRIPTION
This is the agenda for the April CTCFT meeting.
