### PR TITLE
Fix frontmatter assumption

### DIFF
--- a/src/posts.rs
+++ b/src/posts.rs
@@ -58,7 +58,7 @@ impl Post {
 
         // yaml headers.... we know the first four bytes of each file are "---\n"
         // so we need to find the end. we need the fours to adjust for those first bytes
-        let end_of_yaml = contents[4..].find("---\n").unwrap() + 4;
+        let end_of_yaml = contents[4..].find("---").unwrap() + 4;
         let yaml = &contents[..end_of_yaml];
         let YamlHeader {
             author,


### PR DESCRIPTION
Using `---\n` assumes that all files use `\n` line endings, but one of our latest blog posts is using `\r\n` instead. This commit reverts the assumption about the frontmatter again to fix the rendering of that blog post.

This fixes a hidden merge conflict between #1145 and #1132.