### PR TITLE
Update cargo's changelog location

### DIFF
--- a/posts/2019-05-23-Rust-1.35.0.md
+++ b/posts/2019-05-23-Rust-1.35.0.md
@@ -279,7 +279,7 @@ See the [detailed release notes for Clippy][relnotes-clippy] for more details.
 ### Changes in Cargo
 
 [relnotes-cargo]:
-https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-135-2019-05-23
+https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-135-2019-05-23
 
 See the [detailed release notes for Cargo][relnotes-cargo] for more details.
 

--- a/posts/2019-07-04-Rust-1.36.0.md
+++ b/posts/2019-07-04-Rust-1.36.0.md
@@ -148,7 +148,7 @@ the implementation in `std` still defaults to the SipHash 1-3 hashing algorithm.
 [`--offline`]: https://doc.rust-lang.org/cargo/commands/cargo-build.html#cargo_build_manifest_options
 [`cargo fetch`]: https://doc.rust-lang.org/cargo/commands/cargo-fetch.html
 [nrc-blog]: https://www.ncameron.org/blog/cargo-offline/
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-136-2019-07-04
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-136-2019-07-04
 
 During most builds, Cargo doesn't interact with the network.
 Sometimes, however, Cargo has to.

--- a/posts/2019-08-15-Rust-1.37.0.md
+++ b/posts/2019-08-15-Rust-1.37.0.md
@@ -158,7 +158,7 @@ In Rust 1.37.0 there have been a number of standard library stabilizations:
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-137-2019-08-15
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-137-2019-08-15
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-137
 
 There are other changes in the Rust 1.37 release: check out what changed in [Rust][notes], [Cargo][relnotes-cargo], and [Clippy][relnotes-clippy].

--- a/posts/2019-09-26-Rust-1.38.0.md
+++ b/posts/2019-09-26-Rust-1.38.0.md
@@ -125,7 +125,7 @@ Additionally, these functions have been stabilized:
 ### Other changes
 
 [relnotes-rust]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1380-2019-09-26
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-138-2019-09-26
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-138-2019-09-26
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-138
 
 There are other changes in the Rust 1.38 release: check out what changed in [Rust][relnotes-rust], [Cargo][relnotes-cargo], and [Clippy][relnotes-clippy].

--- a/posts/2019-11-07-Rust-1.39.0.md
+++ b/posts/2019-11-07-Rust-1.39.0.md
@@ -157,7 +157,7 @@ In Rust 1.39.0 the following functions were stabilized:
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-139-2019-11-07
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-139-2019-11-07
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-139
 [compat-notes]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#compatibility-notes
 

