### PR TITLE
remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-* @rust-lang/core
-posts/* @rust-lang/core
-posts/inside-rust/* @rust-lang/inside-rust-reviewers @rust-lang/core
-.github/CODEOWNERS @rust-lang/core


### PR DESCRIPTION
The current setup leads to notifications to a large amount of people each time a blog post is created.  Also see the [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/217588-project-leads-.28public.29/topic/inside-rust-reviewers).