### PR TITLE
Revert "style: white-space for wrap text code"

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -218,7 +218,6 @@ div.brand {
     color: var(--code-color);
     background-color: var(--code-bg-color);
     border: 1px solid var(--code-border-color);
-    white-space: pre-wrap;
   }
 
   a.anchor::before {


### PR DESCRIPTION
# Motivation

Leftover from #1473, which should probably be cleaned up as well after double-checking production on the mobile format, given that the issue it originally tried to address (#1325) remains open.

Before with leftover code is wrapped on mobile:

<img width="1536" alt="Capture d’écran 2025-02-05 à 09 36 02" src="https://github.com/user-attachments/assets/0f971bff-ab7b-4e7a-8f80-9c2d2277877b" />

After code become scrollable X:

<img width="1536" alt="Capture d’écran 2025-02-05 à 09 36 06" src="https://github.com/user-attachments/assets/d106168e-3852-44a8-b6ba-05a4358faa6e" />