--- a/posts/2019-12-19-Rust-1.40.0.md
+++ b/posts/2019-12-19-Rust-1.40.0.md
@@ -238,7 +238,7 @@ In Rust 1.40.0 the following functions and macros were stabilized:
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-140-2019-12-19
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-140-2019-12-19
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-140
 [compat-notes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes
 

--- a/posts/2020-01-30-Rust-1.41.0.md
+++ b/posts/2020-01-30-Rust-1.41.0.md
@@ -197,7 +197,7 @@ Rust 1.42.0, these targets will be demoted to the lowest support tier.
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-141-2020-01-30
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-141-2020-01-30
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-141
 [mir-opt]: https://blog.rust-lang.org/inside-rust/2019/12/02/const-prop-on-by-default.html
 

--- a/posts/2020-03-12-Rust-1.42.md
+++ b/posts/2020-03-12-Rust-1.42.md
@@ -168,7 +168,7 @@ In this release, if you are using Cargo, [you no longer need this line when work
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-142-2020-03-12
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-142-2020-03-12
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-142
 
 There are other changes in the Rust 1.42.0 release: check out what changed in [Rust][notes], [Cargo][relnotes-cargo], and [Clippy][relnotes-clippy].

--- a/posts/2020-04-23-Rust-1.43.0.md
+++ b/posts/2020-04-23-Rust-1.43.0.md
@@ -116,7 +116,7 @@ Additionally, we stabilized six new APIs:
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-143-2020-04-23
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-143-2020-04-23
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-143
 
 There are other changes in the Rust 1.43.0 release: check out what changed in

--- a/posts/2020-07-16-Rust-1.45.0.md
+++ b/posts/2020-07-16-Rust-1.45.0.md
@@ -275,7 +275,7 @@ There are other changes in the Rust 1.45.0 release: check out what changed in
 Many people came together to create Rust 1.45.0. We couldn't have done it
 without all of you. [Thanks!](https://thanks.rust-lang.org/rust/1.45.0/)
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-145-2020-07-16
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-145-2020-07-16
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-145
 
 [`Arc::as_ptr`]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#method.as_ptr

--- a/posts/2020-08-27-Rust-1.46.0.md
+++ b/posts/2020-08-27-Rust-1.46.0.md
@@ -119,7 +119,7 @@ See the [detailed release notes][notes] for more.
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-146-2020-08-27
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-146-2020-08-27
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-146
 
 There are other changes in the Rust 1.46.0 release: check out what changed in

--- a/posts/2020-10-08-Rust-1.47.md
+++ b/posts/2020-10-08-Rust-1.47.md
@@ -219,7 +219,7 @@ See the [detailed release notes][notes] for more.
 
 [Rustdoc has gained support for the Ayu theme](https://github.com/rust-lang/rust/pull/71237/).
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-147-2020-10-08
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-147-2020-10-08
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-147
 
 There are other changes in the Rust 1.47.0 release: check out what changed in

--- a/posts/2020-11-19-Rust-1.48.md
+++ b/posts/2020-11-19-Rust-1.48.md
@@ -220,7 +220,7 @@ See the [detailed release notes][notes] for more.
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-148-2020-11-19
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-148-2020-11-19
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-148
 
 There are other changes in the Rust 1.48.0 release: check out what changed in

--- a/posts/2020-12-31-Rust-1.49.0.md
+++ b/posts/2020-12-31-Rust-1.49.0.md
@@ -184,7 +184,7 @@ See the [detailed release notes][notes] to learn about other changes.
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-149-2020-12-31
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-149-2020-12-31
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-149
 
 There are other changes in the Rust 1.49.0 release: check out what changed in

--- a/posts/2021-02-11-Rust-1.50.0.md
+++ b/posts/2021-02-11-Rust-1.50.0.md
@@ -157,7 +157,7 @@ See the [detailed release notes][notes] to learn about other changes.
 
 ### Other changes
 
-[relnotes-cargo]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-150-2021-02-11
+[relnotes-cargo]: https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-150-2021-02-11
 [relnotes-clippy]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-150
 
 There are other changes in the Rust 1.50.0 release: check out what changed in

--- a/posts/2021-03-25-Rust-1.51.0.md
+++ b/posts/2021-03-25-Rust-1.51.0.md
@@ -200,7 +200,7 @@ The following methods were stabilised.
 
 ### Other changes
 
-There are other changes in the Rust 1.51.0 release: check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-151-2021-03-25), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-151).
+There are other changes in the Rust 1.51.0 release: check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-151-2021-03-25), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-151).
 
 ### Contributors to 1.51.0
 Many people came together to create Rust 1.51.0. We couldn't have done it without all of you. [Thanks!](https://thanks.rust-lang.org/rust/1.51.0/)

--- a/posts/2021-05-06-Rust-1.52.0.md
+++ b/posts/2021-05-06-Rust-1.52.0.md
@@ -82,7 +82,7 @@ The following previously stable APIs are now `const`.
 
 ### Other changes
 
-There are other changes in the Rust 1.52.0 release: check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1520-2021-05-06), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-152-2021-05-06), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-152).
+There are other changes in the Rust 1.52.0 release: check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1520-2021-05-06), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-152-2021-05-06), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-152).
 
 ### Contributors to 1.52.0
 

--- a/posts/2021-06-17-Rust-1.53.0.md
+++ b/posts/2021-06-17-Rust-1.53.0.md
@@ -175,7 +175,7 @@ The following methods and trait implementations were stabilized.
 There are other changes in the Rust 1.53.0 release:
 check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1530-2021-06-17),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-153-2021-06-17),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-153-2021-06-17),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-153).
 
 ### Contributors to 1.53.0

