### PR TITLE
Remove automatic `$` prefix for `bash` and `console` code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Pages via GitHub Actions.
 To build the site locally:
 
 ```console
-> git clone https://github.com/rust-lang/blog.rust-lang.org
-> cd blog.rust-lang.org
-> cargo run
+$ git clone https://github.com/rust-lang/blog.rust-lang.org
+$ cd blog.rust-lang.org
+$ cargo run
 ```
 
 You could do it in release mode if you'd like, but it's pretty fast in debug.
@@ -23,13 +23,13 @@ From there, the generated HTML will be in a `site` directory.
 Open `site/index.html` in your web browser to view the site.
 
 ```console
-> firefox site/index.html
+$ firefox site/index.html
 ```
 
 You can also run a server, if you need to preview your changes on a different machine:
 
 ```console
-> cargo run -p serve
+$ cargo run -p serve
 Serving on: http://192.168.123.45:8000
 ```
 

--- a/posts/2015-10-29-Rust-1.4.md
+++ b/posts/2015-10-29-Rust-1.4.md
@@ -79,7 +79,7 @@ information about what it is
 changing.](https://github.com/rust-lang/cargo/pull/1931) For example:
 
 ```console
-cargo update
+$ cargo update
     Updating registry `https://github.com/rust-lang/crates.io-index`
     Updating libc v0.1.8 -> v0.1.10
     Updating memchr v0.1.3 -> v0.1.5

--- a/posts/2016-05-05-cargo-pillars.md
+++ b/posts/2016-05-05-cargo-pillars.md
@@ -158,7 +158,7 @@ Now that we've added the `time` crate, let's see what happens if we ask Cargo to
 build our package:
 
 ```console
-cargo build
+$ cargo build
    Compiling winapi v0.2.6
    Compiling libc v0.2.10
    Compiling winapi-build v0.1.1
@@ -174,14 +174,14 @@ up into smaller crates that do one thing and do it well**.
 Now that we successfully built our crate, what happens if we try to build it again?
 
 ```console
-cargo build
+$ cargo build
 ```
 
 Nothing happened at all. Why's that? We can always ask Cargo to give us more
 information through the `--verbose` flag, so let's do that:
 
 ```console
-cargo build --verbose
+$ cargo build --verbose
        Fresh libc v0.2.10
        Fresh winapi v0.2.6
        Fresh winapi-build v0.1.1
@@ -240,7 +240,7 @@ To do this, we check in our `Cargo.lock` and clone the repository on our new
 machine. Then, we run `cargo build` again.
 
 ```console
-cargo build
+$ cargo build
    Compiling libc v0.2.10
    Compiling winapi v0.2.6
    Compiling winapi-build v0.1.1
@@ -271,7 +271,7 @@ fn main() {
 To run the example, we ask Cargo to build and run it:
 
 ```console
-cargo run --example date
+$ cargo run --example date
    Compiling datetime v0.1.0 (file:///Users/ykatz/Code/datetime)
      Running `target/debug/examples/date`
 26 Apr 2016 :: 05:03:38
@@ -322,7 +322,7 @@ to our package:
 After using the crate in our library, let's run `cargo build` again:
 
 ```console
-cargo build
+$ cargo build
     Updating registry `https://github.com/rust-lang/crates.io-index`
  Downloading tz v0.2.1
  Downloading byteorder v0.5.1
@@ -386,7 +386,7 @@ fn bench_date(b: &mut Bencher) {
 If we then run `cargo bench`:
 
 ```console
-cargo bench
+$ cargo bench
    Compiling winapi v0.2.6
    Compiling libc v0.2.10
    Compiling byteorder v0.5.1
@@ -450,7 +450,7 @@ library for Unix-specific functionality.
 As before, when I run `cargo build`, Cargo *conservatively* adds `nix` and its dependencies:
 
 ```console
-cargo build
+$ cargo build
     Updating registry `https://github.com/rust-lang/crates.io-index`
  Downloading nix v0.5.0
  Downloading bitflags v0.4.0

--- a/posts/2016-05-13-rustup.md
+++ b/posts/2016-05-13-rustup.md
@@ -145,7 +145,7 @@ stable toolchain that targets the 64-bit, MSVC ABI.
 [abi]: https://www.rust-lang.org/downloads.html#win-foot
 
 ```console
-rustup default stable-x86_64-pc-windows-msvc
+$ rustup default stable-x86_64-pc-windows-msvc
 info: syncing channel updates for 'stable-x86_64-pc-windows-msvc'
 info: downloading component 'rustc'
 info: downloading component 'rust-std'

--- a/posts/2016-08-10-Shape-of-errors-to-come.md
+++ b/posts/2016-08-10-Shape-of-errors-to-come.md
@@ -95,7 +95,7 @@ Today, when you can call `--explain`, you pass an error code. The compiler then 
 an extended message that goes into more detail about how errors of that form occur:
 
 ```console
-rustc --explain E0200
+$ rustc --explain E0200
 
 Unsafe traits must have unsafe implementations. This error occurs when an
 implementation for an unsafe trait isn't marked as unsafe. This may be resolved

--- a/posts/2016-09-08-incremental.md
+++ b/posts/2016-09-08-incremental.md
@@ -29,7 +29,7 @@ time since implementation started towards the end of last year, all of the
 been done. You can give it a try in the nightly version of the compiler:
 
 ```console
-rustc -Zincremental=<path> ./main.rs
+$ rustc -Zincremental=<path> ./main.rs
 ```
 
 This will start the compiler in **incremental mode**, using whatever `<path>`

--- a/posts/2016-09-29-Rust-1.12.md
+++ b/posts/2016-09-29-Rust-1.12.md
@@ -74,7 +74,7 @@ we showed above, at the start of the post? Here's an example of attempting to
 compile that code while passing the `--error-format=json` flag:
 
 ```bash
-rustc borrowck-assign-comp.rs --error-format=json
+$ rustc borrowck-assign-comp.rs --error-format=json
 {"message":"cannot assign to `p.x` because it is borrowed","level":"error","spans":[{"file_name":"borrowck-assign-comp.rs","byte_start":562,"byte_end":563,"line_start":15,"line_end":15,"column_start":14,"column_end":15,"is_primary":false,"text":[{"text":"    let q = &p;","highlight_start":14,"highlight_end":15}],"label":"borrow of `p.x` occurs here","suggested_replacement":null,"expansion":null}],"label":"assignment to borrowed `p.x` occurs here","suggested_replacement":null,"expansion":null}],"children":[],"rendered":null}
 {"message":"aborting due to previous error","code":null,"level":"error","spans":[],"children":[],"rendered":null}
 ```

--- a/posts/2016-12-22-Rust-1.14.md
+++ b/posts/2016-12-22-Rust-1.14.md
@@ -43,7 +43,7 @@ small taste of how it works, once you have [emscripten] installed, compiling
 some Rust code to WebAssembly is as easy as:
 
 ```bash
-rustup target add wasm32-unknown-emscripten
+$ rustup target add wasm32-unknown-emscripten
 $ echo 'fn main() { println!("Hello, Emscripten!"); }' > hello.rs
 $ rustc --target=wasm32-unknown-emscripten hello.rs
 $ node hello.js

--- a/posts/2017-02-02-Rust-1.15.md
+++ b/posts/2017-02-02-Rust-1.15.md
@@ -11,7 +11,7 @@ systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.15 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2017-02-09-Rust-1.15.1.md
+++ b/posts/2017-02-09-Rust-1.15.1.md
@@ -11,7 +11,7 @@ systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.15.1 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [download Rust][install] from the

--- a/posts/2017-03-16-Rust-1.16.md
+++ b/posts/2017-03-16-Rust-1.16.md
@@ -11,7 +11,7 @@ systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.16 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the
@@ -115,7 +115,7 @@ will live as long as `Name`, which is required for `Name` to be valid. Let's try
 code with Rust 1.15.1:
 
 ```bash
-rustc +1.15.1 foo.rs --crate-type=lib
+$ rustc +1.15.1 foo.rs --crate-type=lib
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter in generic type due to conflicting requirements
   --> .\foo.rs:10:5
    |
@@ -139,7 +139,7 @@ The compiler explains the issue, and gives a helpful suggestion. So let's try it
 the `'a`, and compile again:
 
 ```bash
-rustc +1.15.1 .\foo.rs --crate-type=lib
+$ rustc +1.15.1 .\foo.rs --crate-type=lib
 error[E0308]: method not compatible with trait
   --> .\foo.rs:10:5
    |
@@ -164,7 +164,7 @@ It still doesn't work. That help message was not actually helpful. It does sugge
 lifetime, this time on `Name`. If we do that...
 
 ```bash
-rustc +1.15.1 .\foo.rs --crate-type=lib
+$ rustc +1.15.1 .\foo.rs --crate-type=lib
 <snip>
 help: consider using an explicit lifetime parameter as shown: fn from_str(s: &'a str) -> Result<Name<'a>, ()>
   --> .\foo.rs:10:5

--- a/posts/2017-04-27-Rust-1.17.md
+++ b/posts/2017-04-27-Rust-1.17.md
@@ -11,7 +11,7 @@ systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.17 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2017-06-08-Rust-1.18.md
+++ b/posts/2017-06-08-Rust-1.18.md
@@ -11,7 +11,7 @@ systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.18 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2017-07-20-Rust-1.19.md
+++ b/posts/2017-07-20-Rust-1.19.md
@@ -11,7 +11,7 @@ systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.19 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2017-08-31-Rust-1.20.md
+++ b/posts/2017-08-31-Rust-1.20.md
@@ -11,7 +11,7 @@ is a systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.20 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2017-10-12-Rust-1.21.md
+++ b/posts/2017-10-12-Rust-1.21.md
@@ -11,7 +11,7 @@ is a systems programming language focused on safety, speed, and concurrency.
 If you have a previous version of Rust installed, getting Rust 1.21 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2017-11-22-Rust-1.22.md
+++ b/posts/2017-11-22-Rust-1.22.md
@@ -20,7 +20,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.22.1 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-01-04-Rust-1.23.md
+++ b/posts/2018-01-04-Rust-1.23.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.23.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-02-15-Rust-1.24.md
+++ b/posts/2018-02-15-Rust-1.24.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.24.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the
@@ -33,7 +33,7 @@ of "standard style." With this release, we're happy to announce that a *preview*
 can be used with 1.24 stable. To give it a try, do this:
 
 ```bash
-rustup component add rustfmt-preview
+$ rustup component add rustfmt-preview
 ```
 
 There are two important aspects here: first, you're using `rustup component

--- a/posts/2018-03-01-Rust-1.24.1.md
+++ b/posts/2018-03-01-Rust-1.24.1.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.24.1 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-03-29-Rust-1.25.md
+++ b/posts/2018-03-29-Rust-1.25.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.25.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-05-10-Rust-1.26.md
+++ b/posts/2018-05-10-Rust-1.26.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.26.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-05-29-Rust-1.26.1.md
+++ b/posts/2018-05-29-Rust-1.26.1.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.26.1 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the
@@ -124,7 +124,7 @@ This was unfortunately fixed too late to make it into 1.26 stable, so we added
 the patch for 1.26.1 to permit users to install Rust on these platforms.
 
 ```console
-rustup update
+$ rustup update
 info: syncing channel updates for 'stable-x86_64-unknown-freebsd'
 info: latest update on 2018-05-10, rust version 1.26.0 (a77568041 2018-05-07)
 error: component 'rust-docs' for 'x86_64-unknown-freebsd' is unavailable for download

--- a/posts/2018-06-05-Rust-1.26.2.md
+++ b/posts/2018-06-05-Rust-1.26.2.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.26.2 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-06-21-Rust-1.27.md
+++ b/posts/2018-06-21-Rust-1.27.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.27.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-07-10-Rust-1.27.1.md
+++ b/posts/2018-07-10-Rust-1.27.1.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.27.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-07-20-Rust-1.27.2.md
+++ b/posts/2018-07-20-Rust-1.27.2.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.27.2 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-08-02-Rust-1.28.md
+++ b/posts/2018-08-02-Rust-1.28.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.28.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-09-13-Rust-1.29.md
+++ b/posts/2018-09-13-Rust-1.29.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.29.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the
@@ -52,7 +52,7 @@ Here, we're calling `do_something` a hundred times. But we never use the variabl
 And so Rust warns:
 
 ```console
-cargo build
+$ cargo build
    Compiling myprogram v0.1.0 (file:///path/to/myprogram)
 warning: unused variable: `i`
  --> src\main.rs:4:9
@@ -69,7 +69,7 @@ See how it suggests that we use `_i` as a name instead? We can automatically
 apply that suggestion with `cargo fix`:
 
 ```console
-cargo fix
+$ cargo fix
     Checking myprogram v0.1.0 (file:///C:/Users/steve/tmp/fix)
       Fixing src\main.rs (1 fix)
     Finished dev [unoptimized + debuginfo] target(s) in 0.59s
@@ -120,13 +120,13 @@ a reference is a no-op, and so this is almost certainly a bug.
 We can get the preview of Clippy from Rustup:
 
 ```console
-rustup component add clippy-preview
+$ rustup component add clippy-preview
 ```
 
 and then run it:
 
 ```console
-cargo clippy
+$ cargo clippy
 error: calls to `std::mem::drop` with a reference instead of an owned value. Dropping a reference does nothing.
  --> src\main.rs:5:5
   |

--- a/posts/2018-09-25-Rust-1.29.1.md
+++ b/posts/2018-09-25-Rust-1.29.1.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.29.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-10-12-Rust-1.29.2.md
+++ b/posts/2018-10-12-Rust-1.29.2.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.29.2 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-10-25-Rust-1.30.0.md
+++ b/posts/2018-10-25-Rust-1.30.0.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.30.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-10-30-help-test-rust-2018.md
+++ b/posts/2018-10-30-help-test-rust-2018.md
@@ -35,14 +35,14 @@ First things first, you'll need to install the beta release channel of Rust.
 With [Rustup], it's as easy as:
 
 ```console
-rustup install beta
+$ rustup install beta
 ```
 
 To use this channel of Rust instead of your default, you can append a `+beta`
 to any `rustc` or cargo commands:
 
 ```console
-rustc +beta --version
+$ rustc +beta --version
 $ cargo +beta build
 ```
 
@@ -56,7 +56,7 @@ experiments.
 To start a new project with Rust 2018:
 
 ```console
-cargo +beta new my-sample-project
+$ cargo +beta new my-sample-project
 ```
 
 Nothing changes! Well, something changed. Check out `Cargo.toml`:
@@ -84,7 +84,7 @@ interoperate seamlessly!
 The first step is to run `cargo fix`:
 
 ```console
-cargo fix --edition
+$ cargo fix --edition
 ```
 
 This will check your code, and automatically fix any issues that it can.

--- a/posts/2018-11-08-Rust-1.30.1.md
+++ b/posts/2018-11-08-Rust-1.30.1.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.30.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2018-12-06-Rust-1.31-and-rust-2018.md
+++ b/posts/2018-12-06-Rust-1.31-and-rust-2018.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.31.0 is as easy as:
 
 ```bash
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the
@@ -69,7 +69,7 @@ We'll be covering all of this and more in this post.
 Let's create a new project with Cargo:
 
 ```console
-cargo new foo
+$ cargo new foo
 ```
 
 Here's the contents of `Cargo.toml`:

--- a/posts/2018-12-20-Rust-1.31.1.md
+++ b/posts/2018-12-20-Rust-1.31.1.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.31.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2019-01-17-Rust-1.32.0.md
+++ b/posts/2019-01-17-Rust-1.32.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.32.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2019-02-28-Rust-1.33.0.md
+++ b/posts/2019-02-28-Rust-1.33.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.33.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2019-04-11-Rust-1.34.0.md
+++ b/posts/2019-04-11-Rust-1.34.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.34.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate

--- a/posts/2019-04-25-Rust-1.34.1.md
+++ b/posts/2019-04-25-Rust-1.34.1.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup,
 getting Rust 1.34.1 and rustup 1.18.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website.

--- a/posts/2019-05-14-Rust-1.34.2.md
+++ b/posts/2019-05-14-Rust-1.34.2.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.34.2 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2019-05-23-Rust-1.35.0.md
+++ b/posts/2019-05-23-Rust-1.35.0.md
@@ -11,7 +11,7 @@ programming language that is empowering everyone to build reliable and efficient
 If you have a previous version of Rust installed via rustup, getting Rust 1.35.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website,

--- a/posts/2019-07-04-Rust-1.36.0.md
+++ b/posts/2019-07-04-Rust-1.36.0.md
@@ -11,7 +11,7 @@ Rust is a programming language that is empowering everyone to build reliable and
 If you have a previous version of Rust installed via rustup, getting Rust 1.36.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website,

--- a/posts/2019-08-15-Rust-1.37.0.md
+++ b/posts/2019-08-15-Rust-1.37.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.37.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, getting Rust 1.37.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website, and check out the [detailed release notes for 1.37.0][notes] on GitHub.

--- a/posts/2019-09-26-Rust-1.38.0.md
+++ b/posts/2019-09-26-Rust-1.38.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.38.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, getting Rust 1.38.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website.

--- a/posts/2019-11-01-nll-hard-errors.md
+++ b/posts/2019-11-01-nll-hard-errors.md
@@ -94,7 +94,7 @@ You can find out which crates you rely upon using the [cargo-tree] command. If y
 that you *do* rely (say) on `url` 1.7.0, you can upgrade to 1.7.2 by executing:
 
 ```bash
-cargo update --package url --precise 1.7.2
+$ cargo update --package url --precise 1.7.2
 ```
 
 [cargo-tree]: https://crates.io/crates/cargo-tree

--- a/posts/2019-11-07-Rust-1.39.0.md
+++ b/posts/2019-11-07-Rust-1.39.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.39.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, getting Rust 1.39.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website, and check out the [detailed release notes for 1.39.0][notes] on GitHub.

--- a/posts/2019-12-19-Rust-1.40.0.md
+++ b/posts/2019-12-19-Rust-1.40.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.40.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, getting Rust 1.40.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website, and check out the [detailed release notes for 1.40.0][notes] on GitHub.

--- a/posts/2020-01-30-Rust-1.41.0.md
+++ b/posts/2020-01-30-Rust-1.41.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.41.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-02-27-Rust-1.41.1.md
+++ b/posts/2020-02-27-Rust-1.41.1.md
@@ -11,7 +11,7 @@ Rust is a programming language that is empowering everyone to build reliable and
 If you have a previous version of Rust installed via rustup, getting Rust 1.41.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website.

--- a/posts/2020-03-12-Rust-1.42.md
+++ b/posts/2020-03-12-Rust-1.42.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.42.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, getting Rust 1.42.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the appropriate page on our website, and check out the [detailed release notes for 1.42.0][notes] on GitHub.

--- a/posts/2020-04-23-Rust-1.43.0.md
+++ b/posts/2020-04-23-Rust-1.43.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.43.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-05-07-Rust.1.43.1.md
+++ b/posts/2020-05-07-Rust.1.43.1.md
@@ -11,7 +11,7 @@ Rust is a programming language that is empowering everyone to build reliable and
 If you have a previous version of Rust installed via rustup, getting Rust 1.43.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-06-18-Rust.1.44.1.md
+++ b/posts/2020-06-18-Rust.1.44.1.md
@@ -11,7 +11,7 @@ Rust is a programming language that is empowering everyone to build reliable and
 If you have a previous version of Rust installed via rustup, getting Rust 1.44.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-07-16-Rust-1.45.0.md
+++ b/posts/2020-07-16-Rust-1.45.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.45.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-07-30-Rust-1.45.1.md
+++ b/posts/2020-07-30-Rust-1.45.1.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.45.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-08-03-Rust-1.45.2.md
+++ b/posts/2020-08-03-Rust-1.45.2.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.45.2 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-08-27-Rust-1.46.0.md
+++ b/posts/2020-08-27-Rust-1.46.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.46.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-10-08-Rust-1.47.md
+++ b/posts/2020-10-08-Rust-1.47.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.47.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-11-19-Rust-1.48.md
+++ b/posts/2020-11-19-Rust-1.48.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.48.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2020-12-31-Rust-1.49.0.md
+++ b/posts/2020-12-31-Rust-1.49.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.49.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install] from the

--- a/posts/2021-02-11-Rust-1.50.0.md
+++ b/posts/2021-02-11-Rust-1.50.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.50.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-03-25-Rust-1.51.0.md
+++ b/posts/2021-03-25-Rust-1.51.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.51.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.52.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-05-10-Rust-1.52.1.md
+++ b/posts/2021-05-10-Rust-1.52.1.md
@@ -16,7 +16,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.52.1 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-06-17-Rust-1.53.0.md
+++ b/posts/2021-06-17-Rust-1.53.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.53.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-07-29-Rust-1.54.0.md
+++ b/posts/2021-07-29-Rust-1.54.0.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.54.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-09-09-Rust-1.55.0.md
+++ b/posts/2021-09-09-Rust-1.55.0.md
@@ -12,7 +12,7 @@ If you have a previous version of Rust installed via rustup, getting Rust
 1.55.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-10-21-Rust-1.56.0.md
+++ b/posts/2021-10-21-Rust-1.56.0.md
@@ -11,7 +11,7 @@ Rust is a programming language empowering everyone to build reliable and efficie
 If you have a previous version of Rust installed via rustup, getting Rust 1.56.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2021-12-02-Rust-1.57.0.md
+++ b/posts/2021-12-02-Rust-1.57.0.md
@@ -11,7 +11,7 @@ Rust is a programming language empowering everyone to build reliable and efficie
 If you have a previous version of Rust installed via rustup, getting Rust 1.57.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2022-01-13-Rust-1.58.0.md
+++ b/posts/2022-01-13-Rust-1.58.0.md
@@ -11,7 +11,7 @@ Rust is a programming language empowering everyone to build reliable and efficie
 If you have a previous version of Rust installed via rustup, getting Rust 1.58.0 is as easy as:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2022-02-24-Rust-1.59.0.md
+++ b/posts/2022-02-24-Rust-1.59.0.md
@@ -22,7 +22,7 @@ If you have a previous version of Rust installed via rustup, you can get 1.59.0
 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2022-04-07-Rust-1.60.0.md
+++ b/posts/2022-04-07-Rust-1.60.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.60.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.60.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2022-05-19-Rust-1.61.0.md
+++ b/posts/2022-05-19-Rust-1.61.0.md
@@ -11,7 +11,7 @@ empowering everyone to build reliable and efficient software.
 If you have a previous version of Rust installed via rustup, you can get 1.61.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2022-06-30-Rust-1.62.0.md
+++ b/posts/2022-06-30-Rust-1.62.0.md
@@ -11,7 +11,7 @@ empowering everyone to build reliable and efficient software.
 If you have a previous version of Rust installed via rustup, you can get 1.62.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]
@@ -74,8 +74,8 @@ This is part of a long effort to improve the efficiency of Rust's lock types, wh
 It's now easier to build OS-less binaries for `x86_64`, for example when writing a kernel. The [`x86_64-unknown-none` target](https://doc.rust-lang.org/beta/rustc/platform-support/x86_64-unknown-none.html) has been promoted to [Tier 2](https://doc.rust-lang.org/rustc/platform-support.html#tier-2) and can be installed with rustup.
 
 ```console
-rustup target add x86_64-unknown-none
-rustc --target x86_64-unknown-none my_no_std_program.rs
+$ rustup target add x86_64-unknown-none
+$ rustc --target x86_64-unknown-none my_no_std_program.rs
 ```
 
 You can read more about development using `no_std` in the [Embedded Rust book](https://docs.rust-embedded.org/book/intro/no-std.html).

--- a/posts/2022-08-11-Rust-1.63.0.md
+++ b/posts/2022-08-11-Rust-1.63.0.md
@@ -11,7 +11,7 @@ empowering everyone to build reliable and efficient software.
 If you have a previous version of Rust installed via rustup, you can get 1.63.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`][install]

--- a/posts/2022-09-22-Rust-1.64.0.md
+++ b/posts/2022-09-22-Rust-1.64.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, you can get 1.64.0
 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get

--- a/posts/2022-11-03-Rust-1.65.0.md
+++ b/posts/2022-11-03-Rust-1.65.0.md
@@ -24,7 +24,7 @@ If you have a previous version of Rust installed via rustup, you can get 1.65.0
 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get

--- a/posts/2022-12-15-Rust-1.66.0.md
+++ b/posts/2022-12-15-Rust-1.66.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, you can get 1.66.0
 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get

--- a/posts/2023-01-26-Rust-1.67.0.md
+++ b/posts/2023-01-26-Rust-1.67.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, you can get 1.67.0
 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get

--- a/posts/2023-03-09-Rust-1.68.0.md
+++ b/posts/2023-03-09-Rust-1.68.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via rustup, you can get 1.68.0
 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get

--- a/posts/2023-04-20-Rust-1.69.0.md
+++ b/posts/2023-04-20-Rust-1.69.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a nice version of Rust, 1.69.0. Rust is a pro
 If you have a previous version of Rust installed via rustup, you can get 1.69.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.69.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1690-2023-04-20) on GitHub.

--- a/posts/2023-04-25-Rustup-1.26.0.md
+++ b/posts/2023-04-25-Rustup-1.26.0.md
@@ -9,13 +9,13 @@ The rustup working group is happy to announce the release of rustup version 1.26
 If you have a previous version of rustup installed, getting rustup 1.26.0 is as easy as stopping any programs which may be using Rustup (e.g. closing your IDE) and running:
 
 ```console
-rustup self update
+$ rustup self update
 ```
 
 Rustup will also automatically update itself at the end of a normal toolchain update:
 
 ```console
-rustup update
+$ rustup update
 ```
 
 If you don't have it already, you can [get rustup][install] from the appropriate page on our website.

--- a/posts/2023-06-01-Rust-1.70.0.md
+++ b/posts/2023-06-01-Rust-1.70.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.70.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.70.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.70.0](https://github.com/rust-lang/rust/releases/tag/1.70.0) on GitHub.

--- a/posts/2023-07-13-Rust-1.71.0.md
+++ b/posts/2023-07-13-Rust-1.71.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.71.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.71.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.71.0](https://github.com/rust-lang/rust/releases/tag/1.71.0) on GitHub.

--- a/posts/2023-08-24-Rust-1.72.0.md
+++ b/posts/2023-08-24-Rust-1.72.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.72.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.72.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.72.0](https://github.com/rust-lang/rust/releases/tag/1.72.0) on GitHub.

--- a/posts/2023-10-05-Rust-1.73.0.md
+++ b/posts/2023-10-05-Rust-1.73.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.73.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.73.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.73.0](https://github.com/rust-lang/rust/releases/tag/1.73.0) on GitHub.

--- a/posts/2023-11-16-Rust-1.74.0.md
+++ b/posts/2023-11-16-Rust-1.74.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.74.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.74.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.74.0](https://github.com/rust-lang/rust/releases/tag/1.74.0) on GitHub.

--- a/posts/2023-12-28-Rust-1.75.0.md
+++ b/posts/2023-12-28-Rust-1.75.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.75.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.75.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.75.0](https://doc.rust-lang.org/nightly/releases.html#version-1750-2023-12-28).

--- a/posts/2024-02-08-Rust-1.76.0.md
+++ b/posts/2024-02-08-Rust-1.76.0.md
@@ -10,7 +10,7 @@ The Rust team is happy to announce a new version of Rust, 1.76.0. Rust is a prog
 If you have a previous version of Rust installed via rustup, you can get 1.76.0 with:
 
 ```console
-rustup update stable
+$ rustup update stable
 ```
 
 If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.76.0](https://doc.rust-lang.org/nightly/releases.html#version-1760-2024-02-08).

--- a/posts/inside-rust/2019-12-18-bisecting-rust-compiler.md
+++ b/posts/inside-rust/2019-12-18-bisecting-rust-compiler.md
@@ -125,7 +125,7 @@ Please give the steps for how to build your repository (platform, system depende
 <p>
 
 ```bash
-Paste the error the compiler is giving
+$ Paste the error the compiler is giving
 ```
 
 </p></details>

--- a/posts/inside-rust/2020-11-15-Using-rustc_codegen_cranelift.md
+++ b/posts/inside-rust/2020-11-15-Using-rustc_codegen_cranelift.md
@@ -95,7 +95,7 @@ if you're just interested! The reason this isn't the recommended way to build
 First, download the Rust repository.
 
 ```console
-git clone https://github.com/rust-lang/rust
+$ git clone https://github.com/rust-lang/rust
 ```
 
 Now, let's set up the build system to use `cg_clif`.
@@ -110,7 +110,7 @@ EOF
 Finally, let's run the build. This can take a long time, over a half-hour in some cases.
 
 ```console
-./x.py build
+$ ./x.py build
 ```
 
 ## How can I help?

--- a/posts/inside-rust/2024-02-13-this-development-cycle-in-cargo-1-77.md
+++ b/posts/inside-rust/2024-02-13-this-development-cycle-in-cargo-1-77.md
@@ -76,14 +76,14 @@ we switched from printing a `Created` status at the end to a `Creating` status a
 
 With the previous `Created`:
 ```console
-cargo new foo
+$ cargo new foo
       Adding `foo` as member of workspace at `/home/epage/src/personal/cargo`
 note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
      Created binary (application) `foo` package
 ```
 With the new `Creating`:
 ```console
-cargo new foo
+$ cargo new foo
     Creating binary (application) `foo` package
       Adding `foo` as member of workspace at `/home/epage/src/personal/cargo`
 note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -346,12 +346,12 @@ We have tried to raise awareness of these tools by calling the, out in our
 There is also the issue that sharing a package name between a binary and a library is more convenient.
 For example, compare
 ```console
-cargo add pulldown-cmark
+$ cargo add pulldown-cmark
 cargo add typos
 ```
 with
 ```console
-cargo install pulldown-cmark
+$ cargo install pulldown-cmark
 cargo install typos-cli
 ```
 [RFC #3383](https://github.com/rust-lang/rfcs/pull/3383) is an attempt at improving this.

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -67,11 +67,6 @@ code {
   overflow: auto;
 }
 
-code.language-console::before,
-code.language-bash::before {
-  content: '$ ';
-}
-
 section {
   padding: 30px 0 60px 0;
 


### PR DESCRIPTION
This prefix is very surprising to blog authors because e.g. GitHub does not render it that way. It also does not work well if a code block contains multiple commands where all but the first one need a manual prefix. The [original commit that introduced this](https://github.com/rust-lang/blog.rust-lang.org/commit/1849fd748d0c8a6515f8df19afd05b15598c3b59) unfortunately does not give any reasons for why it was introduced.

Related:

- https://github.com/rust-lang/blog.rust-lang.org/pull/1260