### PR TITLE
Show links to blogs and their latest post.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,13 @@ impl<'a> Generator<'a> {
             out_directory
                 .as_ref()
                 .canonicalize()
-                .unwrap_or(out_directory.as_ref().to_owned())
+                .unwrap_or_else(|_| out_directory.as_ref().to_owned())
                 .display()
                 .to_string()
                 .trim_start_matches('/')
                 .replace(' ', "%20")
+                .replace("\\\\?\\", "")
+                .replace(std::path::MAIN_SEPARATOR, "/")
         );
 
         Ok(Generator {


### PR DESCRIPTION
This makes the generator show `file:` urls to the main page and the latest post of both blogs:

```
$ cargo r -q
Inside Rust Blog: file:///home/mara/dev/blog.rust-lang.org/site/inside-rust/index.html
└─ Latest post: file:///home/mara/dev/blog.rust-lang.org/site/inside-rust/2022/05/26/Concluding-events-mods.html

Rust Blog: file:///home/mara/dev/blog.rust-lang.org/site/index.html
└─ Latest post: file:///home/mara/dev/blog.rust-lang.org/site/2022/05/19/Rust-1.61.0.html
```

Depending on how cool your terminal is, these might appear as clickable links.