### PR TITLE
posts: Fix typo in 2024-11-07-gsoc-2024-results

### DIFF
--- a/posts/2024-11-07-gsoc-2024-results.md
+++ b/posts/2024-11-07-gsoc-2024-results.md
@@ -168,11 +168,11 @@ Even though this project did not fulfill its original goals and more work will b
 - Mentor: [Oli Scherer](https://github.com/oli-obk)
 - [Final report](https://gist.github.com/tiif/3e08ba6e8cfb1d078e6155410108ae48)
 
-[miri][miri] is an intepreter that can find possible instances of undefined behavior in Rust code. It is being used across the Rust ecosystem, but previously it was not possible to run it on any non-trivial programs (those that ever `await` on anything) that use [tokio][tokio], due a to a fundamental missing feature: support for the `epoll` syscall on Linux (and similar APIs on other major platforms).
+[miri][miri] is an interpreter that can find possible instances of undefined behavior in Rust code. It is being used across the Rust ecosystem, but previously it was not possible to run it on any non-trivial programs (those that ever `await` on anything) that use [tokio][tokio], due a to a fundamental missing feature: support for the `epoll` syscall on Linux (and similar APIs on other major platforms).
 
 Tiffany implemented the basic `epoll` operations needed to cover the majority of the tokio test suite, by crafting pure `libc` code examples that exercised those `epoll` operations, and then implementing their emulation in miri itself. At times, this required refactoring core miri components like file descriptor handling, as they were originally not created with syscalls like `epoll` in mind.
 
-Suprising to everyone (though probably not tokio-internals experts), once these core `epoll` operations were finished, operations like async file reading and writing started working in miri out of the box! Due to limitations of non-blocking file operations offered by operating systems, tokio is wrapping these file operations in dedicated threads, which was already supported by miri.
+Surprising to everyone (though probably not tokio-internals experts), once these core `epoll` operations were finished, operations like async file reading and writing started working in miri out of the box! Due to limitations of non-blocking file operations offered by operating systems, tokio is wrapping these file operations in dedicated threads, which was already supported by miri.
 
 Once Tiffany has finished the project, including stretch goals like implementing async file operations, she proceeded to contact tokio maintainers and worked with them to run miri on most tokio tests in CI. And we have good news: so far no soundness problems have been discovered! Tiffany has become a regular contributor to miri, focusing on continuing to expand the set of supported file descriptor operations. We thank her for all her contributions!
 


### PR DESCRIPTION


[Rendered](https://github.com/yinheli/blog.rust-lang.org/blob/bugfix/typo-posts-2024-11-07-gsoc-2024-results/posts/2024-11-07-gsoc-2024-results.md)