### PR TITLE
Add missing generic in "perfect derive" paragraph

### DIFF
--- a/posts/inside-rust/2022-04-04-lang-roadmap-2024.md
+++ b/posts/inside-rust/2022-04-04-lang-roadmap-2024.md
@@ -176,7 +176,7 @@ to discuss, or send a private message to nikomatsakis.
       matching a `String` with a `"str"`.
     - Perfect derive: determine the precise conditions for generic type
       parameters based on the types of a struct fields. For instance,
-      `#[derive(Clone)] struct MyStruct(Rc<T>)` would not require `T: Clone`,
+      `#[derive(Clone)] struct MyStruct<T>(Rc<T>)` would not require `T: Clone`,
       because `Rc<T>` can be cloned without it.
     - Autoref, operators, and clones: Generic methods that operate on
       references sometimes necessitate types like `&u32`; since `u32` is


### PR DESCRIPTION
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9662ba9557d61e0507477e386a81e260

```rust
use std::rc::Rc;

struct T(u32);

// This does compile:
// #[derive(Clone)]
// struct MyStruct(Rc<T>);

// This does not compile, needing perfect derives:
#[derive(Clone)]
struct MyStruct<T>(Rc<T>);

fn main() {
    let x = Rc::new(T(10));
    MyStruct(x).clone();
}
```