### PR TITLE
Fixed incomplete type StorageRequestFuture declaration

### DIFF
--- a/posts/2022-09-22-Rust-1.64.0.md
+++ b/posts/2022-09-22-Rust-1.64.0.md
@@ -103,7 +103,7 @@ impl StorageRequest {
 // The new implementations:
 // 1. create a new named future type
 // 2. implement `IntoFuture` for `StorageRequest`
-pub type StorageRequestFuture = Pin<Box<dyn Future<Output = Result<StorageResponse, Error> + Send + 'static>>
+pub type StorageRequestFuture = Pin<Box<dyn Future<Output = Result<StorageResponse, Error>> + Send + 'static>>
 impl IntoFuture for StorageRequest {
     type IntoFuture = StorageRequestFuture;
     type Output = <StorageRequestFuture as Future>::Output;


### PR DESCRIPTION
Actual
 ```
 pub type StorageRequestFuture = Pin<Box<dyn Future<Output = Result<StorageResponse, Error> + Send + 'static>>
 ```
 Expected 
 ```
 pub type StorageRequestFuture = Pin<Box<dyn Future<Output = Result<StorageResponse, Error>> + Send + 'static>>
 ```