### PR TITLE
fix typo in 2020-11-15-Using-rustc_codegen_cranelift.md

### DIFF
--- a/posts/inside-rust/2020-11-15-Using-rustc_codegen_cranelift.md
+++ b/posts/inside-rust/2020-11-15-Using-rustc_codegen_cranelift.md
@@ -37,7 +37,7 @@ $ ./build.sh
 ```
 
 Now, we can start using it to compile a project. For demonstration purposes,
-I'll be be using `cargo`, but you can use any Rust project supported by
+I'll be using `cargo`, but you can use any Rust project supported by
 `cg_clif`.
 
 ```


### PR DESCRIPTION
fix typo in 2020-11-15-Using-rustc_codegen_cranelift.md while reading it 