### PR TITLE
Remove duplicate commandline prompt in `console` block displays

### DIFF
--- a/posts/inside-rust/2024-02-13-this-development-cycle-in-cargo-1-77.md
+++ b/posts/inside-rust/2024-02-13-this-development-cycle-in-cargo-1-77.md
@@ -76,14 +76,14 @@ we switched from printing a `Created` status at the end to a `Creating` status a
 
 With the previous `Created`:
 ```console
-$ cargo new foo
+cargo new foo
       Adding `foo` as member of workspace at `/home/epage/src/personal/cargo`
 note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
      Created binary (application) `foo` package
 ```
 With the new `Creating`:
 ```console
-$ cargo new foo
+cargo new foo
     Creating binary (application) `foo` package
       Adding `foo` as member of workspace at `/home/epage/src/personal/cargo`
 note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This PR removes duplicate commandline prompt in `console` blocks.

Thank you for taking the time.