### PR TITLE
Fix `diagnostic` attribute link.

### DIFF
--- a/posts/2024-05-02-Rust-1.78.0.md
+++ b/posts/2024-05-02-Rust-1.78.0.md
@@ -80,7 +80,7 @@ For trait authors, this kind of diagnostic is more useful if you can provide a b
 pub trait Sized {}
 ```
 
-For more information, see the reference section on [the `diagnostic` tool attribute namespace](https://doc.rust-lang.org/stable/reference/attributes/diagnostics.html#the-diagnostic-tool-attribute-namespace).
+For more information, see the reference section on [the `diagnostic` tool attribute namespace](https://doc.rust-lang.org/nightly/reference/attributes/diagnostics.html#the-diagnostic-tool-attribute-namespace).
 
 ### Asserting `unsafe` preconditions
 


### PR DESCRIPTION
The reference documentation for the `diagnostic` attribute was not merged in time for the 1.78 release. This fixes the link to use nightly instead.
