### PR TITLE
style: word wrap code to prevent content overflow-x

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -225,6 +225,14 @@ div.brand {
     white-space: pre-wrap;
   }
 
+  pre code {
+    white-space: inherit;
+  }
+
+  ul code {
+    display: block;
+  }
+
   a.anchor::before {
     content: "§";
     display: none;

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -120,6 +120,10 @@ code {
   overflow: auto;
 }
 
+ul a code {
+  word-break: break-word;
+}
+
 section {
   padding: 30px 0 60px 0;
 
@@ -219,14 +223,6 @@ div.brand {
     background-color: var(--code-bg-color);
     border: 1px solid var(--code-border-color);
     white-space: pre-wrap;
-  }
-
-  pre code {
-    white-space: inherit;
-  }
-
-  ul code {
-    display: block;
   }
 
   a.anchor::before {


### PR DESCRIPTION
# Motivation

While I reverted #1473—a change originally intended to prevent overflow-x on mobile—I noticed that, despite CSS evolving, the issue still occasionally occurs when a code block inside a link within a list has text long enough to overflow the screen. Wrapping the text forces it to break onto a new line.

Before:

<img width="1536" alt="Capture d’écran 2025-02-05 à 06 31 38" src="https://github.com/user-attachments/assets/596da65a-9ba6-4007-94c4-87469cde1e27" />

After:

<img width="1536" alt="after" src="https://github.com/user-attachments/assets/66546adc-b387-4041-8c36-9430a9e1b6a2" />
