### PR TITLE
Add September 2024 council representative selections

### DIFF
--- a/posts/inside-rust/2024-09-27-leadership-council-repr-selection.md
+++ b/posts/inside-rust/2024-09-27-leadership-council-repr-selection.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: "Leadership Council September 2024 Representative Selections"
+author: Eric Huss
+team: Leadership Council <https://www.rust-lang.org/governance/teams/leadership-council>
+---
+
+The September 2024 selections for [Leadership Council] representatives have been finalized. The lang team has chosen [TC] as their new representative, and the moderation team has chosen [Oliver Scherer]. Oli is currently on leave, so the current representative [Josh Gould] will substitute until he returns. Thank you to the outgoing representatives [Jack Huey] and [Josh Gould] for your amazing support on the Council.
+
+The representatives chosen this round are:
+
+* [Infra] — [Mark Rousskov]
+* [Lang] — [TC]
+* [Libs] — [Mara Bos]
+* [Mods] — [Oliver Scherer]
+
+[Leadership Council]: https://www.rust-lang.org/governance/teams/leadership-council
+[Infra]: https://www.rust-lang.org/governance/teams/infra
+[Lang]: https://www.rust-lang.org/governance/teams/lang
+[Libs]: https://www.rust-lang.org/governance/teams/library
+[Mods]: https://www.rust-lang.org/governance/teams/moderation
+[Mark Rousskov]: https://github.com/Mark-Simulacrum
+[Jack Huey]: https://github.com/jackh726
+[Mara Bos]: https://github.com/m-ou-se
+[Josh Gould]: https://github.com/technetos
+[TC]: https://github.com/traviscross
+[Oliver Scherer]: https://github.com/oli-obk
+
+Thanks to everyone who participated in the process! The next representative selections will be in March 2025 for the other half of the Council.

--- a/posts/inside-rust/2024-09-27-leadership-council-repr-selection.md
+++ b/posts/inside-rust/2024-09-27-leadership-council-repr-selection.md
@@ -5,7 +5,7 @@ author: Eric Huss
 team: Leadership Council <https://www.rust-lang.org/governance/teams/leadership-council>
 ---
 
-The September 2024 selections for [Leadership Council] representatives have been finalized. The lang team has chosen [TC] as their new representative, and the moderation team has chosen [Oliver Scherer]. Oli is currently on leave, so the current representative [Josh Gould] will substitute until he returns. Thank you to the outgoing representatives [Jack Huey] and [Josh Gould] for your amazing support on the Council.
+The September 2024 selections for [Leadership Council] representatives have been finalized. The Lang Team has chosen [TC] as their new representative, and the Moderation Team has chosen [Oliver Scherer]. Oli is currently on leave, so the current representative, [Josh Gould], will substitute until he returns. Thank you to the outgoing representatives [Jack Huey] and [Josh Gould] for your amazing support on the Council.
 
 The representatives chosen this round are:
 


### PR DESCRIPTION
cc @rust-lang/leadership-council 

[Rendered](https://github.com/ehuss/blog.rust-lang.org/blob/sep-2024-council-selection/posts/inside-rust/2024-09-27-leadership-council-repr-selection.md)