### PR TITLE
Refactor blog manifests

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,10 +1,11 @@
++++
 title = "Rust Blog"
-index-title = "The Rust Programming Language Blog"
-link-text = "the main Rust blog"
+index_title = "The Rust Programming Language Blog"
+link_text = "the main Rust blog"
 description = "Empowering everyone to build reliable and efficient software."
-index-html = """
+index_html = """
 This is the <b>main Rust blog</b>. \
 <a href="https://www.rust-lang.org/governance/">Rust teams</a> \
 use this blog to announce major developments in the world of Rust."""
-maintained-by = "the Rust Teams"
-requires-team = false
+maintained_by = "the Rust Teams"
++++

--- a/content/inside-rust/_index.md
+++ b/content/inside-rust/_index.md
@@ -1,12 +1,13 @@
++++
 title = "Inside Rust Blog"
-index-title = 'The "Inside Rust" Blog'
-link-text = 'the "Inside Rust" blog'
+index_title = 'The "Inside Rust" Blog'
+link_text = 'the "Inside Rust" blog'
 description = "Want to follow along with Rust development? Curious how you might get involved? Take a look!"
-index-html = """
+index_html = """
 This is the <b>"Inside Rust"</b> blog. This blog is aimed at those who wish \
 to follow along with Rust development. The various \
 <a href="https://www.rust-lang.org/governance">Rust teams and working groups</a> \
 use this blog to post status updates, calls for help, and other \
 similar announcements."""
-maintained-by = "the Rust Teams"
-requires-team = false
+maintained_by = "the Rust Teams"
++++

--- a/src/posts.rs
+++ b/src/posts.rs
@@ -1,4 +1,3 @@
-use super::blogs::Manifest;
 use eyre::Context;
 use front_matter::FrontMatter;
 use regex::Regex;
@@ -30,7 +29,7 @@ pub struct Post {
 }
 
 impl Post {
-    pub(crate) fn open(path: &Path, manifest: &Manifest) -> eyre::Result<Self> {
+    pub(crate) fn open(path: &Path) -> eyre::Result<Self> {
         // yeah this might blow up, but it won't
         let filename = {
             let filename = path.file_name().unwrap().to_str().unwrap().to_string();
@@ -97,11 +96,6 @@ impl Post {
                 path.display()
             ),
         };
-
-        // Enforce extra conditions
-        if manifest.requires_team && team_string.is_none() {
-            panic!("blog post at path `{}` lacks team metadata", path.display());
-        }
 
         // If they supplied team, it should look like `team-text <team-url>`
         let (team, team_url) = team_string.map_or((None, None), |s| {


### PR DESCRIPTION
- The 'requires-team' key is set to false for both blogs, so this enforcement is never active -> delete the key.
- Snake case for the keys will lead to a smaller diff when migrating to zola.
- Using _index.md instead of blog.toml also moves us closer to zola.

RUN_SNAPSHOT_TESTS

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/senekor/yqvtlvllwupx/content/_index.md)