### PR TITLE
link to toml file to clarify membership

### DIFF
--- a/posts/2023-05-29-RustConf.md
+++ b/posts/2023-05-29-RustConf.md
@@ -2,7 +2,7 @@
 layout: post
 title: "On the RustConf keynote"
 author: leadership chat membership
-team: leadership chat <https://www.rust-lang.org/governance>
+team: leadership chat <https://github.com/rust-lang/team//blob/d4c071b86c33683845919cf27eabf33e15fb6784/teams/interim-leadership-chat.toml#L1>
 ---
 
 On May 26th 2023, [JeanHeyd Meneide](https://thephd.dev/about/) announced they [would not speak at RustConf 2023 anymore](https://thephd.dev/i-am-no-longer-speaking-at-rustconf-2023). They were invited to give a keynote at the conference, only to be told two weeks later the keynote would be demoted to a normal talk, due to a decision made within the Rust project leadership.
@@ -11,7 +11,7 @@ That decision was not right, and first off we want to publicly apologize for the
 
 Everyone in leadership chat is still working to fully figure out everything that went wrong and how we can prevent all of this from happening again. That work is not finished yet. Still, we want to share some steps we are taking to reduce the risk of something like this from happening again.
 
-The primary causes of the failure were the decision-making and communication processes of leadership chat. Leadership chat has been the top-level governance structure created after the previous Moderation Team resigned in late 2021. It’s made of all leads of top-level teams, all members of the Core Team, all project directors on the Rust Foundation board, and all current moderators. This leadership chat was meant as a short-term solution and lacked clear rules and processes for decision making and communication. This left a lot of room for misunderstandings about when a decision had actually been made and when individuals were speaking for the project versus themselves. 
+The primary causes of the failure were the decision-making and communication processes of leadership chat. Leadership chat has been the [top-level governance structure created after the previous Moderation Team resigned in late 2021](https://blog.rust-lang.org/inside-rust/2022/10/06/governance-update.html). It’s made of all leads of top-level teams, all members of the Core Team, all project directors on the Rust Foundation board, and all current moderators. This leadership chat was meant as a short-term solution and lacked clear rules and processes for decision making and communication. This left a lot of room for misunderstandings about when a decision had actually been made and when individuals were speaking for the project versus themselves. 
 
 In this post we focus on the organizational and process failure, leaving room for individuals to publicly acknowledge their own role. Nonetheless, formal rules or governance processes should not be required to identify that demoting JeanHeyd’s keynote was the wrong thing to do. The fact is that several individuals exercised poor judgment and poor communication. Recognizing their outsized role in the situation, those individuals have opted to step back from top-level governance roles, including leadership chat and the upcoming leadership council. 
 
@@ -19,4 +19,4 @@ Organizationally, within leadership chat we will enforce a strict consensus rule
 
 We wish to close the post by reiterating our apology to JeanHeyd, but also the wider Rust community. You deserved better than you got from us.
 
--- The members of leadership chat
+-- The [members of leadership chat](https://github.com/rust-lang/team/blob/d4c071b86c33683845919cf27eabf33e15fb6784/teams/interim-leadership-chat.toml#L8-L25)


### PR DESCRIPTION
Clarify the authorship of the post: there isn't a nice landing page for the "leadership chat", as it wasn't meant to be a permanent governance structure, but there is this list from the rfcbot file. 