### PR TITLE
Add post about hiring for program management

### DIFF
--- a/posts/inside-rust/hiring-for-program-management.md
+++ b/posts/inside-rust/hiring-for-program-management.md
@@ -1,0 +1,21 @@
++++
+layout = "post"
+date = 2025-03-18
+title = "Hiring for Rust program management"
+author = "TC"
+team = "the Edition & Goals teams <https://www.rust-lang.org/governance#teams>"
++++
+
+# Hiring for Rust program management
+
+Within the Rust Project, we've recently been doing more explicit program management.  This work supports our efforts on [Editions] and on [Project Goals], and in particular, it was critical for the recent successful release of [Rust 2024].  Better program management helps teams within the project better effect their priorities, and it helps ensure that contributors who are trying to get work done get the resources that they need.
+
+We've seen a lot of value from this work, and we want to expand our capacity for it.  In support of that, we're looking to hire one or more people to help in doing this work.  For details on the role and how to contact us about it, see this document:
+
+- [Role: Rust program manager](https://hackmd.io/VGauVVEyTN2M7pS6d9YTEA)
+
+If you know of someone who might be great for this, please encourage that person to reach out, and please reach out to us with your experiences in working with the person.
+
+[Editions]: https://doc.rust-lang.org/nightly/edition-guide/
+[Project Goals]: https://rust-lang.github.io/rust-project-goals/
+[Rust 2024]: ../../../../2025/02/20/Rust-1.85.0.html


### PR DESCRIPTION
We're looking to hire in support of program management for the Rust Project.  Let's add a post to let people know about this.

cc @ehuss @JoelMarcey @nikomatsakis

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/TC/20250318-pm-hire/posts/inside-rust/hiring-for-program-management.md)