### PR TITLE
style: wrap text code to prevent content overflow-x

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -163,6 +163,11 @@ div.brand {
     color: black;
     background-color: rgba($gray, 0.05);
     border: 1px solid rgba($gray, 0.25);
+    white-space: pre-wrap;
+  }
+
+  pre code {
+    white-space: inherit;
   }
 
   a.anchor::before {


### PR DESCRIPTION
## Description

While I was reading the [announcement](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html) of Rust 1.78 on my mobile device, I noticed the page `overflow-x` was "broken".

## Changes

This PR resolves the UI glitch by setting `white-space: pre-wrap` for the blocks of code that aren't displayed within a preformatted element.

## Screenshots

<img width="1536" alt="Capture d’écran 2024-05-02 à 16 20 07" src="https://github.com/rust-lang/blog.rust-lang.org/assets/16886711/08ca79ce-8019-4b5b-bbaa-1269aeb4da72">
<img width="1536" alt="Capture d’écran 2024-05-02 à 16 21 19" src="https://github.com/rust-lang/blog.rust-lang.org/assets/16886711/04313067-b859-419e-9816-c359e323a76f">
<img width="1536" alt="Capture d’écran 2024-05-02 à 16 20 49" src="https://github.com/rust-lang/blog.rust-lang.org/assets/16886711/ecb685fb-6931-4238-9fa6-516e754032ba">
<img width="1536" alt="Capture d’écran 2024-05-02 à 16 20 26" src="https://github.com/rust-lang/blog.rust-lang.org/assets/16886711/51e5b6e8-16eb-4a23-b1ec-c81482c3e46f">
