### PR TITLE
Improve error message in case of invalid path

### DIFF
--- a/templates/feed.xml
+++ b/templates/feed.xml
@@ -20,6 +20,7 @@
         <title>{{ macros::escape_hbs(input=page.title) | safe }}</title>
         <link rel="alternate" href="https://blog.rust-lang.org{{ macros::escape_hbs(input=page.path) | safe }}" type="text/html" title="{{ macros::escape_hbs(input=page.title) | safe }}" />
         {%- set num_comps = page.components | length %}
+        {%- if num_comps < 4 %}{{ throw(message="Missing date in 'path' key, required format: '[inside-rust/]YYYY/MM/DD/slug-of-your-choice'") }}{% endif %}
         {%- set year = page.components | nth(n=num_comps - 4) %}
         {%- set month = page.components | nth(n=num_comps - 3) %}
         {%- set day = page.components | nth(n=num_comps - 2) %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,7 @@
     {%- set rev_pages = section.pages | reverse %}
     {%- for page in rev_pages %}
       {%- set num_comps = page.components | length %}
+      {%- if num_comps < 4 %}{{ throw(message="Missing date in 'path' key, required format: '[inside-rust/]YYYY/MM/DD/slug-of-your-choice'") }}{% endif %}
       {%- set year = page.components | nth(n=num_comps - 4) | int %}
       {%- set month = page.components | nth(n=num_comps - 3) | int %}
       {%- set day = page.components | nth(n=num_comps - 2) | int %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,6 +2,7 @@
 {% extends "layout.html" -%}
 {% block page -%}
 {% set num_comps = page.components | length -%}
+{% if num_comps < 4 %}{{ throw(message="Missing date in 'path' key, required format: '[inside-rust/]YYYY/MM/DD/slug-of-your-choice'") }}{% endif -%}
 {% set year = page.components | nth(n=num_comps - 4) | int -%}
 {% set month = page.components | nth(n=num_comps - 3) | int -%}
 {% set day = page.components | nth(n=num_comps - 2) | int -%}

--- a/templates/releases.html
+++ b/templates/releases.html
@@ -26,6 +26,7 @@
     {%- set rev_pages = section.pages | reverse %}
     {%- for page in rev_pages %}
       {%- set num_comps = page.components | length %}
+      {%- if num_comps < 4 %}{{ throw(message="Missing date in 'path' key, required format: '[inside-rust/]YYYY/MM/DD/slug-of-your-choice'") }}{% endif %}
       {%- set year = page.components | nth(n=num_comps - 4) | int %}
       {%- set month = page.components | nth(n=num_comps - 3) | int %}
       {%- set day = page.components | nth(n=num_comps - 2) | int %}


### PR DESCRIPTION
Previously, if blog authors didn't set the path key in the front matter, the error message from Zola was:

Filter `nth` received an incorrect type for arg `n`: got `-2` but expected a usize

This is misleading, as it doesn't point out the cause of the problem. The new error message makes authors aware of the required path format.