### PR TITLE
Revert "style: wrap text code to prevent content overflow-x"

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -221,14 +221,6 @@ div.brand {
     white-space: pre-wrap;
   }
 
-  pre code {
-    white-space: inherit;
-  }
-
-  ul code {
-    display: block;
-  }
-
   a.anchor::before {
     content: "§";
     display: none;


### PR DESCRIPTION
# Motivation

Revert PR #1325.

PR was 7 months old, and other CSS changes happened in the meantime, which made its style break some styles for the `<code>` block once applied today, as reported by @weihanglo.

Before #1325:

![image](https://github.com/user-attachments/assets/ee32b8b6-7d5e-475a-bc2d-b46e024e331b)

After:

![image](https://github.com/user-attachments/assets/56716e94-e283-47f2-b74e-88c309815944)

# Notes

I had a quick look, and it seems that the original issue addressed by #1325 in May 2024 still occurs on main when a long function is inside a code block within a list. This can now potentially be prevented with #1474.
