### PR TITLE
Add blog post about deprecating `feature = "cargo-clippy"`

### DIFF
--- a/posts/2024-02-28-Clippy-deprecating-feature-cargo-clippy.md
+++ b/posts/2024-02-28-Clippy-deprecating-feature-cargo-clippy.md
@@ -1,0 +1,90 @@
+---
+layout: post
+title: "Clippy: Deprecating `feature = \"cargo-clippy\"`"
+author: The Clippy Team
+release: true
+---
+
+Since Clippy [`v0.0.97`] and before it was shipped with `rustup`, Clippy
+implicitly added a `feature = "cargo-clippy"` config[^1] when linting your code
+with `cargo clippy`.
+
+[^1]: It's likely that you didn't even know that Clippy implicitly sets this
+    config (which was not a Cargo feature). This is intentional, as we stopped
+    advertising and documenting this a long time ago.
+
+Back in the day (2016) this was necessary to allow, warn or deny Clippy lints
+using attributes:
+
+```rust
+#[cfg_attr(feature = "cargo-clippy", allow(clippy_lint_name))]
+```
+
+Doing this hasn't been necessary for a long time. Today, Clippy users will set
+lint levels with tool lint attributes using the `clippy::` prefix:
+
+```rust
+#[allow(clippy::lint_name)]
+```
+
+The implicit `feature = "cargo-clippy"` has only been kept for backwards
+compatibility, but will now be deprecated.
+
+## Alternative
+
+As there is a rare [use case] for conditional compilation depending on Clippy,
+we will provide an alternative. So in the future you will be able to use:
+
+```rust
+#[cfg(clippy)]
+```
+
+## Transitioning
+
+Should you have instances of `feature = "cargo-clippy"` in your code base, you
+will see a warning from the new Clippy lint
+[`clippy::deprecated_clippy_cfg_attr`][pr-12292]. This lint can automatically fix
+your code. So if you should see this lint triggering, just run:
+
+```
+cargo clippy --fix -- -Aclippy::all -Wclippy::deprecated_clippy_cfg_attr
+```
+
+This will fix all instances in your code.
+
+In addition, check your `.cargo/config` file for:
+
+```toml
+[target.'cfg(feature = "cargo-clippy")']
+rustflags = ["-Aclippy::..."]
+```
+
+If you have this config, you will have to update it yourself, by either changing
+it to `cfg(clippy)` or taking this opportunity to transition to [setting lint
+levels in `Cargo.toml`][cargo-lints] directly.
+
+## Motivation for Deprecation
+
+Currently, there's a [call for testing], in order to stabilize [checking
+conditional compilation at compile time][rfc-3013], aka `cargo check
+-Zcheck-cfg`. If we were to keep the `feature = "cargo-clippy"` config, users
+would start seeing a lot of warnings on their `feature = "cargo-clippy"`
+conditions. To work around this, they would either need to allow the lint or
+have to add a dummy feature to their `Cargo.toml` in order to silence those
+warnings:
+
+```toml
+[features]
+cargo-clippy = []
+```
+
+We didn't think this would be user friendly, and decided that instead we want to
+deprecate the implicit `feature = "cargo-clippy"` config and replace it with the
+`clippy` config.
+
+[`v0.0.97`]: https://github.com/rust-lang/rust-clippy/blob/61daf674eaf17f3b504c51f01b4ee63fac47dfcf/CHANGELOG.md?plain=0#0097--2016-11-03
+[rfc-3013]: https://github.com/rust-lang/rfcs/pull/3013
+[use case]: https://doc.rust-lang.org/clippy/configuration.html#disabling-evaluation-of-certain-code
+[pr-12292]: https://github.com/rust-lang/rust-clippy/pull/12292
+[cargo-lints]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-lints-section
+[call for testing]: https://github.com/rust-lang/rfcs/pull/3013#issuecomment-1936648479


### PR DESCRIPTION
I'm not sure, if this blog post should go into the internals Rust blog or the main blog. I put it in the main blog for now as it might affect a bunch of users, but I'm happy to move it to internals.

cc @rust-lang/clippy @urgau 

[Rendered](https://github.com/flip1995/blog.rust-lang.org/blob/clippy-feature-deprecation/posts/2024-02-16-Clippy-deprecating-feature-cargo-clippy.md)