### PR TITLE
CI: Use `Swatinem/rust-cache` action to simplify Rust dependency caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,33 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Detect the installed Rust version
-        id: rustc
-        run: echo "::set-output name=version::$(rustc -V)"
-
-      - name: Cache Cargo's registry cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/registry/cache
-          key: cargo-registry-cache-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-registry-cache-
-
-      - name: Cache Cargo's registry index
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/registry/index
-          key: cargo-registry-index-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-registry-index-
-
-      - name: Cache Cargo's target directory
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: cargo-build-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-build-${{ steps.rustc.outputs.version }}-
+      - uses: Swatinem/rust-cache@v2.5.0
 
       - run: cargo run
       - run: cp CNAME ./site/


### PR DESCRIPTION
We've been using this action for crates.io for quite some time without any issues.

see https://github.com/Swatinem/rust-cache#cache-details for more details :)

/cc @rust-lang/infra 