### PR TITLE
Re-tighten up some verbiage

### DIFF
--- a/posts/2024-11-27-Rust-2024-public-testing.md
+++ b/posts/2024-11-27-Rust-2024-public-testing.md
@@ -7,7 +7,7 @@ team: the Edition 2024 Project Group <https://doc.rust-lang.org/nightly/edition-
 
 # Rust 2024 call for testing
 
-We've been hard at work on Rust 2024. We're thrilled about how it has turned out. It's going to be the largest edition since Rust 2015. It has a great many improvements that make the language more consistent and ergonomic, that further improve upon our relentless commitment to safety, and that will open the door to long-awaited features such as `gen` blocks, `let` chains, and the never (`!`) type. For more on the changes, see the nightly [Edition Guide](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html).
+We've been hard at work on Rust 2024. We're thrilled about how it has turned out. It's going to be the largest edition since Rust 2015. It has a great many improvements that make the language more consistent and ergonomic, that further our relentless commitment to safety, and that will open the door to long-awaited features such as `gen` blocks, `let` chains, and the never (`!`) type. For more on the changes, see the nightly [Edition Guide](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html).
 
 As planned, we recently merged the feature-complete Rust 2024 edition [to the release train](https://github.com/rust-lang/rust/pull/133349) for Rust 1.85. It has now entered **nightly beta**[^1].
 


### PR DESCRIPTION
We had said "further upon X".  We really meant "further X".  This was changed to "further improve upon X" instead in PR #1436, but that's a bit odd as the sentence uses "improvements" directly before it.

Let's tighten this up to just say "further X".

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/TC/retighten-verbiage-in-rust-2024-nightly-beta-announcement/posts/2024-11-27-Rust-2024-public-testing.md)

cc @Kobzol