### PR TITLE
Add EWG Survey announcement post

### DIFF
--- a/posts/inside-rust/2024-08-22-embedded-wg-micro-survey.md
+++ b/posts/inside-rust/2024-08-22-embedded-wg-micro-survey.md
@@ -5,13 +5,13 @@ author: James Munns
 team: Embedded Devices Working Group <https://www.rust-lang.org/governance/wgs/embedded>
 ---
 
-The [Embedded devices working group] has launched the [2024 Community Micro Survey] starting
+The [Embedded devices working group] has launched the [2024 Embedded Community Micro Survey] starting
 today, and running until **September 19th, 2024**.
 
-**You can take the survey now by [clicking here][2024 Community Micro Survey].**
+**You can take the survey now by [clicking here][2024 Embedded Community Micro Survey].**
 
 [Embedded devices working group]: https://www.rust-lang.org/governance/wgs/embedded
-[2024 Community Micro Survey]: https://www.surveyhero.com/c/uenp3ydt
+[2024 Embedded Community Micro Survey]: https://www.surveyhero.com/c/uenp3ydt
 
 This survey is aimed at gathering information about the community of users who use the Rust Programming Language
 for Embedded Systems, including on microcontrollers. It is being run as a [Micro Survey], run by the same
@@ -24,7 +24,7 @@ We invite you to take this survey even if you have only just begun with Rust on 
 or have only experimented with it informally. Your responses will help us gather data over time towards
 the adoption of Rust for these systems.
 
-Please help us spread the word by sharing the [survey link][2024 Community Micro Survey] via your social networks,
+Please help us spread the word by sharing the [survey link][2024 Embedded Community Micro Survey] via your social networks,
 at meetups, with colleagues, and in any other community that makes sense to you.
 
 This survey would not be possible without the time, resources, and attention of members of the Survey Team,

--- a/posts/inside-rust/2024-08-22-embedded-wg-micro-survey.md
+++ b/posts/inside-rust/2024-08-22-embedded-wg-micro-survey.md
@@ -27,7 +27,7 @@ the adoption of Rust for these systems.
 Please help us spread the word by sharing the [survey link][2024 Community Micro Survey] via your social networks,
 at meetups, with colleagues, and in any other community that makes sense to you.
 
-This survey would not be possible without the time, resources, and attention of members of the Survey Working Group,
+This survey would not be possible without the time, resources, and attention of members of the Survey Team,
 the Embedded Working Group, the Rust Foundation, and other collaborators. Thank you!
 
 We appreciate your participation!

--- a/posts/inside-rust/2024-08-22-embedded-wg-micro-survey.md
+++ b/posts/inside-rust/2024-08-22-embedded-wg-micro-survey.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: "Embedded Working Group Community Micro Survey"
+author: James Munns
+team: Embedded Devices Working Group <https://www.rust-lang.org/governance/wgs/embedded>
+---
+
+The [Embedded devices working group] has launched the [2024 Community Micro Survey] starting
+today, and running until **September 19th, 2024**.
+
+**You can take the survey now by [clicking here][2024 Community Micro Survey].**
+
+[Embedded devices working group]: https://www.rust-lang.org/governance/wgs/embedded
+[2024 Community Micro Survey]: https://www.surveyhero.com/c/uenp3ydt
+
+This survey is aimed at gathering information about the community of users who use the Rust Programming Language
+for Embedded Systems, including on microcontrollers. It is being run as a [Micro Survey], run by the same
+Rust Survey Team responsible for the [Annual Rust Survey]. The survey is only offered in the English language.
+
+[Micro Survey]: https://github.com/rust-lang/surveys/blob/main/micro-surveys.md
+[Annual Rust Survey]: https://blog.rust-lang.org/2024/02/19/2023-Rust-Annual-Survey-2023-results.html
+
+We invite you to take this survey even if you have only just begun with Rust on Embedded Systems,
+or have only experimented with it informally. Your responses will help us gather data over time towards
+the adoption of Rust for these systems.
+
+Please help us spread the word by sharing the [survey link][2024 Community Micro Survey] via your social networks,
+at meetups, with colleagues, and in any other community that makes sense to you.
+
+This survey would not be possible without the time, resources, and attention of members of the Survey Working Group,
+the Embedded Working Group, the Rust Foundation, and other collaborators. Thank you!
+
+We appreciate your participation!


### PR DESCRIPTION
This adds an Inside Rust blog post from the Embedded Working Group announcing our 2024 user micro survey, run by the Survey team.

It borrows some language from previous annual survey posts.

CC @Kobzol 