### PR TITLE
Fix auto completion of username from git

### DIFF
--- a/crates/generate_blog/src/main.rs
+++ b/crates/generate_blog/src/main.rs
@@ -191,7 +191,7 @@ fn try_parse_version_from_title(title: &str) -> Option<String> {
 fn guess_author_from_git() -> Option<String> {
     String::from_utf8(
         Command::new("git")
-            .args(["config", "get", "user.name"])
+            .args(["config", "user.name"])
             .output()
             .ok()?
             .stdout,


### PR DESCRIPTION
`git config get` was only introduced in git https://git-scm.com/docs/git-config/2.46.1 :sweat_smile: Without `get` it should be compatible both with old and new git.