### PR TITLE
Specify what “threads on the RFC diff” is in opposition to.

### DIFF
--- a/posts/2023-09-22-crates-io-usage-policy-rfc.md
+++ b/posts/2023-09-22-crates-io-usage-policy-rfc.md
@@ -19,4 +19,4 @@ Here is a quick **TL;DR**:
 - Reserving names is still allowed, but only to a certain degree and if you have a good reason for it.
 - The crates.io team will try to contact crate owners before taking any actions.
 
-Finally, if you have any comments, please open threads on the [RFC diff](https://github.com/rust-lang/rfcs/pull/3463/files) to keep the discussion somewhat structured. Thank you!
+Finally, if you have any comments, please open threads on the [RFC diff](https://github.com/rust-lang/rfcs/pull/3463/files), instead of using the main comment box, to keep the discussion more structured. Thank you!


### PR DESCRIPTION
I believe this is a useful clarification because without the contrast, it may not be clear what is being asked for, to people not already familiar with the details of GitHub code review features.