### PR TITLE
Add 2024 Annual Rust survey announcement blog post

### DIFF
--- a/posts/2024-12-03-annual-survey-2024-launch.md
+++ b/posts/2024-12-03-annual-survey-2024-launch.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: "Launching the 2024 State of Rust Survey"
+author: The Rust Survey Working Group
+description: "Share your experience using Rust in the ninth edition of the State of Rust Survey"
+---
+
+It’s time for the [2024 State of Rust Survey][survey-link]!
+
+Since 2016, the Rust Project has collected valuable information and feedback from the Rust programming language community through our annual [State of Rust Survey][survey-link]. This tool allows us to more deeply understand how the Rust Project is performing, how we can better serve the global Rust community, and who our community is composed of.
+
+Like last year, the [2024 State of Rust Survey][survey-link] will likely take you between 10 and 25 minutes, and responses are anonymous. We will accept submissions until Sunday, December 22nd, 2024. Trends and key insights will be shared on [blog.rust-lang.org](https://blog.rust-lang.org) as soon as possible.
+
+We invite you to take this year’s survey whether you have just begun using Rust, you consider yourself an intermediate to advanced user, or you have not yet used Rust but intend to one day. Your responses will help us improve Rust over time by shedding light on gaps to fill in the community and development priorities, and more.
+
+**Once again, we are offering the State of Rust Survey in the following languages (if you speak multiple languages, please pick one). Language options are available on the [main survey page][survey-link]:**
+- English
+- Simplified Chinese
+- French
+- German
+- Japanese
+- Russian
+- Spanish
+
+> Note: the non-English translations of the survey are provided in a best-effort manner. If you find any issues with the
+> translations, we would be glad if you could send us a [pull request](https://github.com/rust-lang/surveys/tree/main/surveys/2024-annual-survey/translations) to improve the quality of the translations!
+
+Please help us spread the word by sharing the [survey link][survey-link] via your social media networks, at meetups, with colleagues, and in any other community that makes sense to you.
+
+This survey would not be possible without the time, resources, and attention of members of the Survey Working Group, the Rust Foundation, and other collaborators. Thank you!
+
+If you have any questions, please see our [frequently asked questions](https://github.com/rust-lang/surveys/blob/main/documents/Community-Survey-FAQ.md).
+
+We appreciate your participation!
+
+_Click [here][last-survey-link] to read a summary of last year's survey findings._
+
+[survey-link]: TODO
+[last-survey-link]: https://blog.rust-lang.org/2024/02/19/2023-Rust-Annual-Survey-2023-results.html

--- a/posts/2024-12-05-annual-survey-2024-launch.md
+++ b/posts/2024-12-05-annual-survey-2024-launch.md
@@ -9,7 +9,7 @@ It’s time for the [2024 State of Rust Survey][survey-link]!
 
 Since 2016, the Rust Project has collected valuable information and feedback from the Rust programming language community through our annual [State of Rust Survey][survey-link]. This tool allows us to more deeply understand how the Rust Project is performing, how we can better serve the global Rust community, and who our community is composed of.
 
-Like last year, the [2024 State of Rust Survey][survey-link] will likely take you between 10 and 25 minutes, and responses are anonymous. We will accept submissions until Sunday, December 22nd, 2024. Trends and key insights will be shared on [blog.rust-lang.org](https://blog.rust-lang.org) as soon as possible.
+Like last year, the [2024 State of Rust Survey][survey-link] will likely take you between 10 and 25 minutes, and responses are anonymous. We will accept submissions until Monday, December 23rd, 2024. Trends and key insights will be shared on [blog.rust-lang.org](https://blog.rust-lang.org) as soon as possible.
 
 We invite you to take this year’s survey whether you have just begun using Rust, you consider yourself an intermediate to advanced user, or you have not yet used Rust but intend to one day. Your responses will help us improve Rust over time by shedding light on gaps to fill in the community and development priorities, and more.
 
@@ -35,5 +35,5 @@ We appreciate your participation!
 
 _Click [here][last-survey-link] to read a summary of last year's survey findings._
 
-[survey-link]: TODO
+[survey-link]: https://www.surveyhero.com/c/rust-annual-survey-2024
 [last-survey-link]: https://blog.rust-lang.org/2024/02/19/2023-Rust-Annual-Survey-2023-results.html

--- a/posts/2024-12-05-annual-survey-2024-launch.md
+++ b/posts/2024-12-05-annual-survey-2024-launch.md
@@ -27,7 +27,20 @@ We invite you to take this year’s survey whether you have just begun using Rus
 
 Please help us spread the word by sharing the [survey link][survey-link] via your social media networks, at meetups, with colleagues, and in any other community that makes sense to you.
 
-This survey would not be possible without the time, resources, and attention of members of the Survey Working Group, the Rust Foundation, and other collaborators. Thank you!
+This survey would not be possible without the time, resources, and attention of members of the Survey Working Group, the Rust Foundation, and other collaborators. We would also like to thank the following contributors who helped with translating the survey (in no particular order):
+
+- @albertlarsan68
+- @GuillaumeGomez
+- @Urgau
+- @Jieyou Xu
+- @llogiq
+- @avrong
+- @YohDeadfall
+- @tanakakz
+- @ZuseZ4
+- @igaray
+
+Thank you!
 
 If you have any questions, please see our [frequently asked questions](https://github.com/rust-lang/surveys/blob/main/documents/Community-Survey-FAQ.md).
 


### PR DESCRIPTION
This PR adds a blog post that announces this year's edition of the Annual Rust Survey.

The only main change from [last year's blog post](https://blog.rust-lang.org/2023/12/18/survey-launch.html) is the note about community translations.

[Rendered](https://github.com/Kobzol/blog.rust-lang.org/blob/annual-survey-2024-announcement/posts/2024-12-05-annual-survey-2024-launch.md)