### PR TITLE
fix link to `PanicHookInfo`

### DIFF
--- a/posts/2024-09-05-Rust-1.81.0.md
+++ b/posts/2024-09-05-Rust-1.81.0.md
@@ -132,7 +132,7 @@ these types allows us to add more useful methods to these types, such as
 [`core::panic::PanicInfo::message()`](https://doc.rust-lang.org/stable/core/panic/struct.PanicInfo.html#method.message).
 
 [`std::panic::PanicInfo`]: https://doc.rust-lang.org/stable/std/panic/type.PanicInfo.html
-[`std::panic::PanicHookInfo`]: https://doc.rust-lang.org/stable/std/panic/type.PanicHookInfo.html
+[`std::panic::PanicHookInfo`]: https://doc.rust-lang.org/stable/std/panic/struct.PanicHookInfo.html
 
 #### Abort on uncaught panics in `extern "C"` functions
 


### PR DESCRIPTION
The old link goes to a 404 page.