### PR TITLE
CI: Use pinned Rust version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,5 +4,6 @@
         ":pinAllExceptPeerDependencies",
         ":maintainLockFilesWeekly",
         ":semanticCommitsDisabled",
+        "regexManagers:githubActionsVersions",
     ],
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 env:
+  # renovate: datasource=github-tags depName=rust lookupName=rust-lang/rust
   RUST_VERSION: 1.75.0
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,16 @@ on:
       - master
   pull_request:
 
+env:
+  RUST_VERSION: 1.75.0
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
+      - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - run: cargo run


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/blog.rust-lang.org/pull/1210#issuecomment-1899190669, this PR implements Rust version pinning and configures renovatebot to open PRs for new Rust releases.

An alternative to this would be to use a `rust-toolchain.toml` file (like we do in the crates.io repo), which would ensure that all users of this repository use the same Rust version. Let me know if that would be the preferred solution here too.

r? @Mark-Simulacrum 