--- a/posts/2021-07-29-Rust-1.54.0.md
+++ b/posts/2021-07-29-Rust-1.54.0.md
@@ -117,7 +117,7 @@ The following methods and trait implementations were stabilized.
 ### Other changes
 
 There are other changes in the Rust 1.54.0 release:
-check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1540-2021-07-29), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-154-2021-07-29), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-154).
+check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1540-2021-07-29), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-154-2021-07-29), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-154).
 
 rustfmt has also been fixed in the 1.54.0 release to properly format nested
 out-of-line modules. This may cause changes in formatting to files that were

--- a/posts/2021-09-09-Rust-1.55.0.md
+++ b/posts/2021-09-09-Rust-1.55.0.md
@@ -154,7 +154,7 @@ The following previously stable functions are now `const`.
 ### Other changes
 
 There are other changes in the Rust 1.55.0 release:
-check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-55-2021-09-09), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-155-2021-09-09), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-155).
+check out what changed in [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-55-2021-09-09), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-155-2021-09-09), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-155).
 
 ### Contributors to 1.55.0
 

--- a/posts/2021-10-21-Rust-1.56.0.md
+++ b/posts/2021-10-21-Rust-1.56.0.md
@@ -173,7 +173,7 @@ The following previously stable functions are now `const`.
 
 There are other changes in the Rust 1.56.0 release: check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1560-2021-10-21),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-156-2021-10-21),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-156-2021-10-21),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-156).
 
 ### Contributors to 1.56.0

--- a/posts/2021-12-02-Rust-1.57.0.md
+++ b/posts/2021-12-02-Rust-1.57.0.md
@@ -93,7 +93,7 @@ The following previously stable functions are now `const`.
 
 There are other changes in the Rust 1.57.0 release: check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1570-2021-12-02),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-157-2021-12-02),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-157-2021-12-02),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-157).
 
 ### Contributors to 1.57.0

--- a/posts/2022-01-13-Rust-1.58.0.md
+++ b/posts/2022-01-13-Rust-1.58.0.md
@@ -166,7 +166,7 @@ The following previously stable functions are now `const`.
 
 There are other changes in the Rust 1.58.0 release: check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1580-2022-01-13),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-158-2022-01-13),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-158-2022-01-13),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-158).
 
 ### Contributors to 1.58.0

--- a/posts/2022-02-24-Rust-1.59.0.md
+++ b/posts/2022-02-24-Rust-1.59.0.md
@@ -244,7 +244,7 @@ The following previously stable functions are now `const`:
 
 There are other changes in the Rust 1.59.0 release. Check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1590-2022-02-24),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-159-2022-02-24),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-159-2022-02-24),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-159).
 
 ### Contributors to 1.59.0

--- a/posts/2022-04-07-Rust-1.60.0.md
+++ b/posts/2022-04-07-Rust-1.60.0.md
@@ -184,7 +184,7 @@ The following methods and trait implementations are now stabilized:
 
 There are other changes in the Rust 1.60.0 release. Check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1600-2022-04-07),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-160-2022-04-07),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-160-2022-04-07),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-160).
 
 ### Contributors to 1.60.0

--- a/posts/2022-05-19-Rust-1.61.0.md
+++ b/posts/2022-05-19-Rust-1.61.0.md
@@ -149,7 +149,7 @@ The following previously stable functions are now `const`:
 
 There are other changes in the Rust 1.61.0 release. Check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1610-2022-05-19),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-161-2022-05-19),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-161-2022-05-19),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-161).
 
 In a future release we're planning to increase the baseline requirements for

--- a/posts/2022-06-30-Rust-1.62.0.md
+++ b/posts/2022-06-30-Rust-1.62.0.md
@@ -99,7 +99,7 @@ The following methods and trait implementations are now stabilized:
 
 There are other changes in the Rust 1.62.0 release. Check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1620-2022-06-30),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-162-2022-06-30),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-162-2022-06-30),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-162).
 
 ### Contributors to 1.62.0

