### PR TITLE
Use `eyre` for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "comrak",
+ "eyre",
  "handlebars",
  "lazy_static",
  "regex",
@@ -280,6 +281,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -558,6 +569,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +51,21 @@ name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.7.1",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -99,6 +123,7 @@ name = "blog"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "color-eyre",
  "comrak",
  "eyre",
  "handlebars",
@@ -189,6 +214,33 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -315,7 +367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.5.3",
 ]
 
 [[package]]
@@ -405,6 +457,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "h2"
@@ -630,9 +688,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "line-wrap"
@@ -703,6 +761,15 @@ name = "miniz_oxide"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -795,6 +862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +903,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pem"
@@ -1091,6 +1173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1666,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1700,6 +1829,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "blog"
 path = "src/blog.rs"
 
 [dependencies]
+eyre = "0.6.8"
 handlebars = { version = "3", features = ["dir_source"] }
 lazy_static = "1.4.0"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "blog"
 path = "src/blog.rs"
 
 [dependencies]
+color-eyre = "0.6.2"
 eyre = "0.6.8"
 handlebars = { version = "3", features = ["dir_source"] }
 lazy_static = "1.4.0"

--- a/src/blog.rs
+++ b/src/blog.rs
@@ -1,9 +1,7 @@
-use std::error::Error;
-
 #[path = "lib.rs"]
 mod lib;
 
-pub fn main() -> Result<(), Box<dyn Error>> {
+pub fn main() -> eyre::Result<()> {
     lib::main()?;
 
     println!("blog has been generated; you can now serve its content by running\n\

--- a/src/blog.rs
+++ b/src/blog.rs
@@ -2,6 +2,8 @@
 mod lib;
 
 pub fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
+
     lib::main()?;
 
     println!("blog has been generated; you can now serve its content by running\n\

--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -1,6 +1,5 @@
 use super::posts::Post;
 use serde_derive::{Deserialize, Serialize};
-use std::error::Error;
 use std::path::{Path, PathBuf};
 
 static MANIFEST_FILE: &str = "blog.yml";
@@ -46,7 +45,7 @@ pub(crate) struct Blog {
 }
 
 impl Blog {
-    fn load(prefix: PathBuf, dir: &Path) -> Result<Self, Box<dyn Error>> {
+    fn load(prefix: PathBuf, dir: &Path) -> eyre::Result<Self> {
         let manifest_content = std::fs::read_to_string(dir.join(MANIFEST_FILE))?;
         let manifest: Manifest = serde_yaml::from_str(&manifest_content)?;
 
@@ -122,7 +121,7 @@ impl Blog {
 
 /// Recursively load blogs in a directory. A blog is a directory with a `blog.yml`
 /// file inside it.
-pub(crate) fn load(base: &Path) -> Result<Vec<Blog>, Box<dyn Error>> {
+pub(crate) fn load(base: &Path) -> eyre::Result<Vec<Blog>> {
     let mut blogs = Vec::new();
     load_recursive(base, base, &mut blogs)?;
     Ok(blogs)
@@ -132,7 +131,7 @@ fn load_recursive(
     base: &Path,
     current: &Path,
     blogs: &mut Vec<Blog>,
-) -> Result<(), Box<dyn Error>> {
+) -> eyre::Result<()> {
     for entry in std::fs::read_dir(current)? {
         let path = entry?.path();
         let file_type = path.metadata()?.file_type();

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -2,8 +2,8 @@ use super::blogs::Manifest;
 use comrak::{ComrakExtensionOptions, ComrakOptions, ComrakRenderOptions};
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
-use std::error::Error;
 use std::path::{Path, PathBuf};
+use eyre::eyre;
 
 #[derive(Debug, PartialEq, Deserialize)]
 struct YamlHeader {
@@ -36,7 +36,7 @@ pub(crate) struct Post {
 }
 
 impl Post {
-    pub(crate) fn open(path: &Path, manifest: &Manifest) -> Result<Self, Box<dyn Error>> {
+    pub(crate) fn open(path: &Path, manifest: &Manifest) -> eyre::Result<Self> {
         // yeah this might blow up, but it won't
         let filename = path.file_name().unwrap().to_str().unwrap();
 
@@ -52,7 +52,7 @@ impl Post {
         let contents = std::fs::read_to_string(path)?;
         if contents.len() < 5 {
             return Err(
-                format!("{path:?} is empty, or too short to have valid front matter").into(),
+                eyre!("{path:?} is empty, or too short to have valid front matter")
             );
         }
 


### PR DESCRIPTION
`Box<dyn Error>` is not `Send`, which makes it harder to parallelize the rendering of the blog posts. `eyre::Report` fortunately does not have this problem.

/cc @rust-lang/website 