### PR TITLE
Clippy post: remove `release: true`

### DIFF
--- a/posts/2024-02-28-Clippy-deprecating-feature-cargo-clippy.md
+++ b/posts/2024-02-28-Clippy-deprecating-feature-cargo-clippy.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Clippy: Deprecating `feature = \"cargo-clippy\"`"
 author: The Clippy Team
-release: true
 ---
 
 Since Clippy [`v0.0.97`] and before it was shipped with `rustup`, Clippy


### PR DESCRIPTION
Recently published clippy post had `release` set to `true`, which seems incorrect, as the changelog link on the [main website](https://www.rust-lang.org/) now links to it, and not to https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html.

If just removing the line after-the-fact is not enough to unpublish it from `https://blog.rust-lang.org/releases.json`, feel free to close this PR and open a new one with the proper fix.