### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -154,7 +154,7 @@ fn load_recursive(
     Ok(())
 }
 
-fn add_postfix_slash<S>(path: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
+fn add_postfix_slash<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl<'a> Generator<'a> {
     }
 
     fn render_releases_feed(&self, blog: &Blog) -> eyre::Result<()> {
-        let posts = blog.posts().iter().cloned().collect::<Vec<_>>();
+        let posts = blog.posts().to_vec();
         let is_released: Vec<&Post> = posts.iter().filter(|post| post.release).collect();
         let releases: Vec<ReleasePost> = is_released
             .iter()

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -40,7 +40,7 @@ impl Post {
         let filename = path.file_name().unwrap().to_str().unwrap();
 
         // we need to get the metadata out of the url
-        let mut split = filename.splitn(4, "-");
+        let mut split = filename.splitn(4, '-');
 
         // we do some unwraps because these need to be valid
         let year = split.next().unwrap().parse::<i32>().unwrap();


### PR DESCRIPTION
Together with #1208 and #1209, this fixes the remaining clippy warnings that prevent us from introducing a `cargo clippy` run to the CI workflow.