### PR TITLE
Add blog post about recent Clippy team changes

### DIFF
--- a/posts/inside-rust/2022-07-13-clippy-team-changes.md
+++ b/posts/inside-rust/2022-07-13-clippy-team-changes.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title: "Changes at the Clippy Team"
+author: Philipp Krones
+team: The Clippy Team <https://www.rust-lang.org/governance/teams/dev-tools#clippy>
+---
+
+## New Members
+
+We are thrilled to publicly announce that [Alex
+Macleod](https://github.com/Alexendoo), [dswij](https://github.com/dswij), and
+[Jason Newcomb](https://github.com/Jarcho) have joined the Clippy Team!
+
+Jason has been contributing to Clippy since late 2020 and was the most active
+contributor since then. He has contributed in pretty much every area - big
+refactors, bug fixes, and major improvements to our Clippy utils. Having him as
+an additional reviewer will be a great improvement to the team.
+
+dswij first started contributing late last summer and has fixed many bugs in
+Clippy as well as implementing some new lints to make Clippy even more helpful.
+With their continued contributions to Clippy and engagement in the project,
+we're happy to now have them as a full team member.
+
+Alex started contributing to Clippy shortly after and has improved our dev
+tooling quite a bit. Now he wants to continue focusing on our `lintcheck` tool,
+which will help detect false positives in new lints before we release them to
+the public. We're excited to have Alex on our team and looking forward to all
+the improvements he will bring in the future.
+
+With the new additions to the team, we should be able to handle our long PR
+queue better. We currently have over 40 open PRs, which is a good sign for the
+health of the project, but doesn't help when we don't have the reviewers to
+merge them. Now we do!
+
+## Alumni
+
+At the same time, we recently granted some of our oldest members the
+well-deserved alumni status. We want to thank [Pascal
+Hertleif](https://github.com/killercup) and [Martin
+Carton](https://github.com/mcarton) for all their contributions, especially in
+the early days. People joining today probably never worked with them on Clippy,
+but without them, we probably wouldn't be here.
+
+We also want to thank [Philipp Hansch](https://github.com/phansch) for their
+contributions to Clippy and all of the review work they've done over the years.
+To this day phansch is one of the most active Clippy contributors (measured by
+the number of commits).
+
+And finally, thank you to [mikerite](https://github.com/mikerite), who stepped
+down from an active reviewer/team member position but will be staying on as a
+contributor. We're looking forward to continue working with them!


### PR DESCRIPTION
We changed the Clippy team quite a bit recently with 3 new team additions. We want to get this a little bit more visibility and decided to write up a blog post, like other teams do.

cc @rust-lang/clippy 