### PR TITLE
Remove unneeded 'root' variable from templates

### DIFF
--- a/src/blogs.rs
+++ b/src/blogs.rs
@@ -110,10 +110,6 @@ impl Blog {
         &self.prefix
     }
 
-    pub(crate) fn path_back_to_root(&self) -> PathBuf {
-        self.prefix.components().map(|_| Path::new("../")).collect()
-    }
-
     pub(crate) fn posts(&self) -> &[Post] {
         &self.posts
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,6 @@ impl Generator {
             "title": blog.index_title(),
             "blog": blog,
             "other_blogs": other_blogs,
-            "root": blog.path_back_to_root(),
         });
         let path = blog.prefix().join("index.html");
         self.render_template(&path, "index.html", data)?;
@@ -209,7 +208,6 @@ impl Generator {
             "title": format!("{} | {}", post.title, blog.title()),
             "blog": blog,
             "post": post,
-            "root": blog.path_back_to_root().join("../../../"),
         });
 
         let path = path.join(filename);

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,4 +1,4 @@
-{% macro footer(root) -%}
+{% macro footer() -%}
 <footer>
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <div class="row">
@@ -22,16 +22,16 @@
       <div class="four columns mt3 mt0-l">
         <h4>Social</h4>
         <div class="flex flex-row flex-wrap">
-          <a rel="me" href="https://social.rust-lang.org/@rust" target="_blank" rel="noopener" alt="mastodon link"><img src="{{root}}images/mastodon.svg" alt="mastodon logo" title="Mastodon"/></a>
-          <a href="https://twitter.com/rustlang" target="_blank" rel="noopener" alt="twitter link"><img src="{{root}}images/twitter.svg" alt="twitter logo" title="Twitter"/></a>
-          <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" target="_blank" rel="noopener" alt="youtube link"><img style="padding-top: 6px; padding-bottom:6px" src="{{root}}images/youtube.svg" alt="youtube logo" title="YouTube"/></a>
-          <a href="https://discord.gg/rust-lang" target="_blank" rel="noopener" alt="discord link"><img src="{{root}}images/discord.svg" alt="discord logo" title="Discord"/></a>
-          <a href="https://github.com/rust-lang" target="_blank" rel="noopener" alt="github link"><img src="{{root}}images/github.svg" alt="github logo" title="GitHub"/></a>
+          <a rel="me" href="https://social.rust-lang.org/@rust" target="_blank" rel="noopener" alt="mastodon link"><img src="/images/mastodon.svg" alt="mastodon logo" title="Mastodon"/></a>
+          <a href="https://twitter.com/rustlang" target="_blank" rel="noopener" alt="twitter link"><img src="/images/twitter.svg" alt="twitter logo" title="Twitter"/></a>
+          <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" target="_blank" rel="noopener" alt="youtube link"><img style="padding-top: 6px; padding-bottom:6px" src="/images/youtube.svg" alt="youtube logo" title="YouTube"/></a>
+          <a href="https://discord.gg/rust-lang" target="_blank" rel="noopener" alt="discord link"><img src="/images/discord.svg" alt="discord logo" title="Discord"/></a>
+          <a href="https://github.com/rust-lang" target="_blank" rel="noopener" alt="github link"><img src="/images/github.svg" alt="github logo" title="GitHub"/></a>
         </div>
         <h4 class="mt4 mb3">RSS</h4>
         <ul>
-          <li><a href="{{root}}feed.xml">Main Blog</a></li>
-          <li><a href="{{root}}inside-rust/feed.xml">"Inside Rust" Blog</a></li>
+          <li><a href="/feed.xml">Main Blog</a></li>
+          <li><a href="/inside-rust/feed.xml">"Inside Rust" Blog</a></li>
         </ul>
       </div>
 
@@ -44,5 +44,5 @@
 </footer>
 
 <!-- scripts -->
-<script src="{{root}}scripts/highlight.js"></script>
+<script src="/scripts/highlight.js"></script>
 {% endmacro %}

--- a/templates/headers.html
+++ b/templates/headers.html
@@ -1,4 +1,4 @@
-{% macro headers(root, title, blog) -%}
+{% macro headers(title, blog) -%}
  <!-- Twitter card -->
  <meta name="twitter:card" content="summary">
  <meta name="twitter:site" content="@rustlang">
