### PR TITLE
Add post for 2024 project director elections

### DIFF
--- a/posts/inside-rust/2024-09-04-electing-new-project-directors.md
+++ b/posts/inside-rust/2024-09-04-electing-new-project-directors.md
@@ -1,17 +1,17 @@
 ---
 layout: post
-title: "Electing New Project Directors"
+title: "Electing New Project Directors 2024"
 author: Leadership Council
 team: Leadership Council <https://www.rust-lang.org/governance/teams/leadership-council>
 ---
 
-Today we are launching the process to elect new Project Directors to the Rust Foundation Board of Directors.
-As we begin the process, we wanted to spend some time explaining the goals and procedures we will follow.
-We will summarize everything here, but if you would like to you can read the [official process documentation][pde-process].
+Today we are launching the process to elect two Project Directors to the Rust Foundation Board of Directors. This is the second time we have done this - [here](https://blog.rust-lang.org/2023/08/30/electing-new-project-directors.html) is the blog post from last year.
 
-We ask all project members to begin working with their Leadership Council representative to nominate potential Project Directors. See the [Candidate Gathering](#candidate-gathering) section for more details. Nominations are due by September 15, 2023.
+We will briefly explain the goals and procedures here, but this is mostly copy-pasted from [last year's post](https://blog.rust-lang.org/2023/08/30/electing-new-project-directors.html) and the [official process documentation][pde-process].
 
-[pde-process]: https://github.com/rust-lang/leadership-council/blob/main/policies/project-director-election-process.md
+We ask all project members to begin working with their Leadership Council representative to nominate potential Project Directors. See the [Candidate Gathering](#candidate-gathering) section for more details. Nominations are due by October 9, 2024.
+
+[pde-process]: https://github.com/rust-lang/leadership-council/blob/main/policies/project-directorship/election-process.md
 
 ## What are Project Directors?
 
@@ -19,15 +19,18 @@ The Rust Foundation Board of Directors has five seats reserved for Project Direc
 These Project Directors serve as representatives of the Rust project itself on the Board.
 Like all Directors, the Project Directors are elected by the entity they represent, which in the case of the Rust Project means they are elected by the Rust Leadership Council.
 Project Directors serve for a term of two years and will have staggered terms.
-This year we will appoint two new directors and next year we will appoint three new directors.
+This year we will appoint two directors and next year we will appoint three directors.
 
-The current project directors are Jane Losare-Lusby, Josh Stone, Mark Rousskov, Ryan Levick and Tyler Mandry.
-This year, Jane Losare-Lusby and Josh Stone will be rotating out of their roles as Project Directors, so the current elections are to fill their seats.
-We are grateful for the work the Jane and Josh have put in during their terms as Project Directors!
+See the [Role Description] document for more details about what is involved in being a Director.
+
+The current project directors are Mark Rousskov, Ryan Levick, Santiago Pastorino, Scott McMurray, and Jakob Degen.
+This year, Mark Rousskov and Ryan Levick's seats are open for election.
 
 We want to make sure the Project Directors can effectively represent the project as a whole, so we are soliciting input from the whole project.
 The elections process will go through two phases: Candidate Gathering and Election.
 Read on for more detail about how these work.
+
+[Role Description]: https://github.com/rust-lang/leadership-council/blob/main/roles/rust-foundation-project-director.md
 
 ## Candidate Gathering
 
@@ -40,19 +43,19 @@ Each team is encouraged to suggest candidates.
 Since we are electing two new directors, it would be ideal for teams to nominate at least two candidates.
 Nominees can be anyone in the project and do not have to be a member of the team who nominates them.
 
-The candidate gathering process will be open until September 15, at which point each team's Council Representative will share their team's nominations and reasoning with the whole Leadership Council.
+The candidate gathering process will be open until October 9, at which point each team's Council Representative will share their team's nominations and reasoning with the whole Leadership Council.
 At this point, the Council will confirm with each of the nominees that they are willing to accept the nomination and fill the role of Project Director.
 Then the Council will publish the set of candidates.
 
 This then starts a ten day period where members of the Rust Project are invited to share feedback on the nominees with the Council.
 This feedback can include reasons why a nominee would make a good project director, or concerns the Council should be aware of.
 
-The Council will announce the set of nominees by September 19 and the ten day feedback period will last until September 29.
+The Council will announce the set of nominees by October 11 and the ten day feedback period will last until October 21.
 Once this time has passed, we will move on to the election phase.
 
 ## Election
 
-The Council will meet during the week of October 1 to complete the election process.
+The Council will meet during the week of October 21 to complete the election process.
 In this meeting we will discuss each candidate and once we have done this the facilitator will propose a set of two of them to be the new Project Directors.
 The facilitator puts this to a vote, and if the Council unanimously agrees with the proposed pair of candidates then the process is completed.
 Otherwise, we will give another opportunity for council members to express their objections and we will continue with another proposal.
@@ -67,14 +70,13 @@ In addition, we will contact each of the nominees, including those who were not 
 This process will continue through all of September and into October.
 Below are the key dates:
 
-* Candidate nominations due: September 15
-* Candidates published: ~~September 19~~ September 22
-* Feedback period: ~~September 19 - 29~~ September 22 - October 2
-* Election meeting: Week of October 1
+* Candidate nominations due: October 9
+* Candidates published: October 11
+* Feedback period: October 11 - October 21
+* Election meeting: Week of October 21
+* First board meeting starting the new term: November 12
 
 After the election meeting happens, the Rust Leadership Council will announce the results and the new Project Directors will assume their responsibilities.
-
-*Edit: we have adjusted the candidate publication date due to delays in getting all the nominees ready.*
 
 ## Acknowledgements
 

--- a/posts/inside-rust/2024-09-04-electing-new-project-directors.md
+++ b/posts/inside-rust/2024-09-04-electing-new-project-directors.md
@@ -1,0 +1,84 @@
+---
+layout: post
+title: "Electing New Project Directors"
+author: Leadership Council
+team: Leadership Council <https://www.rust-lang.org/governance/teams/leadership-council>
+---
+
+Today we are launching the process to elect new Project Directors to the Rust Foundation Board of Directors.
+As we begin the process, we wanted to spend some time explaining the goals and procedures we will follow.
+We will summarize everything here, but if you would like to you can read the [official process documentation][pde-process].
+
+We ask all project members to begin working with their Leadership Council representative to nominate potential Project Directors. See the [Candidate Gathering](#candidate-gathering) section for more details. Nominations are due by September 15, 2023.
+
+[pde-process]: https://github.com/rust-lang/leadership-council/blob/main/policies/project-director-election-process.md
+
+## What are Project Directors?
+
+The Rust Foundation Board of Directors has five seats reserved for Project Directors.
+These Project Directors serve as representatives of the Rust project itself on the Board.
+Like all Directors, the Project Directors are elected by the entity they represent, which in the case of the Rust Project means they are elected by the Rust Leadership Council.
+Project Directors serve for a term of two years and will have staggered terms.
+This year we will appoint two new directors and next year we will appoint three new directors.
+
+The current project directors are Jane Losare-Lusby, Josh Stone, Mark Rousskov, Ryan Levick and Tyler Mandry.
+This year, Jane Losare-Lusby and Josh Stone will be rotating out of their roles as Project Directors, so the current elections are to fill their seats.
+We are grateful for the work the Jane and Josh have put in during their terms as Project Directors!
+
+We want to make sure the Project Directors can effectively represent the project as a whole, so we are soliciting input from the whole project.
+The elections process will go through two phases: Candidate Gathering and Election.
+Read on for more detail about how these work.
+
+## Candidate Gathering
+
+The first phase is beginning right now.
+In this phase, we are inviting the members of all of the top level Rust teams and their subteams to nominate people who will make good project directors.
+The goal is to bubble these up to the Council through each of the top-level teams.
+You should be hearing from your Council Representative soon with more details, but if not, feel free to reach out to them directly.
+
+Each team is encouraged to suggest candidates.
+Since we are electing two new directors, it would be ideal for teams to nominate at least two candidates.
+Nominees can be anyone in the project and do not have to be a member of the team who nominates them.
+
+The candidate gathering process will be open until September 15, at which point each team's Council Representative will share their team's nominations and reasoning with the whole Leadership Council.
+At this point, the Council will confirm with each of the nominees that they are willing to accept the nomination and fill the role of Project Director.
+Then the Council will publish the set of candidates.
+
+This then starts a ten day period where members of the Rust Project are invited to share feedback on the nominees with the Council.
+This feedback can include reasons why a nominee would make a good project director, or concerns the Council should be aware of.
+
+The Council will announce the set of nominees by September 19 and the ten day feedback period will last until September 29.
+Once this time has passed, we will move on to the election phase.
+
+## Election
+
+The Council will meet during the week of October 1 to complete the election process.
+In this meeting we will discuss each candidate and once we have done this the facilitator will propose a set of two of them to be the new Project Directors.
+The facilitator puts this to a vote, and if the Council unanimously agrees with the proposed pair of candidates then the process is completed.
+Otherwise, we will give another opportunity for council members to express their objections and we will continue with another proposal.
+This process repeats until we find two nominees who the Council can unanimously consent to.
+The Council will then confirm these nominees through an official vote.
+
+Once this is done, we will announce the new Project Directors.
+In addition, we will contact each of the nominees, including those who were not elected, to tell them a little bit more about what we saw as their strengths and opportunities for growth to help them serve better in similar roles in the future.
+
+## Timeline
+
+This process will continue through all of September and into October.
+Below are the key dates:
+
+* Candidate nominations due: September 15
+* Candidates published: ~~September 19~~ September 22
+* Feedback period: ~~September 19 - 29~~ September 22 - October 2
+* Election meeting: Week of October 1
+
+After the election meeting happens, the Rust Leadership Council will announce the results and the new Project Directors will assume their responsibilities.
+
+*Edit: we have adjusted the candidate publication date due to delays in getting all the nominees ready.*
+
+## Acknowledgements
+
+A number of people have been involved in designing and launching this election process and we wish to extend a heartfelt thanks to all of them!
+We'd especially like to thank the members of the Project Director Election Proposal Committee: Jane Losare-Lusby, Eric Holk, and Ryan Levick.
+Additionally, many members of the Rust Community have provided feedback and thoughtful discussions that led to significant improvements to the process.
+We are grateful for all of your contributions.


### PR DESCRIPTION
This is post-dated for Wednesday (2024-09-04) to give a little time for feedback. I *think* the proposed timeline makes sense, but could use a little scrutiny.

This is structured as two commits if you want to see a diff between last year's post.
