### PR TITLE
Fix grammar in 1.81.0 release

### DIFF
--- a/posts/2024-09-05-Rust-1.81.0.md
+++ b/posts/2024-09-05-Rust-1.81.0.md
@@ -45,7 +45,7 @@ requirements documented in [PartialOrd] and [Ord].
 ### `#[expect(lint)]`
 
 1.81 stabilizes a new lint level, `expect`, which allows explicitly noting that
-a particular lint *should* occur, and warning if it doesn't.  The intended use
+a particular lint *should* occur, and warn if it doesn't.  The intended use
 case for this is temporarily silencing a lint, whether due to lint
 implementation bugs or ongoing refactoring, while wanting to know when the lint
 is no longer required.


### PR DESCRIPTION
This sentence is on the whole a bit weird as it’s not clear what the subject of "warn if it doesn't" is, but I think this conjugation makes more sense overall