### PR TITLE
Add blog post for vision doc survey

### DIFF
--- a/content/vision-doc-survey.md
+++ b/content/vision-doc-survey.md
@@ -1,0 +1,68 @@
++++
+layout = "post"
+date = 2025-04-04
+title = "Help us create a vision for Rust's future"
+author = "Jack Huey"
+team = "Vision Doc Team <https://rust-lang.zulipchat.com/#narrow/channel/486265-vision-doc-2025>"
++++
+
+tl;dr: Please take our [survey here][survey]
+
+Rust turns 10 this year. It's a good time to step back and assess where we are at and to get aligned around where we should be going. Where is Rust succeeding at *empowering everyone to build reliable, efficient software* (as it says on our webpage)? Where are there opportunities to do better? To that end, we have taken on the [goal of authoring a Rust Vision RFC](https://rust-lang.github.io/rust-project-goals/2025h1/rust-vision-doc.html), with the first milestone being to prepare a draft for review at the upcoming Rust All Hands.
+
+### Goals and non-goals
+
+The vision RFC has **two goals**
+
+* to build a shared understanding of **where we are** and
+* to identify **where we should be going** at a high-level.
+
+The vision RFC also has a **non-goal**, which is to provide specific designs or feature recommendations. We'll have plenty of time to write detailed RFCs for that. The vision RFC will instead focus more on higher-level recommendations and on understanding what people need and want from Rust in various domains.
+
+We hope that by answering the above questions, we will then be able to evolve Rust with more confidence. It will also help Rust users (and would-be users) to understand what Rust is for and where it is going.
+
+### Community *and* technology are both in scope
+
+The scope of the vision RFC is not limited to the technical design of Rust. It will also cover topics like
+
+* the experience of open-source maintainers and contributors, both for the Rust project and for Rust crates;
+* integrating global Rust communities across the world;
+* and building momentum and core libraries for particular domains, like embedded, CLI, or gamedev.
+
+### Gathering data
+
+To answer the questions we have set, we need to gather data - we want to do our best *not* to speculate. This is going to come in two main formats:
+
+1) **A [survey]** about peoples' experiences with Rust (see below). Unlike the Annual Rust survey, the questions are open-ended and free-form, and cover somewhat different topics. This also us to gather a list of people to potentially interview:
+2) **Interviews** of people from various backgrounds and domains. In an ideal world, we would interview everyone who wants to be interviewed, but in reality we're going to try to interview as many people as we can to form a diverse and representative set.
+
+While we have some idea of who we want to talk to, we may be missing some! We're hoping that the survey will not only help us connect to the people that we want to talk to, but also potentially help us uncover people we haven't yet thought of. We are currently planning to talk to
+
+* Rust users, novice to expert;
+* Rust non-users (considering or not);
+* Companies using (or considering) Rust, from startup to enterprise;
+* Global or language-based Rust affinity groups;
+* Domain-specific groups;
+* Crate maintainers, big and small;
+* Project maintainers and contributors, volunteer or professional;
+* Rust Foundation staff.
+
+### Our roadmap and timeline
+
+Our current "end goal" is to author and open a vision RFC sometime during the second half of the year, likely in the fall. For this kind of RFC, though, the journey is really more important than the destination. We plan to author several drafts along the way and take feedback, both from Rust community members and from the public at large. The first milestone we are targeting is to prepare an **initial report for review at the [Rust All Hands](https://blog.rust-lang.org/inside-rust/2024/09/02/all-hands.html) in May**. To that end, the data gathering process starts *now* with the [survey][survey], but we intend to spend the month of April conducting interviews (and more after that).
+
+### How you can help
+
+For starters, fill out our [survey here][survey]. This survey has three sections
+
+1. To put the remaining responses into context, the survey asks a few demographic questions to allow us to ensure we are getting good representation across domains, experience, and backgrounds.
+1. It asks a series of questions about your experiences with Rust. As mentioned before, this survey is quite different from the Annual Rust survey. If you have experiences in the context of a company or organization, please feel free to share those (submitting this separately is best)!
+2. It asks for recommendations as to whom we ought to speak to. Please only recommend yourself or people/companies/groups for which you have a specific contact.
+
+*Note: **The first part of the survey will only be shared publicly in aggregate, the second may be made public directly, and the third section will not be made public.** For interviews, we can be more flexible with what information is shared publicly or not.*
+
+Of course, other than taking the survey, you can also *share* it with people. We *really* want to reach people that may not otherwise see it through our typical channels. So, even better if you can help us do that!
+
+Finally, if you are active in the Rust maintainer community, feel free to join the [`#vision-doc-2025`](https://rust-lang.zulipchat.com/#narrow/channel/486265-vision-doc-2025) channel on Zulip and say hello.
+
+[survey]: https://www.surveyhero.com/c/fuznhxp3


### PR DESCRIPTION
cc @nikomatsakis 

Team repo PR is currently failing CI, at some point I'll switch the team link to the vision doc repo.

[Rendered](https://github.com/jackh726/blog.rust-lang.org/blob/vision-doc/content/vision-doc-survey.md)