### PR TITLE
Fix the note link for rust 1.63

### DIFF
--- a/posts/2022-08-11-Rust-1.63.0.md
+++ b/posts/2022-08-11-Rust-1.63.0.md
@@ -23,7 +23,7 @@ the beta channel (`rustup default beta`) or the nightly channel (`rustup default
 Please [report] any bugs you might come across!
 
 [install]: https://www.rust-lang.org/install.html
-[notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1620-2022-06-30
+[notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1630-2022-08-11
 [report]: https://github.com/rust-lang/rust/issues/new/choose
 
 ## What's in 1.63.0 stable


### PR DESCRIPTION
The blog for rust 1.63 is pointing to the wrong note link(1.62).