### PR TITLE
Add snapshot tests in CI

### DIFF
--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -1,0 +1,23 @@
+name: Snapshot tests
+on:
+  pull_request
+
+env:
+  # renovate: datasource=github-tags depName=rust lookupName=rust-lang/rust
+  RUST_VERSION: 1.85.1
+
+jobs:
+  snapshot-tests:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.body, 'RUN_SNAPSHOT_TESTS')
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - run: rustup override set ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+
+      - run: git fetch --depth 2
+      - run: git checkout origin/master
+      - name: Generate good snapshots
+        run: INSTA_OUTPUT=none INSTA_UPDATE=always cargo test -- --include-ignored
+      - run: git checkout $GITHUB_SHA # merge of master+branch
+      - run: cargo test -- --include-ignored

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ release = true # (to be only used for official posts about Rust releases announc
 
 If you're making changes to how the site is generated, you may want to check the impact your changes have on the output.
 For this purpose, there is a setup to do snapshot testing over the entire output directory.
-It's not run in CI, because the number of snapshots is too large.
-But you can run these tests locally as needed.
+
+To run these tests in CI, add the string `RUN_SNAPSHOT_TESTS` to the PR description.
+You can also run these tests locally for a faster feedback cycle:
 
 - Make sure you have [cargo-insta](https://insta.rs/docs/quickstart/) installed.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ pub fn main() -> eyre::Result<()> {
 
 #[test]
 fn snapshot() {
-    std::fs::remove_dir_all(concat!(env!("CARGO_MANIFEST_DIR"), "/site")).unwrap();
+    let _ = std::fs::remove_dir_all(concat!(env!("CARGO_MANIFEST_DIR"), "/site"));
     main().unwrap();
     let timestamped_files = ["releases.json", "feed.xml"];
     let inexplicably_non_deterministic_files = ["images/2023-08-rust-survey-2022/experiences.png"];


### PR DESCRIPTION
closes #1511 

I confirmed that this new workflow works as expected on my fork:

- [workflow is skipped if PR descrption doesn't contain magic string](https://github.com/senekor/blog.rust-lang.org/pull/4)
- [CI passes on harmless change](https://github.com/senekor/blog.rust-lang.org/pull/2)
- [CI fails if output changes](https://github.com/senekor/blog.rust-lang.org/pull/3)