### PR TITLE
chrono: Address deprecation warnings

### DIFF
--- a/src/posts.rs
+++ b/src/posts.rs
@@ -158,9 +158,7 @@ impl Post {
 }
 
 fn build_post_time(year: i32, month: u32, day: u32, seconds: u32) -> String {
-    chrono::DateTime::<chrono::Utc>::from_utc(
-        chrono::NaiveDate::from_ymd(year, month, day).and_hms(0, 0, seconds),
-        chrono::Utc,
-    )
-    .to_rfc3339()
+    let date = chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap();
+    let date_time = date.and_hms_opt(0, 0, seconds).unwrap();
+    chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(date_time, chrono::Utc).to_rfc3339()
 }


### PR DESCRIPTION
```
warning: use of deprecated associated function `chrono::DateTime::<Tz>::from_utc`: Use TimeZone::from_utc_datetime() or DateTime::from_naive_utc_and_offset instead
   --> src/posts.rs:161:38
    |
161 |     chrono::DateTime::<chrono::Utc>::from_utc(
    |                                      ^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default


warning: use of deprecated associated function `chrono::NaiveDate::from_ymd`: use `from_ymd_opt()` instead
   --> src/posts.rs:162:28
    |
162 |         chrono::NaiveDate::from_ymd(year, month, day).and_hms(0, 0, seconds),
    |                            ^^^^^^^^


warning: use of deprecated method `chrono::NaiveDate::and_hms`: use `and_hms_opt()` instead
   --> src/posts.rs:162:55
    |
162 |         chrono::NaiveDate::from_ymd(year, month, day).and_hms(0, 0, seconds),
    |                                                       ^^^^^^^
```