### PR TITLE
Remove console highlight in `cargo add`

### DIFF
--- a/posts/2022-06-30-Rust-1.62.0.md
+++ b/posts/2022-06-30-Rust-1.62.0.md
@@ -34,7 +34,7 @@ You can now add new dependencies directly from the command line using `cargo add
 
 For example:
 
-```console
+```text
 cargo add log
 cargo add serde --features derive
 cargo add nom@5


### PR DESCRIPTION
The "console" rendering is weird when multiple commands are in the same code block:

![2022-06-30--18-44-38](https://user-images.githubusercontent.com/2299951/176732771-8da70439-f47f-4caa-aa90-c21eba856a31.png)
