### PR TITLE
Add renovatebot configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,8 @@
+{
+    extends: [
+        "config:best-practices",
+        ":pinAllExceptPeerDependencies",
+        ":maintainLockFilesWeekly",
+        ":semanticCommitsDisabled",
+    ],
+}


### PR DESCRIPTION
This PR adds a basic configuration file for https://docs.renovatebot.com. The configuration was derived from what we are using at https://github.com/rust-lang/crates.io/blob/main/.github/renovate.json5, but significantly simplified.

This should hopefully help us in keeping the dependencies of this project a bit more up-to-date :)
