### PR TITLE
Announce `relnotes-interest-group` ping group

### DIFF
--- a/posts/inside-rust/2025-02-27-relnotes-interest-group.md
+++ b/posts/inside-rust/2025-02-27-relnotes-interest-group.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: "Relnotes PR and release blog post ping group"
+author: Jieyou Xu
+team: The Release Team <https://www.rust-lang.org/governance/teams/infra#team-release>
+---
+
+# Relnotes PR and release blog post ping group is now available
+
+A new [`relnotes-interest-group`][relnotes-ping-group] ping group is now available for contributors to join to get pinged when a new relnotes PR (to <https://github.com/rust-lang/rust>) or release blog post (to <https://github.com/rust-lang/blog.rust-lang.org>) are created. Ping group members may wish to be pinged so that they can help with:
+
+- Reviewing wording of the release notes PR or blog post
+- Checking if certain release notes entries are unnecessary, redundant, or missing (especially on behalf of their respective team(s))
+- Recommending other improvements
+
+This ping group is primarily intended for project members. If you wish to join the ping group, you may follow the usual procedure to send a PR to <https://github.com/rust-lang/team> and add yourself as a member of [`teams/relnotes-interest-group.toml`](https://github.com/rust-lang/team/blob/master/teams/relnotes-interest-group.toml).
+
+[relnotes-ping-group]: https://github.com/rust-lang/team/pull/1613


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/133334
Discussion: https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release/topic/Please.20CC.20lang

This PR adds a new Inside Rust blog post announcing the `relnotes-interest-group` ping group.

r? @Mark-Simulacrum 

[Rendered](https://github.com/jieyouxu/blog.rust-lang.org/blob/relnotes-interest-group/posts/inside-rust/2025-02-27-relnotes-interest-group.md)