### PR TITLE
Fixing Overflow on Long Inline Elements

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -270,6 +270,8 @@ h3, .post h2, header h2 {
 }
 
 .post {
+  overflow-wrap: break-word;
+
   h2 {
     font-size: 2em;
   }


### PR DESCRIPTION
closes #727

Here is the post mentioned in the linked issue: https://blog.rust-lang.org/2020/10/08/Rust-1.47.html

Adding ```overflow-wrap: break-word``` to the post content container ensures all child inline elements will wrap properly instead of overflowing.

I was originally going to scope the new property to ```.post a```, but putting it directly on ```.post``` could prevent future issues instead of just fixing the tagged issue.