### PR TITLE
Add post announcing the survey 2022 launch

### DIFF
--- a/posts/2022-12-05-survey-launch.md
+++ b/posts/2022-12-05-survey-launch.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Launching the 2022 State of Rust Survey"
-author: The Rust Survey Team
+author: The Rust Survey Working Group
 description: "Hearing from you about the seventh year of Rust"
 ---
 

--- a/posts/2022-12-05-survey-launch.md
+++ b/posts/2022-12-05-survey-launch.md
@@ -5,9 +5,13 @@ author: The Rust Survey Working Group
 description: "Hearing from you about the seventh year of Rust"
 ---
 
+The [2022 State of Rust Survey][survey] is here!
+
 It's that time again! Time for us to take a look at who the Rust community is composed of, how the Rust project is doing, and how we can improve the Rust programming experience. The Rust Survey Team is pleased to announce our [2022 State of Rust Survey][survey]! Whether or not you use Rust today, we want to know your opinions. Your responses will help the project understand its strengths and weaknesses, and establish development priorities for the future.
 
-Completing this survey should take about 5–20 minutes and is anonymous. We will be accepting submissions for the next two weeks (until the 19th of December), and we will write up our findings afterwards on [blog.rust-lang.org]. You can also check out [last year’s results][2021 survey].
+Completing this survey should take about 5–20 minutes and is anonymous. We will be accepting submissions for the next two weeks (until the 19th of December), and we will share our findings on [blog.rust-lang.org] sometime in early 2023. You can also check out [last year’s results][2021 survey].
+
+We're happy to be offering the survey in the following languages. If you speak multiple languages, please pick one.
 
 - [English]
 - [Simplified Chinese]

--- a/posts/2022-12-05-survey-launch.md
+++ b/posts/2022-12-05-survey-launch.md
@@ -19,6 +19,7 @@ Completing this survey should take about 5–20 minutes and is anonymous. We wil
 - [Portuguese]
 - [Russian]
 - [Spanish]
+- [Ukrainian]
 
 (If you speak multiple languages, please pick one)
 
@@ -32,14 +33,15 @@ Finally, we wanted to thank everyone who helped develop, polish, and test the su
 [frequently asked questions]: https://github.com/rust-lang/surveys/blob/main/documents/Community-Survey-FAQ.md
 [2021 survey]: https://blog.rust-lang.org/2022/02/15/Rust-Survey-2021.html
 
-[survey]: https://surveyhero.com/c/jzesmzph
-[English]: https://surveyhero.com/c/dauv4jcd
-[Portuguese]: https://surveyhero.com/c/bhdqz3hj
-[Simplified Chinese]: https://surveyhero.com/c/7rnfv4cf
-[French]: https://surveyhero.com/c/y7hb34nm
-[Korean]: https://surveyhero.com/c/m3bi3nad
-[Spanish]: https://surveyhero.com/c/he7yvafu
-[Russian]: https://surveyhero.com/c/xix7rf7d
-[Traditional Chinese]: https://surveyhero.com/c/h7guatdt
-[German]: https://surveyhero.com/c/pq43azn4
-[Japanese]: https://surveyhero.com/c/9pput3ye
+[survey]: https://surveyhero.com/c/sfhmgxgd
+[English]: https://surveyhero.com/c/sfhmgxgd?lang=en
+[Portuguese]: https://surveyhero.com/c/sfhmgxgd?lang=pt
+[Simplified Chinese]: https://surveyhero.com/c/sfhmgxgd?lang=zh-cn
+[French]: https://surveyhero.com/c/sfhmgxgd?lang=fr
+[Korean]: https://surveyhero.com/c/sfhmgxgd?lang=ko
+[Spanish]: https://surveyhero.com/c/sfhmgxgd?lang=es
+[Russian]: https://surveyhero.com/c/sfhmgxgd?lang=ru
+[Traditional Chinese]: https://surveyhero.com/c/sfhmgxgd?lang=zh-tw
+[German]: https://surveyhero.com/c/sfhmgxgd?lang=de
+[Japanese]: https://surveyhero.com/c/sfhmgxgd?lang=ja
+[Ukrainian]: https://surveyhero.com/c/sfhmgxgd?lang=uk

