### PR TITLE
Update check-cfg blog post with recent Cargo change

### DIFF
--- a/posts/2024-05-06-check-cfg.md
+++ b/posts/2024-05-06-check-cfg.md
@@ -52,13 +52,15 @@ fn win() {}
 
 ![cargo-check](../../../../images/2024-05-06-check-cfg/cargo-check.svg)
 
-## Expecting static cfgs
+## Expecting custom cfgs
 
 *UPDATE: This section was added with the release of nightly-2024-05-19.*
 
-Some crates might use cfgs, like `loom`, `fuzzing` which are always statically known at compile time. For those cases, Cargo provides via the `[lints]` table a way to statically declare those cfgs as expected.
+> In Cargo point-of-view: a custom cfg is one that is neither defined by `rustc` nor by a Cargo feature. Think of `tokio_unstable`, `has_foo`, ... but not `feature = "lasers"`, `unix` or `debug_assertions`
 
-It is done through the special `check-cfg` config under `[lints.rust.unexpected_cfgs]`:
+Some crates might use custom cfgs, like `loom`, `fuzzing` or `tokio_unstable` that they expected from the environment (`RUSTFLAGS` or other means) and which are always statically known at compile time. For those cases, Cargo provides via the `[lints]` table a way to statically declare those cfgs as expected.
+
+Defining those custom cfgs as expected is done through the special `check-cfg` config under `[lints.rust.unexpected_cfgs]`:
 
 *`Cargo.toml`*
 ```toml
@@ -66,11 +68,9 @@ It is done through the special `check-cfg` config under `[lints.rust.unexpected_
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(fuzzing)'] }
 ```
 
-## Custom cfgs and build scripts
+## Custom cfgs in build scripts
 
-> In Cargo point-of-view: a custom cfg is one that is neither defined by `rustc` nor by a Cargo feature. Think of `tokio_unstable`, `has_foo`, ... but not `feature = "lasers"`, `unix` or `debug_assertions`
-
-Some crates use custom cfgs that they either expected from the environment (`RUSTFLAGS`or other means) or is enabled by some logic in the crate `build.rs`. For those crates Cargo provides a new instruction: [`cargo::rustc-check-cfg`](https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg)[^2] (or `cargo:rustc-check-cfg` for older Cargo version).
+On the other hand some crates use custom cfgs that are enabled by some logic in the crate `build.rs`. For those crates Cargo provides a new instruction: [`cargo::rustc-check-cfg`](https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg)[^2] (or `cargo:rustc-check-cfg` for older Cargo version).
 
 [^2]: `cargo::rustc-check-cfg` will start working in Rust 1.80 (or nightly-2024-05-05). From Rust 1.77 to Rust 1.79 *(inclusive)* it is silently ignored. In Rust 1.76 and below a warning is emitted when used without the unstable Cargo flag `-Zcheck-cfg`.
 

--- a/posts/2024-05-06-check-cfg.md
+++ b/posts/2024-05-06-check-cfg.md
@@ -52,6 +52,20 @@ fn win() {}
 
 ![cargo-check](../../../../images/2024-05-06-check-cfg/cargo-check.svg)
 
+## Expecting static cfgs
+
+*UPDATE: This section was added with the release of nightly-2024-05-19.*
+
+Some crates might use cfgs, like `loom`, `fuzzing` which are always statically known at compile time. For those cases, Cargo provides via the `[lints]` table a way to statically declare those cfgs as expected.
+
+It is done through the special `check-cfg` config under `[lints.rust.unexpected_cfgs]`:
+
+*`Cargo.toml`*
+```toml
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(fuzzing)'] }
+```
+
 ## Custom cfgs and build scripts
 
 > In Cargo point-of-view: a custom cfg is one that is neither defined by `rustc` nor by a Cargo feature. Think of `tokio_unstable`, `has_foo`, ... but not `feature = "lasers"`, `unix` or `debug_assertions`
@@ -115,9 +129,11 @@ This means that doing `RUSTFLAGS="--cfg tokio_unstable" cargo check` will not re
 
 ### How to expect custom cfgs without a `build.rs`?
 
-There is **currently no way** to expect a custom cfg other than with `cargo::rustc-check-cfg` in a `build.rs`.
+*UPDATE: Cargo with nightly-2024-05-19 now provides the `[lints.rust.unexpected_cfgs.check-cfg]` config to address the statically known custom cfgs.*
 
-Crate authors that don't want to use a `build.rs` are encouraged to use Cargo features instead.
+~~There is **currently no way** to expect a custom cfg other than with `cargo::rustc-check-cfg` in a `build.rs`.~~
+
+Crate authors that don't want to use a `build.rs` and cannot use `[lints.rust.unexpected_cfgs.check-cfg]`, are encouraged to use Cargo features instead.
 
 ### How does it interact with other build systems?
 

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -73,6 +73,7 @@ impl Post {
                 .build()?,
             extension: comrak::ExtensionOptionsBuilder::default()
                 .header_ids(Some(String::new()))
+                .strikethrough(true)
                 .footnotes(true)
                 .table(true)
                 .build()?,


### PR DESCRIPTION
With recent Cargo change, namely https://github.com/rust-lang/cargo/pull/13913, some part of the blog are no longer true/accurate, this PR therefor update some sections to reflect the recent changes.

cc @epage
r? @ehuss