### PR TITLE
Fixed dead link in posts/2023-08-29-committing-lockfiles.md

### DIFF
--- a/posts/2023-08-29-committing-lockfiles.md
+++ b/posts/2023-08-29-committing-lockfiles.md
@@ -46,7 +46,7 @@ with your MSRV.
 A lockfile is an appropriate way to pin versions for your project so you
 can validate your MSRV but we found people were instead putting upperbounds on their
 version requirements due to the strength of our prior guideline despite
-[likely being a worse solution](https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html#multiple-requirements).
+[likely being a worse solution](https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html#multiple-version-requirements).
 
 The wider software development ecosystem has also changed a lot in the
 intervening time.


### PR DESCRIPTION
Said blog post contains a link to the Cargo book. The heading that was being linked to was changed from "Multiple requirements" to "Multiple version requirements" (in [this commit][doc-change]), this change was not reflected in the blog post. I am not too sure whether the link has ever worked as the docs were changed on 2023-08-27 while the blog post was only written on 2023-08-29, but either way, this PR fixes the link.

[doc-change]: https://github.com/rust-lang/cargo/commit/01e1ff0484b62db28f0a7e231a3a7ad5f7439bca?diff=unified&w=0#diff-d184a3240b09684abaca1a50dc8519dab2a9f5a17631180036f4b8090bb8a2d0L105