--- a/posts/2022-08-11-Rust-1.63.0.md
+++ b/posts/2022-08-11-Rust-1.63.0.md
@@ -247,7 +247,7 @@ These APIs are now usable in const contexts:
 
 There are other changes in the Rust 1.63.0 release. Check out what changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1630-2022-08-11),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-163-2022-08-11),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-163-2022-08-11),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-163).
 
 ### Contributors to 1.63.0

--- a/posts/2022-09-22-Rust-1.64.0.md
+++ b/posts/2022-09-22-Rust-1.64.0.md
@@ -295,7 +295,7 @@ There are other changes in the Rust 1.64 release, including:
 
 Check out everything that changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1640-2022-09-22),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-164-2022-09-22),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-164-2022-09-22),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-164).
 
 ### Contributors to 1.64.0

--- a/posts/2022-11-03-Rust-1.65.0.md
+++ b/posts/2022-11-03-Rust-1.65.0.md
@@ -224,7 +224,7 @@ There are other changes in the Rust 1.65 release, including:
 
 Check out everything that changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1650-2022-11-03),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-165-2022-11-03),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-165-2022-11-03),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-165).
 
 ### Contributors to 1.65.0

--- a/posts/2022-12-15-Rust-1.66.0.md
+++ b/posts/2022-12-15-Rust-1.66.0.md
@@ -154,7 +154,7 @@ There are other changes in the Rust 1.66 release, including:
 
 Check out everything that changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1660-2022-12-15),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-166-2022-12-15),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-166-2022-12-15),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-166).
 
 ### Contributors to 1.66.0

--- a/posts/2023-01-26-Rust-1.67.0.md
+++ b/posts/2023-01-26-Rust-1.67.0.md
@@ -91,7 +91,7 @@ These APIs are now stable in const contexts:
 
 Check out everything that changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1670-2023-01-26),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-167-2023-01-26),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-167-2023-01-26),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-167).
 
 ### Contributors to 1.67.0

--- a/posts/2023-03-09-Rust-1.68.0.md
+++ b/posts/2023-03-09-Rust-1.68.0.md
@@ -121,7 +121,7 @@ These APIs are now stable in const contexts:
 
 Check out everything that changed in
 [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1680-2023-03-09),
-[Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-168-2023-03-09),
+[Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-168-2023-03-09),
 and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-168).
 
 ### Contributors to 1.68.0

--- a/posts/2023-04-20-Rust-1.69.0.md
+++ b/posts/2023-04-20-Rust-1.69.0.md
@@ -77,7 +77,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1690-2023-04-20), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-169-2023-04-20), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-169).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1690-2023-04-20), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-169-2023-04-20), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-169).
 
 ## Contributors to 1.69.0
 

--- a/posts/2023-06-01-Rust-1.70.0.md
+++ b/posts/2023-06-01-Rust-1.70.0.md
@@ -119,7 +119,7 @@ There are known cases where unstable options may have been used without direct u
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.70.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-170-2023-06-01), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-170).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.70.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-170-2023-06-01), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-170).
 
 ## Contributors to 1.70.0
 

--- a/posts/2023-07-13-Rust-1.71.0.md
+++ b/posts/2023-07-13-Rust-1.71.0.md
@@ -120,7 +120,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.71.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-171-2023-07-13), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-171).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.71.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-171-2023-07-13), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-171).
 
 ## Contributors to 1.71.0
 

--- a/posts/2023-08-24-Rust-1.72.0.md
+++ b/posts/2023-08-24-Rust-1.72.0.md
@@ -98,7 +98,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.72.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-172-2023-08-24), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-172).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.72.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-172-2023-08-24), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-172).
 
 ### Future Windows compatibility
 

--- a/posts/2023-10-05-Rust-1.73.0.md
+++ b/posts/2023-10-05-Rust-1.73.0.md
@@ -107,7 +107,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.73.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-173-2023-10-05), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-173).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.73.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-173-2023-10-05), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-173).
 
 ## Contributors to 1.73.0
 

