### PR TITLE
Fix CI workflow for snapshot testing

### DIFF
--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - name: Install Zola
+        run: cargo install --locked --git https://github.com/senekor/zola --rev 620bf3c46a39b41db30b1e91756a995bbff84d3a
 
       - run: git fetch --depth 2
       - run: git checkout origin/master


### PR DESCRIPTION
Zola must be installed for the snapshot tests to work.

RUN_SNAPSHOT_TESTS