### PR TITLE
Small typo on the i128 blog

### DIFF
--- a/posts/2024-03-30-i128-layout-update.md
+++ b/posts/2024-03-30-i128-layout-update.md
@@ -180,8 +180,8 @@ int main() {
         /* load arguments that fit in registers */
         "movl    $0xaf, %edi \n\t"                /* 1st slot (edi): padding char (`edi` is the
                                                    * same as `rdi`, just a smaller access size) */
-        "movq    $0x9900aabbccddeeff, %rsi \n\t"  /* 2rd slot (rsi): lower half of `a` */
-        "movq    $0x1122334455667788, %rdx \n\t"  /* 3nd slot (rdx): upper half of `a` */
+        "movq    $0x9900aabbccddeeff, %rsi \n\t"  /* 2nd slot (rsi): lower half of `a` */
+        "movq    $0x1122334455667788, %rdx \n\t"  /* 3rd slot (rdx): upper half of `a` */
         "movq    $0x9900aabbccddeeff, %rcx \n\t"  /* 4th slot (rcx): lower half of `b` */
         "movq    $0x1122334455667788, %r8  \n\t"  /* 5th slot (r8):  upper half of `b` */
         "movq    $0xdeadbeef4c0ffee0, %r9  \n\t"  /* 6th slot (r9):  should be unused, but


### PR DESCRIPTION
Saw this linked somewhere recently and noticed another minor typo. Fix it here.