--- a/posts/2023-11-16-Rust-1.74.0.md
+++ b/posts/2023-11-16-Rust-1.74.0.md
@@ -149,7 +149,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.74.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-174-2023-11-16), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-174).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.74.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-174-2023-11-16), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-174).
 
 ## Contributors to 1.74.0
 

--- a/posts/2023-12-28-Rust-1.75.0.md
+++ b/posts/2023-12-28-Rust-1.75.0.md
@@ -89,7 +89,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.75.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-175).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.75.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-175-2023-12-28), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-175).
 
 ## Contributors to 1.75.0
 

--- a/posts/2024-02-08-Rust-1.76.0.md
+++ b/posts/2024-02-08-Rust-1.76.0.md
@@ -65,7 +65,7 @@ The sum of the `core::array::iter::IntoIter<i32, 3>` is 6.
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.76.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-176-2024-02-08), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-176).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.76.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-176-2024-02-08), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-176).
 
 ## Contributors to 1.76.0
 

--- a/posts/2024-03-21-Rust-1.77.0.md
+++ b/posts/2024-03-21-Rust-1.77.0.md
@@ -102,7 +102,7 @@ flag in the relevant Cargo profile.
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.77.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-177-2024-03-21), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-177).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.77.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-177-2024-03-21), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-177).
 
 ## Contributors to 1.77.0
 

--- a/posts/2024-05-02-Rust-1.78.0.md
+++ b/posts/2024-05-02-Rust-1.78.0.md
@@ -142,7 +142,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.78.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-178-2024-05-02), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-178).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.78.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-178-2024-05-02), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-178).
 
 ## Contributors to 1.78.0
 

--- a/posts/2024-06-13-Rust-1.79.0.md
+++ b/posts/2024-06-13-Rust-1.79.0.md
@@ -159,7 +159,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.79.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-179-2024-06-13), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-179).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.79.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-179-2024-06-13), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-179).
 
 ## Contributors to 1.79.0
 

--- a/posts/2024-07-25-Rust-1.80.0.md
+++ b/posts/2024-07-25-Rust-1.80.0.md
@@ -178,7 +178,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.80.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-180-2024-07-25), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-180).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.80.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-180-2024-07-25), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-180).
 
 ## Contributors to 1.80.0
 

--- a/posts/2024-09-05-Rust-1.81.0.md
+++ b/posts/2024-09-05-Rust-1.81.0.md
@@ -163,7 +163,7 @@ See more details in the previous [announcement of this change](https://blog.rust
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.81.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-181-2024-09-05), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-181).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.81.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-181-2024-09-05), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-181).
 
 ## Contributors to 1.81.0
 

--- a/posts/2024-10-17-Rust-1.82.0.md
+++ b/posts/2024-10-17-Rust-1.82.0.md
@@ -413,7 +413,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.82.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-182-2024-10-17), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-182).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.82.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-182-2024-10-17), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-182).
 
 ## Contributors to 1.82.0
 

--- a/posts/2024-11-28-Rust-1.83.0.md
+++ b/posts/2024-11-28-Rust-1.83.0.md
@@ -202,7 +202,7 @@ These APIs are now stable in const contexts:
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.83.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-183-2024-11-28), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-183).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.83.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-183-2024-11-28), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-183).
 
 ## Contributors to 1.83.0
 

--- a/posts/2025-01-09-Rust-1.84.0.md
+++ b/posts/2025-01-09-Rust-1.84.0.md
@@ -173,7 +173,7 @@ These APIs are now stable in const contexts
 
 ### Other changes
 
-Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.84.0), [Cargo](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-184-2025-01-09), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-184).
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.84.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-184-2025-01-09), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-184).
 
 ## Contributors to 1.84.0
 


### PR DESCRIPTION
Cargo has moved its changelog to the static site in order to deal with GitHub markdown rendering issues. This updates all the links to use the new location.

[Rendered](https://github.com/ehuss/blog.rust-lang.org/blob/cargo-changelog/posts/2019-05-23-Rust-1.35.0.md)