### PR TITLE
Avoid theme flicker on reload in dark mode

### DIFF
--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -44,4 +44,3 @@
 
 <!-- scripts -->
 <script src="{{root}}scripts/highlight.js"></script>
-<script src="{{root}}scripts/theme-switch.js"></script>

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -19,5 +19,6 @@
         <li class="theme-item" onclick="changeThemeTo('dark');">Dark</li>
       </ul>
     </button>
+    <script src="{{root}}scripts/theme-switch.js"></script>
   </ul>
 </nav>


### PR DESCRIPTION
By loading the theme-switch earlier the nav bar background no longer flickers from bright to dark.

Steps to reproduce:
1. Switch to dark mode
2. Reload page (a couple of times)