### PR TITLE
Update serde_yaml to 0.9.34-deprecated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34-deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "d4f17ab28832fcb8e88a0e938aaa915b4f4618142bd011d4e6a3060028974c47"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ handlebars = { version = "=6.3.0", features = ["dir_source"] }
 lazy_static = "=1.5.0"
 serde = "=1.0.217"
 serde_derive = "=1.0.217"
-serde_yaml = "=0.9.33"
 serde_json = "=1.0.138"
+serde_yaml = "=0.9.34-deprecated"
 comrak = { version = "=0.35.0", features = ["bon"] }
 rayon = "=1.10.0"
 regex = "=1.11.1"


### PR DESCRIPTION
The renovate bot is having trouble with the `-deprecated` marker:
https://github.com/rust-lang/blog.rust-lang.org/pull/1286