### PR TITLE
Remove incompatible_msrv from 1.77 release.

### DIFF
--- a/posts/2024-03-21-Rust-1.77.0.md
+++ b/posts/2024-03-21-Rust-1.77.0.md
@@ -77,21 +77,6 @@ Users which do want debuginfo can explicitly enable it with the
 [debug](https://doc.rust-lang.org/stable/cargo/reference/profiles.html#debug)
 flag in the relevant Cargo profile.
 
-### Clippy adds a new `incompatible_msrv` lint
-
-The Rust project only supports the latest stable release of Rust. Some
-libraries aim to have an older minimum supported Rust version (MSRV), typically
-verifying this support by compiling in CI with an older release. However, when
-developing new code, it's convenient to use latest documentation and the latest
-toolchain with fixed bugs, performance improvements, and other improvements.
-This can make it easy to accidentally start using an API that's only available
-on newer versions of Rust.
-
-Clippy has added a new lint, [`incompatible_msrv`](https://rust-lang.github.io/rust-clippy/master/index.html#/incompatible_msrv),
-which will inform users if functionality being referenced is only available on
-newer versions than their
-[declared MSRV](https://github.com/rust-lang/rust-clippy/?tab=readme-ov-file#specifying-the-minimum-supported-rust-version).
-
 ### Stabilized APIs
 
 - [`array::each_ref`](https://doc.rust-lang.org/stable/std/primitive.array.html#method.each_ref)


### PR DESCRIPTION
This is actually in the 1.78 release.

Closes #1277