### PR TITLE
Fix internal links

### DIFF
--- a/content/Rust-1.0-alpha2.md
+++ b/content/Rust-1.0-alpha2.md
@@ -9,7 +9,7 @@ aliases = ["2015/02/20/Rust-1.0-alpha2.html"]
 Today, we are happy to announce the release of Rust 1.0.0.alpha.2! Rust is a
 systems programming language pursuing the trifecta: safe, fast, and concurrent.
 
-In accordance with our [status report](../../../2015/02/13/Final-1.0-timeline.html)
+In accordance with our [status report](/2015/02/13/Final-1.0-timeline/)
 last week, this is a second alpha release, rather than a first beta release.
 The beta release will be six weeks from today, with the final coming six weeks
 after that.
@@ -18,7 +18,7 @@ We’ve managed to land almost all of the features previously expected for this
 cycle. **The big headline here is that all major API revisions are finished**:
 path and IO reform have landed. At this point, all modules shipping for 1.0 are
 in what we expect to be their final form, modulo minor tweaks during the alpha2
-cycle. See the [previous post](../../../2015/02/13/Final-1.0-timeline.html) for more
+cycle. See the [previous post](/2015/02/13/Final-1.0-timeline/) for more
 details.
 
 This coming release cycle is crucial to Rust, as this will be the last cycle

--- a/content/Rust-1.52.1.md
+++ b/content/Rust-1.52.1.md
@@ -125,7 +125,7 @@ done under the assumption that the new verification would ship in 1.53, not
 
 It turns out `verify-ich` was turned on in version 1.52.0, which was [released recently][].
 
-[released recently]: ../../../2021/05/06/Rust-1.52.0.html
+[released recently]: /2021/05/06/Rust-1.52.0/
 
 Today's new release, 1.52.1, works around the breakage caused by the newly added
 verification by temporarily changing the defaults in the Rust compiler to disable

--- a/content/Rust-1.53.0.md
+++ b/content/Rust-1.53.0.md
@@ -121,7 +121,7 @@ from a repository where the default branch is called `main`.
 
 ### Incremental Compilation remains off by default
 
-As previously discussed on the [blog post for version 1.52.1](../../../2021/05/10/Rust-1.52.1.html), incremental compilation has been turned off by default on the stable Rust release channel. The feature remains available on the beta and nightly release channels. For the 1.53.0 stable release, the method for reenabling incremental is unchanged from 1.52.1.
+As previously discussed on the [blog post for version 1.52.1](/2021/05/10/Rust-1.52.1/), incremental compilation has been turned off by default on the stable Rust release channel. The feature remains available on the beta and nightly release channels. For the 1.53.0 stable release, the method for reenabling incremental is unchanged from 1.52.1.
 
 ### Stabilized APIs
 

--- a/content/inside-rust-blog.md
+++ b/content/inside-rust-blog.md
@@ -11,5 +11,5 @@ updates by the various Rust teams and working groups. If you're
 interested in following along with the "nitty gritty" of Rust
 development, then you should take a look!
 
-[irb]: ../../../inside-rust/index.html
+[irb]: /inside-rust/
 

--- a/content/inside-rust/AsyncAwait-WG-Focus-Issues.md
+++ b/content/inside-rust/AsyncAwait-WG-Focus-Issues.md
@@ -26,7 +26,7 @@ them. This requires us to mix up how the [Async Foundations WG][wg] is
 operating.
 
 [wg]: https://rust-lang.github.io/compiler-team/working-groups/async-await/
-[blog]: ../../../../2019/09/30/Async-await-hits-beta.html
+[blog]: /2019/09/30/Async-await-hits-beta/
 
 ### Announcing: focus issues
 

--- a/content/inside-rust/hiring-for-program-management.md
+++ b/content/inside-rust/hiring-for-program-management.md
@@ -21,4 +21,4 @@ If you know of someone who might be great for this, please encourage that person
 
 [Editions]: https://doc.rust-lang.org/nightly/edition-guide/
 [Project Goals]: https://rust-lang.github.io/rust-project-goals/
-[Rust 2024]: ../../../../2025/02/20/Rust-1.85.0.html
+[Rust 2024]: /2025/02/20/Rust-1.85.0/

--- a/content/sparse-registry-testing.md
+++ b/content/sparse-registry-testing.md
@@ -10,7 +10,7 @@ team_url = "https://www.rust-lang.org/governance/teams/dev-tools#cargo"
 +++
 
 > Note: Sparse registry support has been stabilized for the 1.68 release.
-> See [Help test Cargo's new index protocol](../../../inside-rust/2023/01/30/cargo-sparse-protocol.html) for updated information.
+> See [Help test Cargo's new index protocol](/inside-rust/2023/01/30/cargo-sparse-protocol/) for updated information.
 
 The Cargo nightly [`sparse-registry`][sparse-registry] feature is ready for testing. The
 feature causes Cargo to access the crates.io index over HTTP, rather than git. It can


### PR DESCRIPTION
similar to the problem in #1574

I searched everything containing `../`, hopefully I didn't miss anything.

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/senekor/krqzmoprkuql/content/Rust-1.0-alpha2.md)