### PR TITLE
Fix missing directives in test example

### DIFF
--- a/posts/inside-rust/2024-11-04-test-infra-oct-2024-2.md
+++ b/posts/inside-rust/2024-11-04-test-infra-oct-2024-2.md
@@ -75,6 +75,10 @@ Example usage:
 ```rs
 // tests/ui/abi/my-abi-test.rs
 
+//@ add-core-stubs
+//@ compile-flags: --target x86_64-pc-windows-msvc
+//@ needs-llvm-components: x86
+
 #![crate_type = "lib"]
 #![feature(no_core)]
 #![no_std]


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/blog.rust-lang.org/pull/1425, it just occurred to me the test example was missing directives, lol.

[Rendered](https://github.com/jieyouxu/blog.rust-lang.org/blob/fix-directive/posts/inside-rust/2024-11-04-test-infra-oct-2024-2.md)