### PR TITLE
Add blog post about our participation in GSoC 2025

### DIFF
--- a/posts/2025-03-03-Rust-participates-in-GSoC-2025.md
+++ b/posts/2025-03-03-Rust-participates-in-GSoC-2025.md
@@ -4,7 +4,7 @@ title: "Rust participates in Google Summer of Code 2025"
 author: Jakub Beránek, Jack Huey and Paul Lenz
 ---
 
-We're writing this blog post to announce that the Rust Project will again be participating in [Google Summer of Code (GSoC) 2025][gsoc]. If you're not eligible or interested in participating in GSoC, then most of this post likely isn't relevant to you; if you are, this should contain some useful information and links.
+We are happy to announce that the Rust Project will again be participating in [Google Summer of Code (GSoC) 2025][gsoc], same as [last year][gsoc announcement 2024]. If you're not eligible or interested in participating in GSoC, then most of this post likely isn't relevant to you; if you are, this should contain some useful information and links.
 
 Google Summer of Code (GSoC) is an annual global program organized by Google that aims to bring new contributors to the world of open-source. The program pairs organizations (such as the Rust Project) with contributors (usually students), with the goal of helping the participants make meaningful open-source contributions under the guidance of experienced mentors.
 
@@ -12,13 +12,16 @@ The organizations that have been accepted into the program have been [announced]
 
 We have prepared a [list of project ideas][gsoc repo] that can serve as inspiration for potential GSoC contributors that would like to send a project proposal to the Rust organization. However, applicants can also come up with their own project ideas. You can discuss project ideas or try to find mentors in the [#gsoc][gsoc stream] Zulip stream. We have also prepared a [proposal guide][proposal guide] that should help you with preparing your project proposals.
 
-You can start discussing the project ideas with Rust Project mentors and maintainers immediately. The project proposal application period starts on March 24, 2025, and ends on April 8, 2025 at 18:00 UTC. Take note of that deadline, as there will be no extensions!
+You can start discussing the project ideas with Rust Project mentors and maintainers immediately, but you might want to keep the following important dates in mind:
+- The project proposal application period starts on March 24, 2025. From that date you can submit project proposals into the GSoC dashboard.
+- The project proposal application period ends on **April 8, 2025** at 18:00 UTC. Take note of that deadline, as there will be no extensions!
 
 If you are interested in contributing to the Rust Project, we encourage you to check out our project idea list and send us a GSoC project proposal! Of course, you are also free to discuss these projects and/or try to move them forward even if you do not intend to (or cannot) participate in GSoC. We welcome all contributors to Rust, as there is always enough work to do.
 
-Last year we have participated in GSoC for the first time, and it was a [success][gsoc results]! This year we are very excited to participate again. We hope that participants in the program can improve their skills, but also would love for this to bring new contributors to the Project and increase the awareness of Rust in general. We will publish another blog post later this year with more information about our participation in the program.
+Last year was our first time participating in GSoC, and it was a [success][gsoc results]! This year we are very excited to participate again. We hope that participants in the program can improve their skills, but also would love for this to bring new contributors to the Project and increase the awareness of Rust in general. Like last year, we expect to publish blog posts in the future with updates about our participation in the program.
 
 [gsoc]: https://summerofcode.withgoogle.com
+[gsoc announcement 2024]: https://blog.rust-lang.org/2024/02/21/Rust-participates-in-GSoC-2024.html
 [gsoc orgs]: https://summerofcode.withgoogle.com/programs/2025/organizations
 [gsoc repo]: https://github.com/rust-lang/google-summer-of-code
 [gsoc stream]: https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc

--- a/posts/2025-03-03-Rust-participates-in-GSoC-2025.md
+++ b/posts/2025-03-03-Rust-participates-in-GSoC-2025.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Rust participates in Google Summer of Code 2025"
+author: Jakub Beránek, Jack Huey and Paul Lenz
+---
+
+We're writing this blog post to announce that the Rust Project will again be participating in [Google Summer of Code (GSoC) 2025][gsoc]. If you're not eligible or interested in participating in GSoC, then most of this post likely isn't relevant to you; if you are, this should contain some useful information and links.
+
+Google Summer of Code (GSoC) is an annual global program organized by Google that aims to bring new contributors to the world of open-source. The program pairs organizations (such as the Rust Project) with contributors (usually students), with the goal of helping the participants make meaningful open-source contributions under the guidance of experienced mentors.
+
+The organizations that have been accepted into the program have been [announced][gsoc orgs] by Google. The GSoC applicants now have several weeks to discuss project ideas with mentors. Later, they will send project proposals for the projects that they found the most interesting. If their project proposal is accepted, they will embark on a several month journey during which they will try to complete their proposed project under the guidance of an assigned mentor.
+
+We have prepared a [list of project ideas][gsoc repo] that can serve as inspiration for potential GSoC contributors that would like to send a project proposal to the Rust organization. However, applicants can also come up with their own project ideas. You can discuss project ideas or try to find mentors in the [#gsoc][gsoc stream] Zulip stream. We have also prepared a [proposal guide][proposal guide] that should help you with preparing your project proposals.
+
+You can start discussing the project ideas with Rust Project mentors and maintainers immediately. The project proposal application period starts on March 24, 2025, and ends on April 8, 2025 at 18:00 UTC. Take note of that deadline, as there will be no extensions!
+
+If you are interested in contributing to the Rust Project, we encourage you to check out our project idea list and send us a GSoC project proposal! Of course, you are also free to discuss these projects and/or try to move them forward even if you do not intend to (or cannot) participate in GSoC. We welcome all contributors to Rust, as there is always enough work to do.
+
+Last year we have participated in GSoC for the first time, and it was a [success][gsoc results]! This year we are very excited to participate again. We hope that participants in the program can improve their skills, but also would love for this to bring new contributors to the Project and increase the awareness of Rust in general. We will publish another blog post later this year with more information about our participation in the program.
+
+[gsoc]: https://summerofcode.withgoogle.com
+[gsoc orgs]: https://summerofcode.withgoogle.com/programs/2025/organizations
+[gsoc repo]: https://github.com/rust-lang/google-summer-of-code
+[gsoc stream]: https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc
+[proposal guide]: https://github.com/rust-lang/google-summer-of-code/blob/main/gsoc/proposal-guide.md
+[gsoc results]: https://blog.rust-lang.org/2024/11/07/gsoc-2024-results.html


### PR DESCRIPTION
This blog post announces our participation in GSoC 2025. Since the t-mentorship team isn't official yet, I enumerated the GSoC org admins as authors of the blog post, same as last year.

The blog post is mostly a copy paste of [last year's announcement](https://blog.rust-lang.org/2024/02/21/Rust-participates-in-GSoC-2024.html) post, with a few things modified given that it's our second year participating.

I'm planning to publish three blog posts about GSoC 2025, same as last year:
- Announcement of our participation (this blog post)
- Writing about the accepted projects
- Final results

I set the publish date to Monday, to get it out as soon as possible. We should have probably published this on Thursday 28. 2. already, when the organizations were announced, but being a few days late doesn't hurt that much.

[Rendered](https://github.com/Kobzol/blog.rust-lang.org/blob/gsoc-2025-1/posts/2025-03-03-Rust-participates-in-GSoC-2025.md)