### PR TITLE
Reduce risk of publishing posts with wrong date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,23 @@ jobs:
         with:
           path: public
 
+  pub_date:
+    name: Check publication date for placeholder
+    if: ${{ github.ref == 'refs/heads/master' }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - run: rustup override set ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+
+      - run: cargo test -p front_matter -- --include-ignored date_is_set
+
   deploy:
     if: ${{ github.ref == 'refs/heads/master' }}
 
-    needs: build
+    needs: [pub_date, build]
 
     permissions:
       pages: write

--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ You can store your main blog post in `content/<some-slug>/index.md`.
 Images go into the same directory: `content/<some-slug>/my_image.png`.
 Now you can reference that image with a simple relative path: `![alt text](my_image.png)`.
 
+A post's date of publication is embedded in the `path` key of the front matter.
+Unless the exact date is known in advance, keep the placeholder (`9999/12/31`) until the post is about to be published.
+Don't worry, there's a CI check to prevent a post with a placeholder date from being deployed.
+
 Here is an example of the front matter format:
 ```md
 +++
-path = "2015/03/15/some-slug"
+path = "9999/12/31/some-slug"
 title = "Title of the blog post"
 authors = ["Blog post author (or on behalf of which team)"]
 description = "(optional)"

--- a/front_matter/src/lib.rs
+++ b/front_matter/src/lib.rs
@@ -141,15 +141,7 @@ mod tests {
 
     #[test]
     fn front_matter_is_normalized() {
-        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
-
-        let posts = fs::read_dir(repo_root.join("content"))
-            .unwrap()
-            .chain(fs::read_dir(repo_root.join("content/inside-rust")).unwrap())
-            .map(|p| p.unwrap().path())
-            .filter(|p| p.is_file() && p.file_name() != Some("_index.md".as_ref()));
-
-        for post in posts {
+        for post in all_posts() {
             let slug = post.file_stem().unwrap().to_str().unwrap();
 
             let inside_rust = post
@@ -211,5 +203,37 @@ The post {post} has abnormal front matter.
                 )
             };
         }
+    }
+
+    /// This test is run by the merge queue check to make sure a blog post isn't
+    /// merged before its date of publication is set. The date of a blog post
+    /// is usually a placeholder (path = "9999/12/31/...") until shortly before
+    /// it's published.
+    #[test]
+    #[ignore]
+    fn date_is_set() {
+        for post in all_posts() {
+            let content = fs::read_to_string(&post).unwrap();
+            let (front_matter, _) = parse(&content).unwrap();
+
+            if front_matter.path.starts_with("9999/12/31") {
+                panic!(
+                    "\n\
+                    The post {slug} has a placeholder publication date.\n\
+                    If you're about to publish it, please set it to today.\n\
+                    ",
+                    slug = post.file_stem().unwrap().to_str().unwrap(),
+                );
+            }
+        }
+    }
+
+    fn all_posts() -> impl Iterator<Item = PathBuf> {
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+        fs::read_dir(repo_root.join("content"))
+            .unwrap()
+            .chain(fs::read_dir(repo_root.join("content/inside-rust")).unwrap())
+            .map(|p| p.unwrap().path())
+            .filter(|p| p.is_file() && p.file_name() != Some("_index.md".as_ref()))
     }
 }


### PR DESCRIPTION
The date of publication often has to be adjusted at the last minute. This can easily be forgotten. In order to reduce the risk of posts being published with an incorrect date, this commit encourages authors to keep a placeholder date until shortly before publication. A CI check prevents the deployment if a placeholder date is detected.

The placeholder date "9999/12/31" is chosen because it shows up at the top of the list of posts during development and it's clearly "invalid".

closes #567