### PR TITLE
Fix dead links an deadname in "Shape of errors to come"

### DIFF
--- a/posts/2016-08-10-Shape-of-errors-to-come.md
+++ b/posts/2016-08-10-Shape-of-errors-to-come.md
@@ -1,14 +1,14 @@
 ---
 layout: post
 title: "Shape of errors to come"
-author: Jonathan Turner
+author: Sophia June Turner
 ---
 
 There are changes afoot in the Rust world. If you've tried out the latest nightly, you'll notice
 something is *a little different*. For the past few months we've been working on new way of
 reporting errors that's easier to read and understand. This is part of an on-going campaign to
 improve Rust's usability across the board. We mentioned ways to help us
-[make the transition](https://www.jonathanturner.org/2016/08/helping-out-with-rust-errors.html)
+[make the transition](https://www.sophiajt.com/helping-out-with-rust-errors/)
 to the new errors, and already many people have jumped in (and thank you to those volunteers!)
 
 Let's dive in and see what's changed.  We'll start with a simple example:
@@ -166,7 +166,7 @@ extended errors looks like, come jump into the #rust-cli channel on irc.mozilla.
 
 Great!  We love the enthusiasm. There's
 [a lot to do](https://github.com/rust-lang/rust/issues/35233), and a
-[lot of skills](https://www.jonathanturner.org/2016/08/helping-out-with-rust-errors.html) that could
+[lot of skills](https://www.sophiajt.com/helping-out-with-rust-errors/) that could
 help us in different ways. Whether you're good at unit tests, writing docs,
 writing code, or working on designs, there are places to jump in.
 


### PR DESCRIPTION
Replace Sophia's old name and replace broken links to her old blog that now point to some kind of spam website.

Note that I didn't go through other posts that might have the same issues!