### PR TITLE
Use a link that works for the 1.83 relnotes

### DIFF
--- a/posts/2024-11-28-Rust-1.83.0.md
+++ b/posts/2024-11-28-Rust-1.83.0.md
@@ -13,7 +13,7 @@ If you have a previous version of Rust installed via `rustup`, you can get 1.83.
 $ rustup update stable
 ```
 
-If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.83.0](https://doc.rust-lang.org/nightly/releases.html#version-1830-2024-11-28).
+If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.83.0](https://doc.rust-lang.org/stable/releases.html#version-1830-2024-11-28).
 
 If you'd like to help us out by testing future releases, you might consider updating locally to use the beta channel (`rustup default beta`) or the nightly channel (`rustup default nightly`). Please [report](https://github.com/rust-lang/rust/issues/new/choose) any bugs you might come across!
 


### PR DESCRIPTION
The relnotes PR was merged today before a nightly was cut with it so the link used in the blog post goes nowhere right now.

[Rendered](https://github.com/BoxyUwU/blog.rust-lang.org/blob/1.83.0_stable_relnotes/posts/2024-11-28-Rust-1.83.0.md)