@@ -15,23 +15,23 @@
 <meta property="og:locale" content="en_US" />
 
 <!-- styles -->
-<link rel="stylesheet" href="{{root}}styles/vendor.css"/>
-<link rel="stylesheet" href="{{root}}styles/fonts.css"/>
-<link rel="stylesheet" href="{{root}}styles/app.css"/>
-<link rel="stylesheet" href="{{root}}styles/highlight.css"/>
+<link rel="stylesheet" href="/styles/vendor.css"/>
+<link rel="stylesheet" href="/styles/fonts.css"/>
+<link rel="stylesheet" href="/styles/app.css"/>
+<link rel="stylesheet" href="/styles/highlight.css"/>
 
 <!-- stylesheet for user agents without js -->
 <noscript>
-    <link rel="stylesheet" href="{{root}}styles/noscript.css">
+    <link rel="stylesheet" href="/styles/noscript.css">
 </noscript>
 
 <!-- favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="{{root}}images/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="16x16" href="{{root}}images/favicon-16x16.png">
-<link rel="icon" type="image/png" sizes="32x32" href="{{root}}images/favicon-32x32.png">
-<link rel="icon" type="image/svg+xml" href="{{root}}images/favicon.svg">
-<link rel="manifest" href="{{root}}images/site.webmanifest">
-<link rel="mask-icon" href="{{root}}images/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="manifest" href="/images/site.webmanifest">
+<link rel="mask-icon" href="/images/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="msapplication-TileColor" content="#00aba9">
 <meta name="theme-color" content="#ffffff">
 
@@ -39,5 +39,5 @@
  <link type="application/atom+xml" rel="alternate" href="https://blog.rust-lang.org/{{blog.prefix}}feed.xml" title="{{blog.title}}" />
 
 <!-- theme switcher -->
-<script src="{{root}}scripts/theme-switch.js"></script>
+<script src="/scripts/theme-switch.js"></script>
 {% endmacro %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
       <p>
       <b>See also:</b>
       {%- for other in other_blogs %}
-              <a href="{{root}}{{other.url}}">{{other.link_text | escape_hbs}}</a>
+              <a href="/{{other.url}}">{{other.link_text | escape_hbs}}</a>
       {%- endfor %}
       </p>
     </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,11 +8,11 @@
     <title>{{ title | escape_hbs }}</title>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <meta name="description" content="Empowering everyone to build reliable and efficient software.">
-     {{ headers::headers(root=root, title=title, blog=blog) | indent(prefix="    ", blank=true) }}
+     {{ headers::headers(title=title, blog=blog) | indent(prefix="    ", blank=true) }}
   </head>
   <body>
-    {{ nav::nav(root=root, blog=blog) | indent(prefix="    ", blank=true) }}
+    {{ nav::nav(blog=blog) | indent(prefix="    ", blank=true) }}
     {%- block page %}{% endblock page %}
-    {{ footer::footer(root=root) | indent(prefix="    ", blank=true) }}
+    {{ footer::footer() | indent(prefix="    ", blank=true) }}
   </body>
 </html>

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -1,8 +1,8 @@
-{% macro nav(root, blog) -%}
+{% macro nav(blog) -%}
 <nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr4-ns">
   <div class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
-    <a href="{{root}}{{blog.prefix}}">
-      <img class="v-mid ml0-l rust-logo" alt="Rust Logo" src="{{root}}images/rust-logo-blk.svg">
+    <a href="/{{blog.prefix}}">
+      <img class="v-mid ml0-l rust-logo" alt="Rust Logo" src="/images/rust-logo-blk.svg">
       <span class="dib ml1 ml0-l">{{blog.title}}</span>
     </a>
   </div>
@@ -21,7 +21,7 @@
         <li class="theme-item" onclick="changeThemeTo('system');">System</li>
       </ul>
     </button>
-    <script src="{{root}}scripts/theme-switch-post.js"></script>
+    <script src="/scripts/theme-switch-post.js"></script>
   </ul>
 </nav>
 {% endmacro %}


### PR DESCRIPTION
This does change the output HTML, so snapshot tests are no use here.

Example change in output:
```diff
-    <script src="../../../../scripts/highlight.js"></script>
+    <script src="/scripts/highlight.js"></script>
```