### PR TITLE
fix typo in Rust-1.86.0.md

### DIFF
--- a/content/Rust-1.86.0.md
+++ b/content/Rust-1.86.0.md
@@ -98,7 +98,7 @@ fn requires_avx2() {
 
 #[target_feature(enable = "avx2")]
 fn safe_callsite() {
-    // Calling `requires_avx2` here is safe as `bar`
+    // Calling `requires_avx2` here is safe as `safe_callsite`
     // requires the `avx2` feature itself.
     requires_avx2();
 }


### PR DESCRIPTION


[Rendered](https://github.com/slanterns/blog.rust-lang.org/blob/patch-1/content/Rust-1.86.0.md)