### PR TITLE
Announcing Rust 1.85.0 and Rust 2024

### DIFF
--- a/posts/2025-02-20-Rust-1.85.0.md
+++ b/posts/2025-02-20-Rust-1.85.0.md
@@ -31,7 +31,7 @@ This is the largest edition we have released. The [edition guide](https://doc.ru
   - [RPIT lifetime capture rules](https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html) — Changes the default impl trait `use<..>` capturing.
   - [`if let` temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html) — Changes the scope of temporaries for `if let` expressions.
   - [Tail expression temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html) — Changes the scope of temporaries for the tail expression in a block.
-  - [Match ergonomics reservations](https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html) — New restrictions on pattern binding modes.
+  - [Match ergonomics reservations](https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html) — Disallow some pattern combinations to avoid confusion and allow for future improvements.
   - [Unsafe `extern` blocks](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html) — `extern` blocks now require the `unsafe` keyword.
   - [Unsafe attributes](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html) — The `export_name`, `link_section`, and `no_mangle` attributes must now be marked as `unsafe`.
   - [`unsafe_op_in_unsafe_fn` warning](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html) — The [`unsafe_op_in_unsafe_fn`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-op-in-unsafe-fn) lint now warns by default, requiring explicit `unsafe {}` blocks in `unsafe` functions.
@@ -55,7 +55,6 @@ This is the largest edition we have released. The [edition guide](https://doc.ru
 - Rustfmt
   - [Rustfmt: Style edition](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-style-edition.html) — Introduces the concept of "style editions", which allow you to independently control the formatting edition from the Rust edition.
   - [Rustfmt: Formatting fixes](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-formatting-fixes.html) — A large number of fixes to formatting various situations.
-  - [Rustfmt: Combine all delimited exprs as last argument](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-overflow-delimited-expr.html) — Changes to multi-line expressions as the last argument.
   - [Rustfmt: Raw identifier sorting](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-raw-identifier-sorting.html) — Changes to how `r#foo` identifiers are sorted.
   - [Rustfmt: Version sorting](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-version-sorting.html) — Changes to how identifiers that contain integers are sorted.
 
@@ -64,6 +63,8 @@ This is the largest edition we have released. The [edition guide](https://doc.ru
 The guide includes migration instructions for all new features, and in general
 [transitioning an existing project to a new edition](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html).
 In many cases `cargo fix` can automate the necessary changes. You may even find that no changes in your code are needed at all for 2024!
+
+Note that automatic fixes via `cargo fix` are very conservative to avoid ever changing the semantics of your code. In many cases you may wish to keep your code the same and use the new semantics of Rust 2024; for instance, continuing to use the `expr` macro matcher, and ignoring the conversions of conditionals because you want the new 2024 drop order semantics. The result of `cargo fix` should not be considered a recommendation, just a conservative conversion that preserves behavior.
 
 *Many* people came together to create this edition. We'd like to thank them all for their hard work!
 
@@ -75,8 +76,6 @@ In many cases `cargo fix` can automate the necessary changes. You may even find 
   See [RFC 3668](https://rust-lang.github.io/rfcs/3668-async-closures.html) for more details.
 
 ### Hiding trait implementations from diagnostics
-
-- [Stabilize `#[diagnostic::do_not_recommend]`](https://github.com/rust-lang/rust/pull/132056)
 
 The new `#[diagnostic::do_not_recommend]` attribute is a hint to the compiler to not show the annotated trait implementation as part of a diagnostic message. For library authors, this is a way to keep the compiler from making suggestions that may be unhelpful or misleading. For example:
 
@@ -150,7 +149,7 @@ fn main() {
 [0, 1, 16, 81, 256, 625, 1296, 2401, 4096, 6561]
 ```
 
-### Updates to `home_dir()`
+### Updates to `std::env::home_dir()`
 
 `std::env::home_dir()` has been deprecated for years, because it can give surprising results in some Windows configurations if the `HOME` environment variable is set (which is not the normal configuration on Windows). We had previously avoided changing its behavior, out of concern for compatibility with code depending on this non-standard configuration. Given how long this function has been deprecated, we're now updating its behavior as a bug fix, and a subsequent release will remove the deprecation for this function.
 

--- a/posts/2025-02-20-Rust-1.85.0.md
+++ b/posts/2025-02-20-Rust-1.85.0.md
@@ -1,0 +1,202 @@
+---
+layout: post
+title: "Announcing Rust 1.85.0 and Rust 2024"
+author: The Rust Release Team
+release: true
+---
+
+The Rust team is happy to announce a new version of Rust, 1.85.0. This stabilizes the 2024 edition as well.
+Rust is a programming language empowering everyone to build reliable and efficient software.
+
+If you have a previous version of Rust installed via `rustup`, you can get 1.85.0 with:
+
+```console
+$ rustup update stable
+```
+
+If you don't have it already, you can [get `rustup`](https://www.rust-lang.org/install.html) from the appropriate page on our website, and check out the [detailed release notes for 1.85.0](https://doc.rust-lang.org/stable/releases.html#version-1850-2025-02-20).
+
+If you'd like to help us out by testing future releases, you might consider updating locally to use the beta channel (`rustup default beta`) or the nightly channel (`rustup default nightly`). Please [report](https://github.com/rust-lang/rust/issues/new/choose) any bugs you might come across!
+
+## What's in 1.85.0 stable
+
+### Rust 2024
+
+We are excited to announce that the Rust 2024 Edition is now stable!
+Editions are a mechanism for opt-in changes that may otherwise pose a backwards compatibility risk. See [the edition guide](https://doc.rust-lang.org/edition-guide/editions/index.html) for details on how this is achieved, and detailed instructions on how to migrate.
+
+This is the largest edition we have released. The [edition guide](https://doc.rust-lang.org/edition-guide/rust-2024/index.html) contains detailed information about each change, but as a summary, here are all the changes:
+
+- Language
+  - [RPIT lifetime capture rules](https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html) — Changes the default impl trait `use<..>` capturing.
+  - [`if let` temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html) — Changes the scope of temporaries for `if let` expressions.
+  - [Tail expression temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html) — Changes the scope of temporaries for the tail expression in a block.
+  - [Match ergonomics reservations](https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html) — New restrictions on pattern binding modes.
+  - [Unsafe `extern` blocks](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html) — `extern` blocks now require the `unsafe` keyword.
+  - [Unsafe attributes](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html) — The `export_name`, `link_section`, and `no_mangle` attributes must now be marked as `unsafe`.
+  - [`unsafe_op_in_unsafe_fn` warning](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html) — The [`unsafe_op_in_unsafe_fn`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-op-in-unsafe-fn) lint now warns by default, requiring explicit `unsafe {}` blocks in `unsafe` functions.
+  - [Disallow references to `static mut`](https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html) — References to `static mut` items now generate a deny-by-default error.
+  - [Never type fallback change](https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html) — Changes to how the never type `!` coerces, and changes the [`never_type_fallback_flowing_into_unsafe`](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#never-type-fallback-flowing-into-unsafe) lint level to "deny".
+  - [Macro fragment specifiers](https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html) — The `expr` macro fragment specifier in `macro_rules!` macros now also matches `const` and `_` expressions.
+  - [Missing macro fragment specifiers](https://doc.rust-lang.org/edition-guide/rust-2024/missing-macro-fragment-specifiers.html) — The [`missing_fragment_specifier`](https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#missing-fragment-specifier) lint is now a hard error, rejecting macro meta variables without a fragment specifier kind.
+  - [`gen` keyword](https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html) — Reserves the `gen` keyword in anticipation of adding generator blocks in the future.
+  - [Reserved syntax](https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html) — Reserves `#"foo"#` style strings and `##` tokens in anticipation of changing how guarded string literals may change in the future.
+- Standard library
+  - [Changes to the prelude](https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html) — Adds `Future` and `IntoFuture` to the prelude.
+  - [Add `IntoIterator` for `Box<[T]>`](https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html) — Changes how iterators work with boxed slices.
+  - [Newly unsafe functions](https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html) — `std::env::set_var`, `std::env::remove_var`, and `std::os::unix::process::CommandExt::before_exec` are now unsafe functions.
+- Cargo
+  - [Cargo: Rust-version aware resolver](https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html) — Changes the default dependency resolver behavior to consider the `rust-version` field.
+  - [Cargo: Table and key name consistency](https://doc.rust-lang.org/edition-guide/rust-2024/cargo-table-key-names.html) — Removes some outdated `Cargo.toml` keys.
+  - [Cargo: Reject unused inherited default-features](https://doc.rust-lang.org/edition-guide/rust-2024/cargo-inherited-default-features.html) — Changes how `default-features = false` works with inherited workspace dependencies.
+- Rustdoc
+  - [Rustdoc combined tests](https://doc.rust-lang.org/edition-guide/rust-2024/rustdoc-doctests.html) — Doctests are now combined into a single executable, significantly improving performance.
+  - [Rustdoc nested `include!` change](https://doc.rust-lang.org/edition-guide/rust-2024/rustdoc-nested-includes.html) — Changes to the relative path behavior of nested `include!` files.
+- Rustfmt
+  - [Rustfmt: Style edition](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-style-edition.html) — Introduces the concept of "style editions", which allow you to independently control the formatting edition from the Rust edition.
+  - [Rustfmt: Formatting fixes](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-formatting-fixes.html) — A large number of fixes to formatting various situations.
+  - [Rustfmt: Combine all delimited exprs as last argument](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-overflow-delimited-expr.html) — Changes to multi-line expressions as the last argument.
+  - [Rustfmt: Raw identifier sorting](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-raw-identifier-sorting.html) — Changes to how `r#foo` identifiers are sorted.
+  - [Rustfmt: Version sorting](https://doc.rust-lang.org/edition-guide/rust-2024/rustfmt-version-sorting.html) — Changes to how identifiers that contain integers are sorted.
+
+#### Migrating to 2024
+
+The guide includes migration instructions for all new features, and in general
+[transitioning an existing project to a new edition](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html).
+In many cases `cargo fix` can automate the necessary changes. You may even find that no changes in your code are needed at all for 2024!
+
+*Many* people came together to create this edition. We'd like to thank them all for their hard work!
+
+### `async` closures
+
+**🚧 TODO 🚧**
+
+- [Stabilize async closures](https://github.com/rust-lang/rust/pull/132706)
+  See [RFC 3668](https://rust-lang.github.io/rfcs/3668-async-closures.html) for more details.
+
+### Hiding trait implementations from diagnostics
+
+- [Stabilize `#[diagnostic::do_not_recommend]`](https://github.com/rust-lang/rust/pull/132056)
+
+The new `#[diagnostic::do_not_recommend]` attribute is a hint to the compiler to not show the annotated trait implementation as part of a diagnostic message. For library authors, this is a way to keep the compiler from making suggestions that may be unhelpful or misleading. For example:
+
+```rust
+pub trait Foo {}
+pub trait Bar {}
+
+impl<T: Foo> Bar for T {}
+
+struct MyType;
+
+fn main() {
+    let _object: &dyn Bar = &MyType;
+}
+```
+
+```text
+error[E0277]: the trait bound `MyType: Bar` is not satisfied
+ --> src/main.rs:9:29
+  |
+9 |     let _object: &dyn Bar = &MyType;
+  |                             ^^^^ the trait `Foo` is not implemented for `MyType`
+  |
+note: required for `MyType` to implement `Bar`
+ --> src/main.rs:4:14
+  |
+4 | impl<T: Foo> Bar for T {}
+  |         ---  ^^^     ^
+  |         |
+  |         unsatisfied trait bound introduced here
+  = note: required for the cast from `&MyType` to `&dyn Bar`
+```
+
+For some APIs, it might make good sense for you to implement `Foo`, and get `Bar` indirectly by that blanket implementation. For others, it might be expected that most users should implement `Bar` directly, so that `Foo` suggestion is a red herring. In that case, adding the diagnostic hint will change the error message like so:
+
+```rust
+#[diagnostic::do_not_recommend]
+impl<T: Foo> Bar for T {}
+```
+
+```text
+error[E0277]: the trait bound `MyType: Bar` is not satisfied
+  --> src/main.rs:10:29
+   |
+10 |     let _object: &dyn Bar = &MyType;
+   |                             ^^^^ the trait `Bar` is not implemented for `MyType`
+   |
+   = note: required for the cast from `&MyType` to `&dyn Bar`
+```
+
+See [RFC 2397](https://rust-lang.github.io/rfcs/2397-do-not-recommend.html) for the original motivation, and the current [reference](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-diagnosticdo_not_recommend-attribute) for more details.
+
+### `FromIterator` and `Extend` for tuples
+
+Earlier versions of Rust implemented convenience traits for iterators of `(T, U)` tuple pairs to behave like `Iterator::unzip`, with `Extend` in 1.56 and `FromIterator` in 1.79. These have now been *extended* to more tuple lengths, from singleton `(T,)` through to 12 items long, `(T1, T2, .., T11, T12)`. For example, you can now use `collect()` to fanout into multiple collections at once:
+
+```rust
+use std::collections::{LinkedList, VecDeque};
+fn main() {
+    let (squares, cubes, tesseracts): (Vec<_>, VecDeque<_>, LinkedList<_>) =
+        (0i32..10).map(|i| (i * i, i.pow(3), i.pow(4))).collect();
+    println!("{squares:?}");
+    println!("{cubes:?}");
+    println!("{tesseracts:?}");
+}
+```
+
+```text
+[0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+[0, 1, 8, 27, 64, 125, 216, 343, 512, 729]
+[0, 1, 16, 81, 256, 625, 1296, 2401, 4096, 6561]
+```
+
+### Updates to `home_dir()`
+
+`std::env::home_dir()` has been deprecated for years, because it can give surprising results in some Windows configurations if the `HOME` environment variable is set (which is not the normal configuration on Windows). We had previously avoided changing its behavior, out of concern for compatibility with code depending on this non-standard configuration. Given how long this function has been deprecated, we're now updating its behavior as a bug fix, and a subsequent release will remove the deprecation for this function.
+
+### Stabilized APIs
+
+- [`BuildHasherDefault::new`](https://doc.rust-lang.org/stable/std/hash/struct.BuildHasherDefault.html#method.new)
+- [`ptr::fn_addr_eq`](https://doc.rust-lang.org/std/ptr/fn.fn_addr_eq.html)
+- [`io::ErrorKind::QuotaExceeded`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.QuotaExceeded)
+- [`io::ErrorKind::CrossesDevices`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.CrossesDevices)
+- [`{float}::midpoint`](https://doc.rust-lang.org/core/primitive.f32.html#method.midpoint)
+- [Unsigned `{integer}::midpoint`](https://doc.rust-lang.org/std/primitive.u64.html#method.midpoint)
+- [`NonZeroU*::midpoint`](https://doc.rust-lang.org/std/num/type.NonZeroU32.html#method.midpoint)
+- [impl `std::iter::Extend` for tuples with arity 1 through 12](https://doc.rust-lang.org/stable/std/iter/trait.Extend.html#impl-Extend%3C(A,)%3E-for-(EA,))
+- [`FromIterator<(A, ...)>` for tuples with arity 1 through 12](https://doc.rust-lang.org/stable/std/iter/trait.FromIterator.html#impl-FromIterator%3C(EA,)%3E-for-(A,))
+- [`std::task::Waker::noop`](https://doc.rust-lang.org/stable/std/task/struct.Waker.html#method.noop)
+
+These APIs are now stable in const contexts
+
+- [`mem::size_of_val`](https://doc.rust-lang.org/stable/std/mem/fn.size_of_val.html)
+- [`mem::align_of_val`](https://doc.rust-lang.org/stable/std/mem/fn.align_of_val.html)
+- [`Layout::for_value`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.for_value)
+- [`Layout::align_to`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.align_to)
+- [`Layout::pad_to_align`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.pad_to_align)
+- [`Layout::extend`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.extend)
+- [`Layout::array`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.array)
+- [`std::mem::swap`](https://doc.rust-lang.org/stable/std/mem/fn.swap.html)
+- [`std::ptr::swap`](https://doc.rust-lang.org/stable/std/ptr/fn.swap.html)
+- [`NonNull::new`](https://doc.rust-lang.org/stable/std/ptr/struct.NonNull.html#method.new)
+- [`HashMap::with_hasher`](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#method.with_hasher)
+- [`HashSet::with_hasher`](https://doc.rust-lang.org/stable/std/collections/struct.HashSet.html#method.with_hasher)
+- [`BuildHasherDefault::new`](https://doc.rust-lang.org/stable/std/hash/struct.BuildHasherDefault.html#method.new)
+- [`<float>::recip`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.recip)
+- [`<float>::to_degrees`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.to_degrees)
+- [`<float>::to_radians`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.to_radians)
+- [`<float>::max`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.max)
+- [`<float>::min`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.min)
+- [`<float>::clamp`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.clamp)
+- [`<float>::abs`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.abs)
+- [`<float>::signum`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.signum)
+- [`<float>::copysign`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.copysign)
+- [`MaybeUninit::write`](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.write)
+
+### Other changes
+
+Check out everything that changed in [Rust](https://github.com/rust-lang/rust/releases/tag/1.85.0), [Cargo](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-185-2025-02-20), and [Clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-185).
+
+## Contributors to 1.85.0
+
+Many people came together to create Rust 1.85.0. We couldn't have done it without all of you. [Thanks!](https://thanks.rust-lang.org/rust/1.85.0/)

--- a/posts/2025-02-20-Rust-1.85.0.md
+++ b/posts/2025-02-20-Rust-1.85.0.md
@@ -28,7 +28,7 @@ Editions are a mechanism for opt-in changes that may otherwise pose a backwards 
 This is the largest edition we have released. The [edition guide](https://doc.rust-lang.org/edition-guide/rust-2024/index.html) contains detailed information about each change, but as a summary, here are all the changes:
 
 - Language
-  - [RPIT lifetime capture rules](https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html) — Changes the default impl trait `use<..>` capturing.
+  - [RPIT lifetime capture rules](https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html) — Changes the default capturing of parameters by `impl Trait` types when `use<..>` is not present.
   - [`if let` temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html) — Changes the scope of temporaries for `if let` expressions.
   - [Tail expression temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html) — Changes the scope of temporaries for the tail expression in a block.
   - [Match ergonomics reservations](https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html) — Disallow some pattern combinations to avoid confusion and allow for future improvements.
@@ -40,7 +40,7 @@ This is the largest edition we have released. The [edition guide](https://doc.ru
   - [Macro fragment specifiers](https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html) — The `expr` macro fragment specifier in `macro_rules!` macros now also matches `const` and `_` expressions.
   - [Missing macro fragment specifiers](https://doc.rust-lang.org/edition-guide/rust-2024/missing-macro-fragment-specifiers.html) — The [`missing_fragment_specifier`](https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#missing-fragment-specifier) lint is now a hard error, rejecting macro meta variables without a fragment specifier kind.
   - [`gen` keyword](https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html) — Reserves the `gen` keyword in anticipation of adding generator blocks in the future.
-  - [Reserved syntax](https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html) — Reserves `#"foo"#` style strings and `##` tokens in anticipation of changing how guarded string literals may change in the future.
+  - [Reserved syntax](https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html) — Reserves `#"foo"#` style strings and `##` tokens in anticipation of changing how guarded string literals may be parsed in the future.
 - Standard library
   - [Changes to the prelude](https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html) — Adds `Future` and `IntoFuture` to the prelude.
   - [Add `IntoIterator` for `Box<[T]>`](https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html) — Changes how iterators work with boxed slices.

--- a/posts/2025-02-20-Rust-1.85.0.md
+++ b/posts/2025-02-20-Rust-1.85.0.md
@@ -70,10 +70,41 @@ Note that automatic fixes via `cargo fix` are very conservative to avoid ever ch
 
 ### `async` closures
 
-**🚧 TODO 🚧**
+Rust now supports asynchronous closures like `async || {}` which return futures when called. This works like an `async fn` which can also capture values from the local environment, just like the difference between regular closures and functions. This also comes with 3 analogous traits in the standard library prelude: `AsyncFn`, `AsyncFnMut`, and `AsyncFnOnce`.
 
-- [Stabilize async closures](https://github.com/rust-lang/rust/pull/132706)
-  See [RFC 3668](https://rust-lang.github.io/rfcs/3668-async-closures.html) for more details.
+In some cases, you could already approximate this with a regular closure and an asynchronous block, like `|| async {}`. However, the future returned by such an inner block is not able to borrow from the closure captures, but this does work with `async` closures:
+
+```rust
+let mut vec: Vec<String> = vec![];
+
+let closure = async || {
+    vec.push(ready(String::from("")).await);
+};
+```
+
+It also has not been possible to properly express higher-ranked function signatures with the `Fn` traits returning a `Future`, but you can write this with the `AsyncFn` traits:
+
+```rust
+use core::future::Future;
+async fn f<Fut>(_: impl for<'a> Fn(&'a u8) -> Fut)
+where
+    Fut: Future<Output = ()>,
+{ todo!() }
+
+async fn f2(_: impl for<'a> AsyncFn(&'a u8))
+{ todo!() }
+
+async fn main() {
+    async fn g(_: &u8) { todo!() }
+    f(g).await;
+    //~^ ERROR mismatched types
+    //~| ERROR one type is more general than the other
+
+    f2(g).await; // ok!
+}
+```
+
+So `async` closures provide first-class solutions to both of these problems! See [RFC 3668](https://rust-lang.github.io/rfcs/3668-async-closures.html) and the [stabilization report](https://github.com/rust-lang/rust/pull/132706) for more details.
 
 ### Hiding trait implementations from diagnostics
 


### PR DESCRIPTION
- [x] Rust 2024
- [x] `async` closures
- [x] `#[diagnostic::do_not_recommend]`
- [x] `FromIterator` and `Extend` for tuples
- [x] Updates to `home_dir()`
- [x] Stabilized APIs

cc @rust-lang/release 
@rustbot ping relnotes-interest-group

[Rendered](https://github.com/cuviper/blog.rust-lang.org/blob/rust-1.85.0/posts/2025-02-20-Rust-1.85.0.md)