### PR TITLE
Lang blog posts: lang advisors and membership update

### DIFF
--- a/posts/inside-rust/2023-02-14-lang-advisors.md
+++ b/posts/inside-rust/2023-02-14-lang-advisors.md
@@ -13,7 +13,7 @@ The initial advisors team consists of the following people:
 
 **Jakob Degen** is one of the authorities around the semantics of unsafe code. He has consistently shown the ability to aggregate opinion, identify the key constraints to respect and those to disregard, and find consensus solutions.
 
-**Mark Rousskov** has been a huge part of the Rust community for many years now, and participates regularly in lang-team meetings. He has a wide knowledge Rust and its nooks and crannies, and often brings key insights to our discussions.
+**Mark Rousskov** has been a huge part of the Rust community for many years now, and participates regularly in lang-team meetings. He has a wide knowledge of Rust and its nooks and crannies, and often brings key insights to our discussions.
 
 **Jack Huey** co-leads the types team, and provides expertise in the workings of Rust's trait and type system, as well as the chalk system.
 

--- a/posts/inside-rust/2023-02-14-lang-advisors.md
+++ b/posts/inside-rust/2023-02-14-lang-advisors.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Language team advisors"
+author: Josh Triplett, Niko Matsakis
+team: The Rust Lang Team <https://www.rust-lang.org/governance/teams/lang>
+---
+
+[RFC #3327](https://github.com/rust-lang/rfcs/pull/3327) created a new lang-team subteam, the lang team advisors. The advisors team recognizes people who regularly aid the Rust community and the lang team in particular in language design decisions. We already value their input highly and treat their concerns as blocking on features or proposals. The advisors team gives us a way to acknowledge them officially.
+
+The initial advisors team consists of the following people:
+
+**Ralf Jung** is a leader in designing Rust's rules for unsafe code as well as, through his work on miri, the semantics of compile-time evaluation. His work on stacked borrows and minirust has moved the state of that conversation forward in major ways, and he has also driven a number of language changes related to that area.
+
+**Jakob Degen** is one of the authorities around the semantics of unsafe code. He has consistently shown the ability to aggregate opinion, identify the key constraints to respect and those to disregard, and find consensus solutions.
+
+**Mark Rousskov** has been a huge part of the Rust community for many years now, and participates regularly in lang-team meetings. He has a wide knowledge Rust and its nooks and crannies, and often brings key insights to our discussions.
+
+**Jack Huey** co-leads the types team, and provides expertise in the workings of Rust's trait and type system, as well as the chalk system.
+
+**Amanieu d'Antras** leads the design of inline assembly and has been involved as an expert in a number of other areas, such as the "FFI unwind" working group.
+
+**Wesley Wiser** is the co-lead of the compiler team. He's been involved in the project for many years and is an expert on the overall compiler architecture as well as several areas within.
+
+**Alex Crichton** is a well-known figure to many Rustaceans. Among other things, he is a former lead of the libs team, a key cargo contributor, and drove extensive work for Rust in WebAssembly. Indeed, it's hard to find a part of Rust that Alex hasn't had an impact on.
+
+Finally, as part of this change, **Taylor Cramer** will be stepping back as a full-time lang team member and becoming an advisor. In his time on the lang team, Taylor was a core driver for `async`/`await`, `impl Trait`, and a number of other highly impactful language features. We look forward to continuing to have his guidance as an advisor going forward.

--- a/posts/inside-rust/2023-02-14-lang-team-membership-update.md
+++ b/posts/inside-rust/2023-02-14-lang-team-membership-update.md
@@ -11,7 +11,7 @@ We are happy to announce that [Tyler Mandry][tmandry] is joining the Rust langua
 
 Tyler has been driving the design of async functions in traits over the last year. In that process Tyler has authored two RFCs, [#3185 (static async functions in traits)](https://github.com/rust-lang/rfcs/pull/3185) and [#3245 (refined trait impls)](https://github.com/rust-lang/rfcs/pull/3245), both of which were accepted. He has good instincts for language design and orthogonality, devising general solutions to address a range of use cases with a small set of language changes, such as [contexts/capabilities](https://tmandry.gitlab.io/blog/posts/2021-12-21-context-capabilities/) and [`dyn*`](https://smallcultfollowing.com/babysteps/blog/2022/03/29/dyn-can-we-make-dyn-sized/).
 
-Tyler is also a strong implementor. He was a past contributor to the chalk project and understands the intrincacies of the trait and type system quite well. He also implementing a number of improvements to async Rust, such as work to reduce the size of futures.
+Tyler is also a strong implementor. He was a past contributor to the chalk project and understands the intricacies of the trait and type system quite well. He also implemented a number of improvements to async Rust, such as work to reduce the size of futures.
 
 Throughout his work on Rust, Tyler has demonstrated his ability to drive discussions towards consensus on a number of occasions. For example, he helped to navigate questions around boxing and auto-traits. He always makes an effort to understand people's points, even when he disagrees with their conclusions.
 

--- a/posts/inside-rust/2023-02-14-lang-team-membership-update.md
+++ b/posts/inside-rust/2023-02-14-lang-team-membership-update.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: "Welcome Tyler Mandry to the Rust language team!"
+author: Josh Triplett, Niko Matsakis
+team: The Rust Lang Team <https://www.rust-lang.org/governance/teams/lang>
+---
+
+We are happy to announce that [Tyler Mandry][tmandry] is joining the Rust language design team as a full member!
+
+[tmandry]: https://github.com/tmandry
+
+Tyler has been driving the design of async functions in traits over the last year. In that process Tyler has authored two RFCs, [#3185 (static async functions in traits)](https://github.com/rust-lang/rfcs/pull/3185) and [#3245 (refined trait impls)](https://github.com/rust-lang/rfcs/pull/3245), both of which were accepted. He has good instincts for language design and orthogonality, devising general solutions to address a range of use cases with a small set of language changes, such as [contexts/capabilities](https://tmandry.gitlab.io/blog/posts/2021-12-21-context-capabilities/) and [`dyn*`](https://smallcultfollowing.com/babysteps/blog/2022/03/29/dyn-can-we-make-dyn-sized/).
+
+Tyler is also a strong implementor. He was a past contributor to the chalk project and understands the intrincacies of the trait and type system quite well. He also implementing a number of improvements to async Rust, such as work to reduce the size of futures.
+
+Throughout his work on Rust, Tyler has demonstrated his ability to drive discussions towards consensus on a number of occasions. For example, he helped to navigate questions around boxing and auto-traits. He always makes an effort to understand people's points, even when he disagrees with their conclusions.
+
+Welcome to the team, Tyler!


### PR DESCRIPTION
- Add blog post on language team advisors
- Add blog post welcoming Tyler Mandry to the lang team
