### PR TITLE
renovate: Throttle "warpy" PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,4 +6,12 @@
         ":semanticCommitsDisabled",
         "regexManagers:githubActionsVersions",
     ],
+    packageRules: [
+        {
+            matchPackageNames: [
+                "warpy",
+            ],
+            extends: ["schedule:weekly"],
+        }
+    ]
 }


### PR DESCRIPTION
warpy is automatically releasing every merged PR as a new version, and it also automatically merges every minor or patch version update of its dependencies. This leads to a questionable and very noisy release schedule. This change configures renovatebot to only send warpy update PRs once per week to avoid the useless noise.

r? @rust-lang/website 