### PR TITLE
Make the first mention of `type_name_of_val` a link and qualified.

### DIFF
--- a/posts/2024-02-08-Rust-1.76.0.md
+++ b/posts/2024-02-08-Rust-1.76.0.md
@@ -29,7 +29,7 @@ The one new addition is that it is now guaranteed that `char` and `u32` are ABI 
 
 ### Type names from references
 
-For debugging purposes, [`any::type_name::<T>()`](https://doc.rust-lang.org/stable/std/any/fn.type_name.html) has been available since Rust 1.38 to return a string description of the type `T`, but that requires an explicit type parameter. It is not always easy to specify that type, especially for unnameable types like closures or for opaque return types. The new `type_name_of_val(&T)` offers a way to get a descriptive name from any reference to a type.
+For debugging purposes, [`any::type_name::<T>()`](https://doc.rust-lang.org/stable/std/any/fn.type_name.html) has been available since Rust 1.38 to return a string description of the type `T`, but that requires an explicit type parameter. It is not always easy to specify that type, especially for unnameable types like closures or for opaque return types. The new [`any::type_name_of_val(&T)`](https://doc.rust-lang.org/stable/std/any/fn.type_name_of_val.html) offers a way to get a descriptive name from any reference to a type.
 
 ```rust
 fn get_iter() -> impl Iterator<Item = i32> {


### PR DESCRIPTION
This will make it easier for people reading the post to jump to the documentation for more details. There is already a link in Stabilized APIs but why not both?