### PR TITLE
Validate front matter in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
 
       - run: cargo clippy --workspace -- -D warnings
       - run: cargo fmt --check --all
+      - run: cargo test --package front_matter
 
   build:
     runs-on: ubuntu-latest

--- a/front_matter/src/lib.rs
+++ b/front_matter/src/lib.rs
@@ -108,7 +108,6 @@ pub fn normalize(
             slug = slug.split_once('@').map(|(s, _)| s).unwrap_or(slug),
         );
     }
-    front_matter.aliases = vec![format!("{}.html", front_matter.path)];
 
     if front_matter.extra.team.is_some() ^ front_matter.extra.team_url.is_some() {
         bail!("extra.team and extra.team_url must always come in a pair");


### PR DESCRIPTION
The changes in the test itself make it more lenient, it won't error out on stuff like whitespace, comments or order of keys. Otherwise it would just be annoying for blog authors.