### PR TITLE
Fix the 'mutness' of the WindowsMut GAT example

### DIFF
--- a/posts/2022-10-28-gats-stabilization.md
+++ b/posts/2022-10-28-gats-stabilization.md
@@ -44,7 +44,7 @@ trait LendingIterator {
 }
 
 pub struct WindowsMut<'x, T> {
-    slice: &'x [T],
+    slice: &'x mut [T],
 }
 
 impl<'x, T> LendingIterator for WindowsMut<'x, T> {


### PR DESCRIPTION
Fixes the 'mutness' of the slice field in the WindowsMut example.