### PR TITLE
Rollback rustup 1.28

### DIFF
--- a/posts/2025-03-02-Rustup-1.28.0.md
+++ b/posts/2025-03-02-Rustup-1.28.0.md
@@ -4,6 +4,12 @@ title: "Announcing Rustup 1.28.0"
 author: The Rustup Team
 ---
 
+# Rustup 1.28 has been rolled back
+
+See our new [post](/2025/03/04/Rustup-rollback.html) for details.
+
+---
+
 The rustup team is happy to announce the release of rustup version 1.28.0.
 [Rustup][install] is the recommended tool to install [Rust][rust], a programming language that is empowering everyone to build reliable and efficient software.
 

--- a/posts/2025-03-04-Rustup-rollback.md
+++ b/posts/2025-03-04-Rustup-rollback.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: "Rolling back Rustup 1.28.0"
+author: The Rustup Team
+---
+
+Due to unexpected impact to many CI systems not being ready for the new
+rustup-toolchain.toml behavior, we have rolled back the rustup [1.28.0] release.
+Rustup should self-update back to 1.27.1, and new installations will start to
+install 1.27.1 again.
+
+The Rustup team will follow up with a more concrete plan for rolling out the
+changes in 1.28, but we're mitigating impact through a rollback for now.
+
+[1.28.0]: /2025/03/02/Rustup-1.28.0.html


### PR DESCRIPTION
Just putting out in case we go this direction, otherwise will just close this.

[Rendered](https://github.com/Mark-Simulacrum/blog.rust-lang.org/blob/rustup-rollback/posts/2025-03-02-Rustup-1.28.0.md)