### PR TITLE
Add 2024 State of Rust results link to the announcement post

### DIFF
--- a/posts/2024-12-05-annual-survey-2024-launch.md
+++ b/posts/2024-12-05-annual-survey-2024-launch.md
@@ -7,6 +7,8 @@ description: "Share your experience using Rust in the ninth edition of the State
 
 It’s time for the [2024 State of Rust Survey][survey-link]!
 
+> The results of the survey can be found [here](https://blog.rust-lang.org/2025/02/13/2024-State-Of-Rust-Survey-results.html).
+
 Since 2016, the Rust Project has collected valuable information and feedback from the Rust programming language community through our annual [State of Rust Survey][survey-link]. This tool allows us to more deeply understand how the Rust Project is performing, how we can better serve the global Rust community, and who our community is composed of.
 
 Like last year, the [2024 State of Rust Survey][survey-link] will likely take you between 10 and 25 minutes, and responses are anonymous. We will accept submissions until Monday, December 23rd, 2024. Trends and key insights will be shared on [blog.rust-lang.org](https://blog.rust-lang.org) as soon as possible.

--- a/posts/2025-02-13-2024-State-Of-Rust-Survey-results.md
+++ b/posts/2025-02-13-2024-State-Of-Rust-Survey-results.md
@@ -229,7 +229,7 @@ We cannot of course forget the favourite topic of many programmers: which IDE (d
 </div>
 <!-- Chart what-ide-do-you-use end -->
 
-> You can also take a look at the linked [wordcloud](../../../images/2025-01-rust-survey-2024/what-ide-do-you-use-wordcloud.png) that summarizes open answers to this question (the "Other" category), to see what other editors are also popular.
+> You can also take a look at the linked [wordcloud](../../../images/2025-02-13-rust-survey-2024/what-ide-do-you-use-wordcloud.png) that summarizes open answers to this question (the "Other" category), to see what other editors are also popular.
 
 ## Rust at Work
 

--- a/static/scripts/2025-02-13-rust-survey-2024/charts.js
+++ b/static/scripts/2025-02-13-rust-survey-2024/charts.js
@@ -65,7 +65,7 @@ function relayoutCharts() {
         layout.autosize = false;
         layout.width = "100%";
         Plotly.relayout(chart, layout);
-        Plotly.restyle(chart, {textangle: -90});
+        Plotly.restyle(chart, {textangle: 90});
     }
     var matrix_charts = document.getElementsByClassName("matrix-chart");
     for (var i = 0; i < matrix_charts.length; i++) {


### PR DESCRIPTION
This was suggested in an issue on the surveys repo, and is a good idea in general.

This PR also fixes some small things in the 2024 survey.

[Rendered](https://github.com/Kobzol/blog.rust-lang.org/blob/survey-results-2024/posts/2024-12-05-annual-survey-2024-launch.md)