--- a/posts/2022-12-05-survey-launch.md
+++ b/posts/2022-12-05-survey-launch.md
@@ -7,7 +7,7 @@ description: "Hearing from you about the seventh year of Rust"
 
 The [2022 State of Rust Survey][survey] is here!
 
-It's that time again! Time for us to take a look at who the Rust community is composed of, how the Rust project is doing, and how we can improve the Rust programming experience. The Rust Survey Team is pleased to announce our [2022 State of Rust Survey][survey]! Whether or not you use Rust today, we want to know your opinions. Your responses will help the project understand its strengths and weaknesses, and establish development priorities for the future.
+It's that time again! Time for us to take a look at who the Rust community is composed of, how the Rust project is doing, and how we can improve the Rust programming experience. The Rust Survey working group is pleased to announce our [2022 State of Rust Survey][survey]! Whether or not you use Rust today, we want to know your opinions. Your responses will help the project understand its strengths and weaknesses, and establish development priorities for the future.
 
 Completing this survey should take about 5–20 minutes and is anonymous. We will be accepting submissions for the next two weeks (until the 19th of December), and we will share our findings on [blog.rust-lang.org] sometime in early 2023. You can also check out [last year’s results][2021 survey].
 

--- a/posts/2022-12-05-survey-launch.md
+++ b/posts/2022-12-05-survey-launch.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: "Launching the 2022 State of Rust Survey"
+author: The Rust Survey Team
+description: "Hearing from you about the seventh year of Rust"
+---
+
+It's that time again! Time for us to take a look at who the Rust community is composed of, how the Rust project is doing, and how we can improve the Rust programming experience. The Rust Survey Team is pleased to announce our [2022 State of Rust Survey][survey]! Whether or not you use Rust today, we want to know your opinions. Your responses will help the project understand its strengths and weaknesses, and establish development priorities for the future.
+
+Completing this survey should take about 5–20 minutes and is anonymous. We will be accepting submissions for the next two weeks (until the 19th of December), and we will write up our findings afterwards on [blog.rust-lang.org]. You can also check out [last year’s results][2021 survey].
+
+- [English]
+- [Simplified Chinese]
+- [Traditional Chinese]
+- [French]
+- [German]
+- [Japanese]
+- [Korean]
+- [Portuguese]
+- [Russian]
+- [Spanish]
+
+(If you speak multiple languages, please pick one)
+
+Please help us spread the word by sharing the survey link on your social network feeds, at meetups, around your office, and in other communities.
+
+If you have any questions, please see our [frequently asked questions].
+
+Finally, we wanted to thank everyone who helped develop, polish, and test the survey.
+
+[blog.rust-lang.org]: https://blog.rust-lang.org
+[frequently asked questions]: https://github.com/rust-lang/surveys/blob/main/documents/Community-Survey-FAQ.md
+[2021 survey]: https://blog.rust-lang.org/2022/02/15/Rust-Survey-2021.html
+
+[survey]: https://surveyhero.com/c/jzesmzph
+[English]: https://surveyhero.com/c/dauv4jcd
+[Portuguese]: https://surveyhero.com/c/bhdqz3hj
+[Simplified Chinese]: https://surveyhero.com/c/7rnfv4cf
+[French]: https://surveyhero.com/c/y7hb34nm
+[Korean]: https://surveyhero.com/c/m3bi3nad
+[Spanish]: https://surveyhero.com/c/he7yvafu
+[Russian]: https://surveyhero.com/c/xix7rf7d
+[Traditional Chinese]: https://surveyhero.com/c/h7guatdt
+[German]: https://surveyhero.com/c/pq43azn4
+[Japanese]: https://surveyhero.com/c/9pput3ye

--- a/posts/2022-12-05-survey-launch.md
+++ b/posts/2022-12-05-survey-launch.md
@@ -25,8 +25,6 @@ We're happy to be offering the survey in the following languages. If you speak m
 - [Spanish]
 - [Ukrainian]
 
-(If you speak multiple languages, please pick one)
-
 Please help us spread the word by sharing the survey link on your social network feeds, at meetups, around your office, and in other communities.
 
 If you have any questions, please see our [frequently asked questions].


### PR DESCRIPTION
The plan is for this to go live at 17:00 UTC on Monday the 5th of December 2022.

Still left to do:
* [x] Update survey links

cc @nrc 