### PR TITLE
Fix incorrect link in RFL project goal description

### DIFF
--- a/posts/2025-03-03-Project-Goals-Feb-Update.md
+++ b/posts/2025-03-03-Project-Goals-Feb-Update.md
@@ -155,7 +155,7 @@ Next up:
 </div>
 <!-- markdown separator --> 
 
-**Why this goal?** This goal continues our work from 2024H2 in supporting the [experimental support for Rust development in the Linux kernel][RFL.com]. Whereas in 2024H2 we were focused on stabilizing required language features, our focus in 2025H1 is stabilizing compiler flags and tooling options. We will (1) implement [RFC #3716] which lays out a design for ABI-modifying flags; (2) take the first step towards stabilizing [`build-std`](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) by [creating a stable way to rebuild core with specific compiler options](./build-std.md); (3) extending rustdoc, clippy, and the compiler with features that extract metadata for integration into other build systems (in this case, the kernel&#x27;s build system).
+**Why this goal?** This goal continues our work from 2024H2 in supporting the [experimental support for Rust development in the Linux kernel][RFL.com]. Whereas in 2024H2 we were focused on stabilizing required language features, our focus in 2025H1 is stabilizing compiler flags and tooling options. We will (1) implement [RFC #3716] which lays out a design for ABI-modifying flags; (2) take the first step towards stabilizing [`build-std`](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) by [creating a stable way to rebuild core with specific compiler options](https://rust-lang.github.io/rust-project-goals/2025h1/build-std.html); (3) extending rustdoc, clippy, and the compiler with features that extract metadata for integration into other build systems (in this case, the kernel&#x27;s build system).
 
 [RFC #3716]: https://github.com/rust-lang/rfcs/pull/3716
 [RFL.com]: https://rust-for-linux.com/


### PR DESCRIPTION
This fixes the incorrect `./build-std.md` link in the February Project Goals Update post.

[Rendered](https://github.com/lqd/blog.rust-lang.org/blob/feb-goals-link/posts/2025-03-03-Project-Goals-Feb-Update.md)