### PR TITLE
Add releases/... alias for release posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ path = "2015/03/15/some-slug"
 title = "Title of the blog post"
 authors = ["Blog post author (or on behalf of which team)"]
 description = "(optional)"
+aliases = ["releases/X.XX.X"] # only if the post is a release
 
 [extra] # optional section
 team = "Team Name" # if post is made on behalf of a team

--- a/content/Rust-1.0@1.md
+++ b/content/Rust-1.0@1.md
@@ -2,7 +2,10 @@
 path = "2015/05/15/Rust-1.0"
 title = "Announcing Rust 1.0"
 authors = ["The Rust Core Team"]
-aliases = ["2015/05/15/Rust-1.0.html"]
+aliases = [
+    "2015/05/15/Rust-1.0.html",
+    "releases/1.0.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.1.md
+++ b/content/Rust-1.1.md
@@ -2,7 +2,10 @@
 path = "2015/06/25/Rust-1.1"
 title = "Rust 1.1 stable, the Community Subteam, and RustCamp"
 authors = ["The Rust Core Team"]
-aliases = ["2015/06/25/Rust-1.1.html"]
+aliases = [
+    "2015/06/25/Rust-1.1.html",
+    "releases/1.1.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.10.md
+++ b/content/Rust-1.10.md
@@ -2,7 +2,10 @@
 path = "2016/07/07/Rust-1.10"
 title = "Announcing Rust 1.10"
 authors = ["The Rust Core Team"]
-aliases = ["2016/07/07/Rust-1.10.html"]
+aliases = [
+    "2016/07/07/Rust-1.10.html",
+    "releases/1.10.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.11.md
+++ b/content/Rust-1.11.md
@@ -2,7 +2,10 @@
 path = "2016/08/18/Rust-1.11"
 title = "Announcing Rust 1.11"
 authors = ["The Rust Core Team"]
-aliases = ["2016/08/18/Rust-1.11.html"]
+aliases = [
+    "2016/08/18/Rust-1.11.html",
+    "releases/1.11.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.12.1.md
+++ b/content/Rust-1.12.1.md
@@ -2,7 +2,10 @@
 path = "2016/10/20/Rust-1.12.1"
 title = "Announcing Rust 1.12.1"
 authors = ["The Rust Core Team"]
-aliases = ["2016/10/20/Rust-1.12.1.html"]
+aliases = [
+    "2016/10/20/Rust-1.12.1.html",
+    "releases/1.12.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.14.md
+++ b/content/Rust-1.14.md
@@ -2,7 +2,10 @@
 path = "2016/12/22/Rust-1.14"
 title = "Announcing Rust 1.14"
 authors = ["The Rust Core Team"]
-aliases = ["2016/12/22/Rust-1.14.html"]
+aliases = [
+    "2016/12/22/Rust-1.14.html",
+    "releases/1.14.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.15.1.md
+++ b/content/Rust-1.15.1.md
@@ -2,7 +2,10 @@
 path = "2017/02/09/Rust-1.15.1"
 title = "Announcing Rust 1.15.1"
 authors = ["The Rust Core Team"]
-aliases = ["2017/02/09/Rust-1.15.1.html"]
+aliases = [
+    "2017/02/09/Rust-1.15.1.html",
+    "releases/1.15.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.15.md
+++ b/content/Rust-1.15.md
@@ -2,7 +2,10 @@
 path = "2017/02/02/Rust-1.15"
 title = "Announcing Rust 1.15"
 authors = ["The Rust Core Team"]
-aliases = ["2017/02/02/Rust-1.15.html"]
+aliases = [
+    "2017/02/02/Rust-1.15.html",
+    "releases/1.15.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.16.md
+++ b/content/Rust-1.16.md
@@ -2,7 +2,10 @@
 path = "2017/03/16/Rust-1.16"
 title = "Announcing Rust 1.16"
 authors = ["The Rust Core Team"]
-aliases = ["2017/03/16/Rust-1.16.html"]
+aliases = [
+    "2017/03/16/Rust-1.16.html",
+    "releases/1.16.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.17.md
+++ b/content/Rust-1.17.md
@@ -2,7 +2,10 @@
 path = "2017/04/27/Rust-1.17"
 title = "Announcing Rust 1.17"
 authors = ["The Rust Core Team"]
-aliases = ["2017/04/27/Rust-1.17.html"]
+aliases = [
+    "2017/04/27/Rust-1.17.html",
+    "releases/1.17.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.18.md
+++ b/content/Rust-1.18.md
@@ -2,7 +2,10 @@
 path = "2017/06/08/Rust-1.18"
 title = "Announcing Rust 1.18"
 authors = ["The Rust Core Team"]
-aliases = ["2017/06/08/Rust-1.18.html"]
+aliases = [
+    "2017/06/08/Rust-1.18.html",
+    "releases/1.18.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.19.md
+++ b/content/Rust-1.19.md
@@ -2,7 +2,10 @@
 path = "2017/07/20/Rust-1.19"
 title = "Announcing Rust 1.19"
 authors = ["The Rust Core Team"]
-aliases = ["2017/07/20/Rust-1.19.html"]
+aliases = [
+    "2017/07/20/Rust-1.19.html",
+    "releases/1.19.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.2.md
+++ b/content/Rust-1.2.md
@@ -2,7 +2,10 @@
 path = "2015/08/06/Rust-1.2"
 title = "Announcing Rust 1.2"
 authors = ["The Rust Core Team"]
-aliases = ["2015/08/06/Rust-1.2.html"]
+aliases = [
+    "2015/08/06/Rust-1.2.html",
+    "releases/1.2.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.20.md
+++ b/content/Rust-1.20.md
@@ -2,7 +2,10 @@
 path = "2017/08/31/Rust-1.20"
 title = "Announcing Rust 1.20"
 authors = ["The Rust Core Team"]
-aliases = ["2017/08/31/Rust-1.20.html"]
+aliases = [
+    "2017/08/31/Rust-1.20.html",
+    "releases/1.20.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.21.md
+++ b/content/Rust-1.21.md
@@ -2,7 +2,10 @@
 path = "2017/10/12/Rust-1.21"
 title = "Announcing Rust 1.21"
 authors = ["The Rust Core Team"]
-aliases = ["2017/10/12/Rust-1.21.html"]
+aliases = [
+    "2017/10/12/Rust-1.21.html",
+    "releases/1.21.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.22.md
+++ b/content/Rust-1.22.md
@@ -2,7 +2,10 @@
 path = "2017/11/22/Rust-1.22"
 title = "Announcing Rust 1.22 (and 1.22.1)"
 authors = ["The Rust Core Team"]
-aliases = ["2017/11/22/Rust-1.22.html"]
+aliases = [
+    "2017/11/22/Rust-1.22.html",
+    "releases/1.22.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.23.md
+++ b/content/Rust-1.23.md
@@ -2,7 +2,10 @@
 path = "2018/01/04/Rust-1.23"
 title = "Announcing Rust 1.23"
 authors = ["The Rust Core Team"]
-aliases = ["2018/01/04/Rust-1.23.html"]
+aliases = [
+    "2018/01/04/Rust-1.23.html",
+    "releases/1.23.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.24.1.md
+++ b/content/Rust-1.24.1.md
@@ -2,7 +2,10 @@
 path = "2018/03/01/Rust-1.24.1"
 title = "Announcing Rust 1.24.1"
 authors = ["The Rust Core Team"]
-aliases = ["2018/03/01/Rust-1.24.1.html"]
+aliases = [
+    "2018/03/01/Rust-1.24.1.html",
+    "releases/1.24.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.24.md
+++ b/content/Rust-1.24.md
@@ -2,7 +2,10 @@
 path = "2018/02/15/Rust-1.24"
 title = "Announcing Rust 1.24"
 authors = ["The Rust Core Team"]
-aliases = ["2018/02/15/Rust-1.24.html"]
+aliases = [
+    "2018/02/15/Rust-1.24.html",
+    "releases/1.24.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.25.md
+++ b/content/Rust-1.25.md
@@ -2,7 +2,10 @@
 path = "2018/03/29/Rust-1.25"
 title = "Announcing Rust 1.25"
 authors = ["The Rust Core Team"]
-aliases = ["2018/03/29/Rust-1.25.html"]
+aliases = [
+    "2018/03/29/Rust-1.25.html",
+    "releases/1.25.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.26.1.md
+++ b/content/Rust-1.26.1.md
@@ -2,7 +2,10 @@
 path = "2018/05/29/Rust-1.26.1"
 title = "Announcing Rust 1.26.1"
 authors = ["The Rust Core Team"]
-aliases = ["2018/05/29/Rust-1.26.1.html"]
+aliases = [
+    "2018/05/29/Rust-1.26.1.html",
+    "releases/1.26.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.26.2.md
+++ b/content/Rust-1.26.2.md
@@ -2,7 +2,10 @@
 path = "2018/06/05/Rust-1.26.2"
 title = "Announcing Rust 1.26.2"
 authors = ["The Rust Core Team"]
-aliases = ["2018/06/05/Rust-1.26.2.html"]
+aliases = [
+    "2018/06/05/Rust-1.26.2.html",
+    "releases/1.26.2",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.26.md
+++ b/content/Rust-1.26.md
@@ -2,7 +2,10 @@
 path = "2018/05/10/Rust-1.26"
 title = "Announcing Rust 1.26"
 authors = ["The Rust Core Team"]
-aliases = ["2018/05/10/Rust-1.26.html"]
+aliases = [
+    "2018/05/10/Rust-1.26.html",
+    "releases/1.26.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.27.1.md
+++ b/content/Rust-1.27.1.md
@@ -2,7 +2,10 @@
 path = "2018/07/10/Rust-1.27.1"
 title = "Announcing Rust 1.27.1"
 authors = ["The Rust Core Team"]
-aliases = ["2018/07/10/Rust-1.27.1.html"]
+aliases = [
+    "2018/07/10/Rust-1.27.1.html",
+    "releases/1.27.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.27.2.md
+++ b/content/Rust-1.27.2.md
@@ -2,7 +2,10 @@
 path = "2018/07/20/Rust-1.27.2"
 title = "Announcing Rust 1.27.2"
 authors = ["The Rust Core Team"]
-aliases = ["2018/07/20/Rust-1.27.2.html"]
+aliases = [
+    "2018/07/20/Rust-1.27.2.html",
+    "releases/1.27.2",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.27.md
+++ b/content/Rust-1.27.md
@@ -2,7 +2,10 @@
 path = "2018/06/21/Rust-1.27"
 title = "Announcing Rust 1.27"
 authors = ["The Rust Core Team"]
-aliases = ["2018/06/21/Rust-1.27.html"]
+aliases = [
+    "2018/06/21/Rust-1.27.html",
+    "releases/1.27.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.28.md
+++ b/content/Rust-1.28.md
@@ -2,7 +2,10 @@
 path = "2018/08/02/Rust-1.28"
 title = "Announcing Rust 1.28"
 authors = ["The Rust Core Team"]
-aliases = ["2018/08/02/Rust-1.28.html"]
+aliases = [
+    "2018/08/02/Rust-1.28.html",
+    "releases/1.28.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.29.1.md
+++ b/content/Rust-1.29.1.md
@@ -2,7 +2,10 @@
 path = "2018/09/25/Rust-1.29.1"
 title = "Announcing Rust 1.29.1"
 authors = ["The Rust Core Team"]
-aliases = ["2018/09/25/Rust-1.29.1.html"]
+aliases = [
+    "2018/09/25/Rust-1.29.1.html",
+    "releases/1.29.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.29.2.md
+++ b/content/Rust-1.29.2.md
@@ -2,7 +2,10 @@
 path = "2018/10/12/Rust-1.29.2"
 title = "Announcing Rust 1.29.2"
 authors = ["The Rust Release Team"]
-aliases = ["2018/10/12/Rust-1.29.2.html"]
+aliases = [
+    "2018/10/12/Rust-1.29.2.html",
+    "releases/1.29.2",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.29.md
+++ b/content/Rust-1.29.md
@@ -2,7 +2,10 @@
 path = "2018/09/13/Rust-1.29"
 title = "Announcing Rust 1.29"
 authors = ["The Rust Core Team"]
-aliases = ["2018/09/13/Rust-1.29.html"]
+aliases = [
+    "2018/09/13/Rust-1.29.html",
+    "releases/1.29.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.3.md
+++ b/content/Rust-1.3.md
@@ -2,7 +2,10 @@
 path = "2015/09/17/Rust-1.3"
 title = "Announcing Rust 1.3"
 authors = ["The Rust Core Team"]
-aliases = ["2015/09/17/Rust-1.3.html"]
+aliases = [
+    "2015/09/17/Rust-1.3.html",
+    "releases/1.3.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.30.1.md
+++ b/content/Rust-1.30.1.md
@@ -2,7 +2,10 @@
 path = "2018/11/08/Rust-1.30.1"
 title = "Announcing Rust 1.30.1"
 authors = ["The Rust Release Team"]
-aliases = ["2018/11/08/Rust-1.30.1.html"]
+aliases = [
+    "2018/11/08/Rust-1.30.1.html",
+    "releases/1.30.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.31-and-rust-2018.md
+++ b/content/Rust-1.31-and-rust-2018.md
@@ -2,7 +2,10 @@
 path = "2018/12/06/Rust-1.31-and-rust-2018"
 title = "Announcing Rust 1.31 and Rust 2018"
 authors = ["The Rust Core Team"]
-aliases = ["2018/12/06/Rust-1.31-and-rust-2018.html"]
+aliases = [
+    "2018/12/06/Rust-1.31-and-rust-2018.html",
+    "releases/1.31.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.31.1.md
+++ b/content/Rust-1.31.1.md
@@ -2,7 +2,10 @@
 path = "2018/12/20/Rust-1.31.1"
 title = "Announcing Rust 1.31.1"
 authors = ["The Rust Release Team"]
-aliases = ["2018/12/20/Rust-1.31.1.html"]
+aliases = [
+    "2018/12/20/Rust-1.31.1.html",
+    "releases/1.31.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.32.0.md
+++ b/content/Rust-1.32.0.md
@@ -2,7 +2,10 @@
 path = "2019/01/17/Rust-1.32.0"
 title = "Announcing Rust 1.32.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/01/17/Rust-1.32.0.html"]
+aliases = [
+    "2019/01/17/Rust-1.32.0.html",
+    "releases/1.32.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.33.0.md
+++ b/content/Rust-1.33.0.md
@@ -2,7 +2,10 @@
 path = "2019/02/28/Rust-1.33.0"
 title = "Announcing Rust 1.33.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/02/28/Rust-1.33.0.html"]
+aliases = [
+    "2019/02/28/Rust-1.33.0.html",
+    "releases/1.33.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.34.0.md
+++ b/content/Rust-1.34.0.md
@@ -2,7 +2,10 @@
 path = "2019/04/11/Rust-1.34.0"
 title = "Announcing Rust 1.34.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/04/11/Rust-1.34.0.html"]
+aliases = [
+    "2019/04/11/Rust-1.34.0.html",
+    "releases/1.34.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.34.1.md
+++ b/content/Rust-1.34.1.md
@@ -2,7 +2,10 @@
 path = "2019/04/25/Rust-1.34.1"
 title = "Announcing Rust 1.34.1"
 authors = ["The Rust Release Team"]
-aliases = ["2019/04/25/Rust-1.34.1.html"]
+aliases = [
+    "2019/04/25/Rust-1.34.1.html",
+    "releases/1.34.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.34.2.md
+++ b/content/Rust-1.34.2.md
@@ -2,7 +2,10 @@
 path = "2019/05/14/Rust-1.34.2"
 title = "Announcing Rust 1.34.2"
 authors = ["The Rust Release Team"]
-aliases = ["2019/05/14/Rust-1.34.2.html"]
+aliases = [
+    "2019/05/14/Rust-1.34.2.html",
+    "releases/1.34.2",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.35.0.md
+++ b/content/Rust-1.35.0.md
@@ -2,7 +2,10 @@
 path = "2019/05/23/Rust-1.35.0"
 title = "Announcing Rust 1.35.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/05/23/Rust-1.35.0.html"]
+aliases = [
+    "2019/05/23/Rust-1.35.0.html",
+    "releases/1.35.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.36.0.md
+++ b/content/Rust-1.36.0.md
@@ -2,7 +2,10 @@
 path = "2019/07/04/Rust-1.36.0"
 title = "Announcing Rust 1.36.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/07/04/Rust-1.36.0.html"]
+aliases = [
+    "2019/07/04/Rust-1.36.0.html",
+    "releases/1.36.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.37.0.md
+++ b/content/Rust-1.37.0.md
@@ -2,7 +2,10 @@
 path = "2019/08/15/Rust-1.37.0"
 title = "Announcing Rust 1.37.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/08/15/Rust-1.37.0.html"]
+aliases = [
+    "2019/08/15/Rust-1.37.0.html",
+    "releases/1.37.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.38.0.md
+++ b/content/Rust-1.38.0.md
@@ -2,7 +2,10 @@
 path = "2019/09/26/Rust-1.38.0"
 title = "Announcing Rust 1.38.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/09/26/Rust-1.38.0.html"]
+aliases = [
+    "2019/09/26/Rust-1.38.0.html",
+    "releases/1.38.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.39.0.md
+++ b/content/Rust-1.39.0.md
@@ -2,7 +2,10 @@
 path = "2019/11/07/Rust-1.39.0"
 title = "Announcing Rust 1.39.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/11/07/Rust-1.39.0.html"]
+aliases = [
+    "2019/11/07/Rust-1.39.0.html",
+    "releases/1.39.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.4.md
+++ b/content/Rust-1.4.md
@@ -2,7 +2,10 @@
 path = "2015/10/29/Rust-1.4"
 title = "Announcing Rust 1.4"
 authors = ["The Rust Core Team"]
-aliases = ["2015/10/29/Rust-1.4.html"]
+aliases = [
+    "2015/10/29/Rust-1.4.html",
+    "releases/1.4.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.40.0.md
+++ b/content/Rust-1.40.0.md
@@ -2,7 +2,10 @@
 path = "2019/12/19/Rust-1.40.0"
 title = "Announcing Rust 1.40.0"
 authors = ["The Rust Release Team"]
-aliases = ["2019/12/19/Rust-1.40.0.html"]
+aliases = [
+    "2019/12/19/Rust-1.40.0.html",
+    "releases/1.40.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.41.0.md
+++ b/content/Rust-1.41.0.md
@@ -2,7 +2,10 @@
 path = "2020/01/30/Rust-1.41.0"
 title = "Announcing Rust 1.41.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/01/30/Rust-1.41.0.html"]
+aliases = [
+    "2020/01/30/Rust-1.41.0.html",
+    "releases/1.41.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.41.1.md
+++ b/content/Rust-1.41.1.md
@@ -2,7 +2,10 @@
 path = "2020/02/27/Rust-1.41.1"
 title = "Announcing Rust 1.41.1"
 authors = ["The Rust Release Team"]
-aliases = ["2020/02/27/Rust-1.41.1.html"]
+aliases = [
+    "2020/02/27/Rust-1.41.1.html",
+    "releases/1.41.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.42.md
+++ b/content/Rust-1.42.md
@@ -2,7 +2,10 @@
 path = "2020/03/12/Rust-1.42"
 title = "Announcing Rust 1.42.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/03/12/Rust-1.42.html"]
+aliases = [
+    "2020/03/12/Rust-1.42.html",
+    "releases/1.42.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.43.0.md
+++ b/content/Rust-1.43.0.md
@@ -2,7 +2,10 @@
 path = "2020/04/23/Rust-1.43.0"
 title = "Announcing Rust 1.43.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/04/23/Rust-1.43.0.html"]
+aliases = [
+    "2020/04/23/Rust-1.43.0.html",
+    "releases/1.43.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.44.0.md
+++ b/content/Rust-1.44.0.md
@@ -2,7 +2,10 @@
 path = "2020/06/04/Rust-1.44.0"
 title = "Announcing Rust 1.44.0"
 authors = ["The Rust Core Team"]
-aliases = ["2020/06/04/Rust-1.44.0.html"]
+aliases = [
+    "2020/06/04/Rust-1.44.0.html",
+    "releases/1.44.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.45.0.md
+++ b/content/Rust-1.45.0.md
@@ -2,7 +2,10 @@
 path = "2020/07/16/Rust-1.45.0"
 title = "Announcing Rust 1.45.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/07/16/Rust-1.45.0.html"]
+aliases = [
+    "2020/07/16/Rust-1.45.0.html",
+    "releases/1.45.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.45.1.md
+++ b/content/Rust-1.45.1.md
@@ -2,7 +2,10 @@
 path = "2020/07/30/Rust-1.45.1"
 title = "Announcing Rust 1.45.1"
 authors = ["The Rust Release Team"]
-aliases = ["2020/07/30/Rust-1.45.1.html"]
+aliases = [
+    "2020/07/30/Rust-1.45.1.html",
+    "releases/1.45.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.45.2.md
+++ b/content/Rust-1.45.2.md
@@ -2,7 +2,10 @@
 path = "2020/08/03/Rust-1.45.2"
 title = "Announcing Rust 1.45.2"
 authors = ["The Rust Release Team"]
-aliases = ["2020/08/03/Rust-1.45.2.html"]
+aliases = [
+    "2020/08/03/Rust-1.45.2.html",
+    "releases/1.45.2",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.46.0.md
+++ b/content/Rust-1.46.0.md
@@ -2,7 +2,10 @@
 path = "2020/08/27/Rust-1.46.0"
 title = "Announcing Rust 1.46.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/08/27/Rust-1.46.0.html"]
+aliases = [
+    "2020/08/27/Rust-1.46.0.html",
+    "releases/1.46.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.47.md
+++ b/content/Rust-1.47.md
@@ -2,7 +2,10 @@
 path = "2020/10/08/Rust-1.47"
 title = "Announcing Rust 1.47.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/10/08/Rust-1.47.html"]
+aliases = [
+    "2020/10/08/Rust-1.47.html",
+    "releases/1.47.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.48.md
+++ b/content/Rust-1.48.md
@@ -2,7 +2,10 @@
 path = "2020/11/19/Rust-1.48"
 title = "Announcing Rust 1.48.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/11/19/Rust-1.48.html"]
+aliases = [
+    "2020/11/19/Rust-1.48.html",
+    "releases/1.48.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.49.0.md
+++ b/content/Rust-1.49.0.md
@@ -2,7 +2,10 @@
 path = "2020/12/31/Rust-1.49.0"
 title = "Announcing Rust 1.49.0"
 authors = ["The Rust Release Team"]
-aliases = ["2020/12/31/Rust-1.49.0.html"]
+aliases = [
+    "2020/12/31/Rust-1.49.0.html",
+    "releases/1.49.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.5.md
+++ b/content/Rust-1.5.md
@@ -2,7 +2,10 @@
 path = "2015/12/10/Rust-1.5"
 title = "Announcing Rust 1.5"
 authors = ["The Rust Core Team"]
-aliases = ["2015/12/10/Rust-1.5.html"]
+aliases = [
+    "2015/12/10/Rust-1.5.html",
+    "releases/1.5.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.50.0.md
+++ b/content/Rust-1.50.0.md
@@ -2,7 +2,10 @@
 path = "2021/02/11/Rust-1.50.0"
 title = "Announcing Rust 1.50.0"
 authors = ["The Rust Release Team"]
-aliases = ["2021/02/11/Rust-1.50.0.html"]
+aliases = [
+    "2021/02/11/Rust-1.50.0.html",
+    "releases/1.50.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.51.0.md
+++ b/content/Rust-1.51.0.md
@@ -2,7 +2,10 @@
 path = "2021/03/25/Rust-1.51.0"
 title = "Announcing Rust 1.51.0"
 authors = ["The Rust Release Team"]
-aliases = ["2021/03/25/Rust-1.51.0.html"]
+aliases = [
+    "2021/03/25/Rust-1.51.0.html",
+    "releases/1.51.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.52.0.md
+++ b/content/Rust-1.52.0.md
@@ -2,7 +2,10 @@
 path = "2021/05/06/Rust-1.52.0"
 title = "Announcing Rust 1.52.0"
 authors = ["The Rust Release Team"]
-aliases = ["2021/05/06/Rust-1.52.0.html"]
+aliases = [
+    "2021/05/06/Rust-1.52.0.html",
+    "releases/1.52.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.52.1.md
+++ b/content/Rust-1.52.1.md
@@ -2,7 +2,10 @@
 path = "2021/05/10/Rust-1.52.1"
 title = "Announcing Rust 1.52.1"
 authors = ["Felix Klock, Mark Rousskov"]
-aliases = ["2021/05/10/Rust-1.52.1.html"]
+aliases = [
+    "2021/05/10/Rust-1.52.1.html",
+    "releases/1.52.1",
+]
 
 [extra]
 team = "the compiler team"

--- a/content/Rust-1.53.0.md
+++ b/content/Rust-1.53.0.md
@@ -2,7 +2,10 @@
 path = "2021/06/17/Rust-1.53.0"
 title = "Announcing Rust 1.53.0"
 authors = ["The Rust Release Team"]
-aliases = ["2021/06/17/Rust-1.53.0.html"]
+aliases = [
+    "2021/06/17/Rust-1.53.0.html",
+    "releases/1.53.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.54.0.md
+++ b/content/Rust-1.54.0.md
@@ -2,7 +2,10 @@
 path = "2021/07/29/Rust-1.54.0"
 title = "Announcing Rust 1.54.0"
 authors = ["The Rust Release Team"]
-aliases = ["2021/07/29/Rust-1.54.0.html"]
+aliases = [
+    "2021/07/29/Rust-1.54.0.html",
+    "releases/1.54.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.55.0.md
+++ b/content/Rust-1.55.0.md
@@ -2,7 +2,10 @@
 path = "2021/09/09/Rust-1.55.0"
 title = "Announcing Rust 1.55.0"
 authors = ["The Rust Release Team"]
-aliases = ["2021/09/09/Rust-1.55.0.html"]
+aliases = [
+    "2021/09/09/Rust-1.55.0.html",
+    "releases/1.55.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.56.0.md
+++ b/content/Rust-1.56.0.md
@@ -2,7 +2,10 @@
 path = "2021/10/21/Rust-1.56.0"
 title = "Announcing Rust 1.56.0 and Rust 2021"
 authors = ["The Rust Release Team"]
-aliases = ["2021/10/21/Rust-1.56.0.html"]
+aliases = [
+    "2021/10/21/Rust-1.56.0.html",
+    "releases/1.56.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.56.1.md
+++ b/content/Rust-1.56.1.md
@@ -2,7 +2,10 @@
 path = "2021/11/01/Rust-1.56.1"
 title = "Announcing Rust 1.56.1"
 authors = ["The Rust Security Response WG"]
-aliases = ["2021/11/01/Rust-1.56.1.html"]
+aliases = [
+    "2021/11/01/Rust-1.56.1.html",
+    "releases/1.56.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.57.0.md
+++ b/content/Rust-1.57.0.md
@@ -2,7 +2,10 @@
 path = "2021/12/02/Rust-1.57.0"
 title = "Announcing Rust 1.57.0"
 authors = ["The Rust Release Team"]
-aliases = ["2021/12/02/Rust-1.57.0.html"]
+aliases = [
+    "2021/12/02/Rust-1.57.0.html",
+    "releases/1.57.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.58.0.md
+++ b/content/Rust-1.58.0.md
@@ -2,7 +2,10 @@
 path = "2022/01/13/Rust-1.58.0"
 title = "Announcing Rust 1.58.0"
 authors = ["The Rust Release Team"]
-aliases = ["2022/01/13/Rust-1.58.0.html"]
+aliases = [
+    "2022/01/13/Rust-1.58.0.html",
+    "releases/1.58.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.58.1.md
+++ b/content/Rust-1.58.1.md
@@ -2,7 +2,10 @@
 path = "2022/01/20/Rust-1.58.1"
 title = "Announcing Rust 1.58.1"
 authors = ["The Rust Release Team"]
-aliases = ["2022/01/20/Rust-1.58.1.html"]
+aliases = [
+    "2022/01/20/Rust-1.58.1.html",
+    "releases/1.58.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.59.0.md
+++ b/content/Rust-1.59.0.md
@@ -2,7 +2,10 @@
 path = "2022/02/24/Rust-1.59.0"
 title = "Announcing Rust 1.59.0"
 authors = ["The Rust Team"]
-aliases = ["2022/02/24/Rust-1.59.0.html"]
+aliases = [
+    "2022/02/24/Rust-1.59.0.html",
+    "releases/1.59.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.6.md
+++ b/content/Rust-1.6.md
@@ -2,7 +2,10 @@
 path = "2016/01/21/Rust-1.6"
 title = "Announcing Rust 1.6"
 authors = ["The Rust Core Team"]
-aliases = ["2016/01/21/Rust-1.6.html"]
+aliases = [
+    "2016/01/21/Rust-1.6.html",
+    "releases/1.6.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.61.0.md
+++ b/content/Rust-1.61.0.md
@@ -2,7 +2,10 @@
 path = "2022/05/19/Rust-1.61.0"
 title = "Announcing Rust 1.61.0"
 authors = ["The Rust Release Team"]
-aliases = ["2022/05/19/Rust-1.61.0.html"]
+aliases = [
+    "2022/05/19/Rust-1.61.0.html",
+    "releases/1.61.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.62.0.md
+++ b/content/Rust-1.62.0.md
@@ -2,7 +2,10 @@
 path = "2022/06/30/Rust-1.62.0"
 title = "Announcing Rust 1.62.0"
 authors = ["The Rust Release Team"]
-aliases = ["2022/06/30/Rust-1.62.0.html"]
+aliases = [
+    "2022/06/30/Rust-1.62.0.html",
+    "releases/1.62.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.62.1.md
+++ b/content/Rust-1.62.1.md
@@ -2,7 +2,10 @@
 path = "2022/07/19/Rust-1.62.1"
 title = "Announcing Rust 1.62.1"
 authors = ["The Rust Release Team"]
-aliases = ["2022/07/19/Rust-1.62.1.html"]
+aliases = [
+    "2022/07/19/Rust-1.62.1.html",
+    "releases/1.62.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.63.0.md
+++ b/content/Rust-1.63.0.md
@@ -2,7 +2,10 @@
 path = "2022/08/11/Rust-1.63.0"
 title = "Announcing Rust 1.63.0"
 authors = ["The Rust Release Team"]
-aliases = ["2022/08/11/Rust-1.63.0.html"]
+aliases = [
+    "2022/08/11/Rust-1.63.0.html",
+    "releases/1.63.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.64.0.md
+++ b/content/Rust-1.64.0.md
@@ -2,7 +2,10 @@
 path = "2022/09/22/Rust-1.64.0"
 title = "Announcing Rust 1.64.0"
 authors = ["The Rust Release Team"]
-aliases = ["2022/09/22/Rust-1.64.0.html"]
+aliases = [
+    "2022/09/22/Rust-1.64.0.html",
+    "releases/1.64.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.65.0.md
+++ b/content/Rust-1.65.0.md
@@ -2,7 +2,10 @@
 path = "2022/11/03/Rust-1.65.0"
 title = "Announcing Rust 1.65.0"
 authors = ["The Rust Release Team"]
-aliases = ["2022/11/03/Rust-1.65.0.html"]
+aliases = [
+    "2022/11/03/Rust-1.65.0.html",
+    "releases/1.65.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.66.0.md
+++ b/content/Rust-1.66.0.md
@@ -2,7 +2,10 @@
 path = "2022/12/15/Rust-1.66.0"
 title = "Announcing Rust 1.66.0"
 authors = ["The Rust Release Team"]
-aliases = ["2022/12/15/Rust-1.66.0.html"]
+aliases = [
+    "2022/12/15/Rust-1.66.0.html",
+    "releases/1.66.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.66.1.md
+++ b/content/Rust-1.66.1.md
@@ -2,7 +2,10 @@
 path = "2023/01/10/Rust-1.66.1"
 title = "Announcing Rust 1.66.1"
 authors = ["The Rust Release Team"]
-aliases = ["2023/01/10/Rust-1.66.1.html"]
+aliases = [
+    "2023/01/10/Rust-1.66.1.html",
+    "releases/1.66.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.67.0.md
+++ b/content/Rust-1.67.0.md
@@ -2,7 +2,10 @@
 path = "2023/01/26/Rust-1.67.0"
 title = "Announcing Rust 1.67.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/01/26/Rust-1.67.0.html"]
+aliases = [
+    "2023/01/26/Rust-1.67.0.html",
+    "releases/1.67.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.67.1.md
+++ b/content/Rust-1.67.1.md
@@ -2,7 +2,10 @@
 path = "2023/02/09/Rust-1.67.1"
 title = "Announcing Rust 1.67.1"
 authors = ["The Rust Release Team"]
-aliases = ["2023/02/09/Rust-1.67.1.html"]
+aliases = [
+    "2023/02/09/Rust-1.67.1.html",
+    "releases/1.67.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.68.0.md
+++ b/content/Rust-1.68.0.md
@@ -2,7 +2,10 @@
 path = "2023/03/09/Rust-1.68.0"
 title = "Announcing Rust 1.68.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/03/09/Rust-1.68.0.html"]
+aliases = [
+    "2023/03/09/Rust-1.68.0.html",
+    "releases/1.68.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.68.1.md
+++ b/content/Rust-1.68.1.md
@@ -2,7 +2,10 @@
 path = "2023/03/23/Rust-1.68.1"
 title = "Announcing Rust 1.68.1"
 authors = ["The Rust Release Team"]
-aliases = ["2023/03/23/Rust-1.68.1.html"]
+aliases = [
+    "2023/03/23/Rust-1.68.1.html",
+    "releases/1.68.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.68.2.md
+++ b/content/Rust-1.68.2.md
@@ -2,7 +2,10 @@
 path = "2023/03/28/Rust-1.68.2"
 title = "Announcing Rust 1.68.2"
 authors = ["The Rust Release Team"]
-aliases = ["2023/03/28/Rust-1.68.2.html"]
+aliases = [
+    "2023/03/28/Rust-1.68.2.html",
+    "releases/1.68.2",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.69.0.md
+++ b/content/Rust-1.69.0.md
@@ -2,7 +2,10 @@
 path = "2023/04/20/Rust-1.69.0"
 title = "Announcing Rust 1.69.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/04/20/Rust-1.69.0.html"]
+aliases = [
+    "2023/04/20/Rust-1.69.0.html",
+    "releases/1.69.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.7.md
+++ b/content/Rust-1.7.md
@@ -2,7 +2,10 @@
 path = "2016/03/02/Rust-1.7"
 title = "Announcing Rust 1.7"
 authors = ["The Rust Core Team"]
-aliases = ["2016/03/02/Rust-1.7.html"]
+aliases = [
+    "2016/03/02/Rust-1.7.html",
+    "releases/1.7.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.70.0.md
+++ b/content/Rust-1.70.0.md
@@ -2,7 +2,10 @@
 path = "2023/06/01/Rust-1.70.0"
 title = "Announcing Rust 1.70.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/06/01/Rust-1.70.0.html"]
+aliases = [
+    "2023/06/01/Rust-1.70.0.html",
+    "releases/1.70.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.71.0.md
+++ b/content/Rust-1.71.0.md
@@ -2,7 +2,10 @@
 path = "2023/07/13/Rust-1.71.0"
 title = "Announcing Rust 1.71.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/07/13/Rust-1.71.0.html"]
+aliases = [
+    "2023/07/13/Rust-1.71.0.html",
+    "releases/1.71.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.71.1.md
+++ b/content/Rust-1.71.1.md
@@ -2,7 +2,10 @@
 path = "2023/08/03/Rust-1.71.1"
 title = "Announcing Rust 1.71.1"
 authors = ["The Rust Release Team"]
-aliases = ["2023/08/03/Rust-1.71.1.html"]
+aliases = [
+    "2023/08/03/Rust-1.71.1.html",
+    "releases/1.71.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.72.0.md
+++ b/content/Rust-1.72.0.md
@@ -2,7 +2,10 @@
 path = "2023/08/24/Rust-1.72.0"
 title = "Announcing Rust 1.72.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/08/24/Rust-1.72.0.html"]
+aliases = [
+    "2023/08/24/Rust-1.72.0.html",
+    "releases/1.72.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.72.1.md
+++ b/content/Rust-1.72.1.md
@@ -2,7 +2,10 @@
 path = "2023/09/19/Rust-1.72.1"
 title = "Announcing Rust 1.72.1"
 authors = ["The Rust Release Team"]
-aliases = ["2023/09/19/Rust-1.72.1.html"]
+aliases = [
+    "2023/09/19/Rust-1.72.1.html",
+    "releases/1.72.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.73.0.md
+++ b/content/Rust-1.73.0.md
@@ -2,7 +2,10 @@
 path = "2023/10/05/Rust-1.73.0"
 title = "Announcing Rust 1.73.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/10/05/Rust-1.73.0.html"]
+aliases = [
+    "2023/10/05/Rust-1.73.0.html",
+    "releases/1.73.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.74.0.md
+++ b/content/Rust-1.74.0.md
@@ -2,7 +2,10 @@
 path = "2023/11/16/Rust-1.74.0"
 title = "Announcing Rust 1.74.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/11/16/Rust-1.74.0.html"]
+aliases = [
+    "2023/11/16/Rust-1.74.0.html",
+    "releases/1.74.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.74.1.md
+++ b/content/Rust-1.74.1.md
@@ -2,7 +2,10 @@
 path = "2023/12/07/Rust-1.74.1"
 title = "Announcing Rust 1.74.1"
 authors = ["The Rust Release Team"]
-aliases = ["2023/12/07/Rust-1.74.1.html"]
+aliases = [
+    "2023/12/07/Rust-1.74.1.html",
+    "releases/1.74.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.75.0.md
+++ b/content/Rust-1.75.0.md
@@ -2,7 +2,10 @@
 path = "2023/12/28/Rust-1.75.0"
 title = "Announcing Rust 1.75.0"
 authors = ["The Rust Release Team"]
-aliases = ["2023/12/28/Rust-1.75.0.html"]
+aliases = [
+    "2023/12/28/Rust-1.75.0.html",
+    "releases/1.75.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.76.0.md
+++ b/content/Rust-1.76.0.md
@@ -2,7 +2,10 @@
 path = "2024/02/08/Rust-1.76.0"
 title = "Announcing Rust 1.76.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/02/08/Rust-1.76.0.html"]
+aliases = [
+    "2024/02/08/Rust-1.76.0.html",
+    "releases/1.76.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.77.0.md
+++ b/content/Rust-1.77.0.md
@@ -2,7 +2,10 @@
 path = "2024/03/21/Rust-1.77.0"
 title = "Announcing Rust 1.77.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/03/21/Rust-1.77.0.html"]
+aliases = [
+    "2024/03/21/Rust-1.77.0.html",
+    "releases/1.77.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.77.1.md
+++ b/content/Rust-1.77.1.md
@@ -2,7 +2,10 @@
 path = "2024/03/28/Rust-1.77.1"
 title = "Announcing Rust 1.77.1"
 authors = ["The Rust Release Team"]
-aliases = ["2024/03/28/Rust-1.77.1.html"]
+aliases = [
+    "2024/03/28/Rust-1.77.1.html",
+    "releases/1.77.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.77.2.md
+++ b/content/Rust-1.77.2.md
@@ -2,7 +2,10 @@
 path = "2024/04/09/Rust-1.77.2"
 title = "Announcing Rust 1.77.2"
 authors = ["The Rust Security Response WG"]
-aliases = ["2024/04/09/Rust-1.77.2.html"]
+aliases = [
+    "2024/04/09/Rust-1.77.2.html",
+    "releases/1.77.2",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.78.0.md
+++ b/content/Rust-1.78.0.md
@@ -2,7 +2,10 @@
 path = "2024/05/02/Rust-1.78.0"
 title = "Announcing Rust 1.78.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/05/02/Rust-1.78.0.html"]
+aliases = [
+    "2024/05/02/Rust-1.78.0.html",
+    "releases/1.78.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.79.0.md
+++ b/content/Rust-1.79.0.md
@@ -2,7 +2,10 @@
 path = "2024/06/13/Rust-1.79.0"
 title = "Announcing Rust 1.79.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/06/13/Rust-1.79.0.html"]
+aliases = [
+    "2024/06/13/Rust-1.79.0.html",
+    "releases/1.79.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.8.md
+++ b/content/Rust-1.8.md
@@ -2,7 +2,10 @@
 path = "2016/04/14/Rust-1.8"
 title = "Announcing Rust 1.8"
 authors = ["The Rust Core Team"]
-aliases = ["2016/04/14/Rust-1.8.html"]
+aliases = [
+    "2016/04/14/Rust-1.8.html",
+    "releases/1.8.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.80.0.md
+++ b/content/Rust-1.80.0.md
@@ -2,7 +2,10 @@
 path = "2024/07/25/Rust-1.80.0"
 title = "Announcing Rust 1.80.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/07/25/Rust-1.80.0.html"]
+aliases = [
+    "2024/07/25/Rust-1.80.0.html",
+    "releases/1.80.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.80.1.md
+++ b/content/Rust-1.80.1.md
@@ -2,7 +2,10 @@
 path = "2024/08/08/Rust-1.80.1"
 title = "Announcing Rust 1.80.1"
 authors = ["The Rust Release Team"]
-aliases = ["2024/08/08/Rust-1.80.1.html"]
+aliases = [
+    "2024/08/08/Rust-1.80.1.html",
+    "releases/1.80.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.81.0.md
+++ b/content/Rust-1.81.0.md
@@ -2,7 +2,10 @@
 path = "2024/09/05/Rust-1.81.0"
 title = "Announcing Rust 1.81.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/09/05/Rust-1.81.0.html"]
+aliases = [
+    "2024/09/05/Rust-1.81.0.html",
+    "releases/1.81.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.82.0.md
+++ b/content/Rust-1.82.0.md
@@ -2,7 +2,10 @@
 path = "2024/10/17/Rust-1.82.0"
 title = "Announcing Rust 1.82.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/10/17/Rust-1.82.0.html"]
+aliases = [
+    "2024/10/17/Rust-1.82.0.html",
+    "releases/1.82.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.83.0.md
+++ b/content/Rust-1.83.0.md
@@ -2,7 +2,10 @@
 path = "2024/11/28/Rust-1.83.0"
 title = "Announcing Rust 1.83.0"
 authors = ["The Rust Release Team"]
-aliases = ["2024/11/28/Rust-1.83.0.html"]
+aliases = [
+    "2024/11/28/Rust-1.83.0.html",
+    "releases/1.83.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.84.0.md
+++ b/content/Rust-1.84.0.md
@@ -2,7 +2,10 @@
 path = "2025/01/09/Rust-1.84.0"
 title = "Announcing Rust 1.84.0"
 authors = ["The Rust Release Team"]
-aliases = ["2025/01/09/Rust-1.84.0.html"]
+aliases = [
+    "2025/01/09/Rust-1.84.0.html",
+    "releases/1.84.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.84.1.md
+++ b/content/Rust-1.84.1.md
@@ -2,7 +2,10 @@
 path = "2025/01/30/Rust-1.84.1"
 title = "Announcing Rust 1.84.1"
 authors = ["The Rust Release Team"]
-aliases = ["2025/01/30/Rust-1.84.1.html"]
+aliases = [
+    "2025/01/30/Rust-1.84.1.html",
+    "releases/1.84.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.85.0.md
+++ b/content/Rust-1.85.0.md
@@ -2,7 +2,10 @@
 path = "2025/02/20/Rust-1.85.0"
 title = "Announcing Rust 1.85.0 and Rust 2024"
 authors = ["The Rust Release Team"]
-aliases = ["2025/02/20/Rust-1.85.0.html"]
+aliases = [
+    "2025/02/20/Rust-1.85.0.html",
+    "releases/1.85.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.85.1.md
+++ b/content/Rust-1.85.1.md
@@ -2,7 +2,10 @@
 path = "2025/03/18/Rust-1.85.1"
 title = "Announcing Rust 1.85.1"
 authors = ["The Rust Release Team"]
-aliases = ["2025/03/18/Rust-1.85.1.html"]
+aliases = [
+    "2025/03/18/Rust-1.85.1.html",
+    "releases/1.85.1",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.86.0.md
+++ b/content/Rust-1.86.0.md
@@ -2,7 +2,10 @@
 path = "2025/04/03/Rust-1.86.0"
 title = "Announcing Rust 1.86.0"
 authors = ["The Rust Release Team"]
-aliases = ["2025/04/03/Rust-1.86.0.html"]
+aliases = [
+    "2025/04/03/Rust-1.86.0.html",
+    "releases/1.86.0",
+]
 
 [extra]
 release = true

--- a/content/Rust-1.9.md
+++ b/content/Rust-1.9.md
@@ -2,7 +2,10 @@
 path = "2016/05/26/Rust-1.9"
 title = "Announcing Rust 1.9"
 authors = ["The Rust Core Team"]
-aliases = ["2016/05/26/Rust-1.9.html"]
+aliases = [
+    "2016/05/26/Rust-1.9.html",
+    "releases/1.9.0",
+]
 
 [extra]
 release = true

--- a/content/Rust.1.43.1.md
+++ b/content/Rust.1.43.1.md
@@ -2,7 +2,10 @@
 path = "2020/05/07/Rust.1.43.1"
 title = "Announcing Rust 1.43.1"
 authors = ["The Rust Release Team"]
-aliases = ["2020/05/07/Rust.1.43.1.html"]
+aliases = [
+    "2020/05/07/Rust.1.43.1.html",
+    "releases/1.43.1",
+]
 
 [extra]
 release = true

--- a/content/Rust.1.44.1.md
+++ b/content/Rust.1.44.1.md
@@ -2,7 +2,10 @@
 path = "2020/06/18/Rust.1.44.1"
 title = "Announcing Rust 1.44.1"
 authors = ["The Rust Release Team"]
-aliases = ["2020/06/18/Rust.1.44.1.html"]
+aliases = [
+    "2020/06/18/Rust.1.44.1.html",
+    "releases/1.44.1",
+]
 
 [extra]
 release = true


### PR DESCRIPTION
closes #679
stacked on #1577

This could be improved in the future:
- make it more discoverable
- add `releases/latest` alias
- add `releases/` section listing only the release announcements, similar to `releases.json` but human readable

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/senekor/zzkyzkvtvlzu/content/Rust-1.0@1.md)