### PR TITLE
rustfmt: Fix broken formatting

### DIFF
--- a/serve/src/main.rs
+++ b/serve/src/main.rs
@@ -6,6 +6,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let footer = format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 
-    warpy::server::run(format!("{}/../site", env!("CARGO_MANIFEST_DIR")), [0, 0, 0, 0], footer, Some(8000), false).await?;
+    warpy::server::run(
+        format!("{}/../site", env!("CARGO_MANIFEST_DIR")),
+        [0, 0, 0, 0],
+        footer,
+        Some(8000),
+        false,
+    )
+    .await?;
     Ok(())
 }

--- a/src/blog.rs
+++ b/src/blog.rs
@@ -6,13 +6,16 @@ pub fn main() -> eyre::Result<()> {
 
     lib::main()?;
 
-    println!("blog has been generated; you can now serve its content by running\n\
+    println!(
+        "blog has been generated; you can now serve its content by running\n\
               {INDENT}python3 -m http.server --directory {ROOT}/site\n\
               or running:\n\
               {INDENT}cargo run -p serve\n\
               or you can read it directly by opening a web browser on:\n\
               {INDENT}file:///{ROOT}/site/index.html",
-             ROOT=env!("CARGO_MANIFEST_DIR"), INDENT="    ");
+        ROOT = env!("CARGO_MANIFEST_DIR"),
+        INDENT = "    "
+    );
 
     Ok(())
 }

--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -127,11 +127,7 @@ pub(crate) fn load(base: &Path) -> eyre::Result<Vec<Blog>> {
     Ok(blogs)
 }
 
-fn load_recursive(
-    base: &Path,
-    current: &Path,
-    blogs: &mut Vec<Blog>,
-) -> eyre::Result<()> {
+fn load_recursive(base: &Path, current: &Path, blogs: &mut Vec<Blog>) -> eyre::Result<()> {
     for entry in std::fs::read_dir(current)? {
         let path = entry?.path();
         let file_type = path.metadata()?.file_type();

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -1,8 +1,8 @@
 use super::blogs::Manifest;
+use eyre::eyre;
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use eyre::eyre;
 
 #[derive(Debug, PartialEq, Deserialize)]
 struct YamlHeader {
@@ -50,9 +50,9 @@ impl Post {
 
         let contents = std::fs::read_to_string(path)?;
         if contents.len() < 5 {
-            return Err(
-                eyre!("{path:?} is empty, or too short to have valid front matter")
-            );
+            return Err(eyre!(
+                "{path:?} is empty, or too short to have valid front matter"
+            ));
         }
 
         // yaml headers.... we know the first four bytes of each file are "---\n"
@@ -68,7 +68,9 @@ impl Post {
         } = serde_yaml::from_str(yaml)?;
         // next, the contents. we add + to get rid of the final "---\n\n"
         let options = comrak::Options {
-            render: comrak::RenderOptionsBuilder::default().unsafe_(true).build()?,
+            render: comrak::RenderOptionsBuilder::default()
+                .unsafe_(true)
+                .build()?,
             extension: comrak::ExtensionOptionsBuilder::default()
                 .header_ids(Some(String::new()))
                 .footnotes(true)


### PR DESCRIPTION
Looks like a couple of code lines were added/changed without using `cargo fmt` before committing. This PR fixes the "broken" formatting.

We could consider adding a `cargo fmt --check` call to our CI workflow to avoid this in the future.

r? @rust-lang/website 