### PR TITLE
Use rustbot config to configure rendered links

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,4 @@
 [assign]
+
+[rendered-link]
+trigger-files = ["posts/"]


### PR DESCRIPTION
This PR adds the new config related to the rendered links.

cc https://github.com/rust-lang/triagebot/pull/1868
cc @ehuss