### PR TITLE
Add blog post about GSoC 2024

### DIFF
--- a/posts/2024-02-21-Rust-participates-in-GSoC-2024.md
+++ b/posts/2024-02-21-Rust-participates-in-GSoC-2024.md
@@ -12,6 +12,8 @@ As of today, the organizations that have been accepted into the program have bee
 
 We have prepared a [list of project ideas][gsoc repo] that can serve as inspiration for potential GSoC contributors that would like to send a project proposal to the Rust organization. However, applicants can also come up with their own project ideas. You can discuss project ideas or try to find mentors in the [#gsoc][gsoc stream] Zulip stream. We have also prepared a [proposal guide][proposal guide] that should help you with preparing your project proposals.
 
+You can start discussing the project ideas with Rust Project maintainers immediately. The project proposal application period starts on 18. 3. 2024, and ends on 2. 4. 2024 at 18:00 UTC. Take note of that deadline, as there will be no extensions!
+
 If you are interested in contributing to the Rust Project, we encourage you to check out our project idea list and send us a GSoC project proposal! Of course, you are also free to discuss these projects and/or try to move them forward even if you do not intend to (or cannot) participate in GSoC. We welcome all contributors to Rust, as there is always enough work to do.
 
 This is the first time that the Rust Project is participating in GSoC, so we are quite excited about it. We hope that participants in the program can improve their skills, but also would love for this to bring new contributors to the Project and increase the awareness of Rust in general. We will publish another blog post later this year with more information about our participation in the program.

--- a/posts/2024-02-21-Rust-participates-in-GSoC-2024.md
+++ b/posts/2024-02-21-Rust-participates-in-GSoC-2024.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Rust participates in Google Summer of Code 2024"
+author: Jakub Beránek, Jack Huey and Paul Lenz
+---
+
+We're writing this blog post to announce that the Rust Project will be participating in [Google Summer of Code (GSoC) 2024][gsoc]. If you're not eligible or interested in participating in GSoC, then most of this post likely isn't relevant to you; if you are, this should contain some useful information and links.
+
+Google Summer of Code (GSoC) is an annual global program organized by Google that aims to bring new contributors to the world of open-source. The program pairs organizations (such as the Rust Project) with contributors (usually students), with the goal of helping the participants make meaningful open-source contributions under the guidance of experienced mentors.
+
+As of today, the organizations that have been accepted into the program have been announced by Google. The GSoC applicants now have several weeks to send project proposals to organizations that appeal to them. If their project proposal is accepted, they will embark on a 12-week journey during which they will try to complete their proposed project under the guidance of an assigned mentor.
+
+We have prepared a [list of project ideas][gsoc repo] that can serve as inspiration for potential GSoC contributors that would like to send a project proposal to the Rust organization. However, applicants can also come up with their own project ideas. You can discuss project ideas or try to find mentors in the [#gsoc][gsoc stream] Zulip stream. We have also prepared a [proposal guide][proposal guide] that should help you with preparing your project proposals.
+
+If you are interested in contributing to the Rust Project, we encourage you to check out our project idea list and send us a GSoC project proposal! Of course, you are also free to discuss these projects and/or try to move them forward even if you do not intend to (or cannot) participate in GSoC. We welcome all contributors to Rust, as there is always enough work to do.
+
+This is the first time that the Rust Project is participating in GSoC, so we are quite excited about it. We hope that participants in the program can improve their skills, but also would love for this to bring new contributors to the Project and increase the awareness of Rust in general. We will publish another blog post later this year with more information about our participation in the program.
+
+[gsoc]: https://summerofcode.withgoogle.com
+[gsoc repo]: https://github.com/rust-lang/google-summer-of-code
+[gsoc stream]: https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc
+[proposal guide]: https://github.com/rust-lang/google-summer-of-code/blob/main/proposal-guide.md

--- a/posts/2024-02-21-Rust-participates-in-GSoC-2024.md
+++ b/posts/2024-02-21-Rust-participates-in-GSoC-2024.md
@@ -12,7 +12,7 @@ As of today, the organizations that have been accepted into the program have bee
 
 We have prepared a [list of project ideas][gsoc repo] that can serve as inspiration for potential GSoC contributors that would like to send a project proposal to the Rust organization. However, applicants can also come up with their own project ideas. You can discuss project ideas or try to find mentors in the [#gsoc][gsoc stream] Zulip stream. We have also prepared a [proposal guide][proposal guide] that should help you with preparing your project proposals.
 
-You can start discussing the project ideas with Rust Project maintainers immediately. The project proposal application period starts on 18. 3. 2024, and ends on 2. 4. 2024 at 18:00 UTC. Take note of that deadline, as there will be no extensions!
+You can start discussing the project ideas with Rust Project maintainers immediately. The project proposal application period starts on March 18, 2024, and ends on April 2, 2024 at 18:00 UTC. Take note of that deadline, as there will be no extensions!
 
 If you are interested in contributing to the Rust Project, we encourage you to check out our project idea list and send us a GSoC project proposal! Of course, you are also free to discuss these projects and/or try to move them forward even if you do not intend to (or cannot) participate in GSoC. We welcome all contributors to Rust, as there is always enough work to do.
 


### PR DESCRIPTION
This blog post announces our participation in Google Summer of Code 2024. It will be announced publicly on 21. 2. 2024 by Google. I'm preparing the post in advance to make the announcement as soon as possible, to allow people to start discussing the project ideas.