### PR TITLE
Update fork of Zola

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Install Zola
-        run: cargo install --locked --git https://github.com/senekor/zola --rev 620bf3c46a39b41db30b1e91756a995bbff84d3a
+        run: cargo install --locked --git https://github.com/senekor/zola --rev 79410eea82f837e4de9b1e4c3905287060b69255
       - run: zola build
       - run: cp CNAME ./public/
       - run: touch public/.nojekyll

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -15,7 +15,7 @@ jobs:
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - name: Install Zola
-        run: cargo install --locked --git https://github.com/senekor/zola --rev 620bf3c46a39b41db30b1e91756a995bbff84d3a
+        run: cargo install --locked --git https://github.com/senekor/zola --rev 79410eea82f837e4de9b1e4c3905287060b69255
 
       - run: git fetch --depth 2
       - run: git checkout origin/master

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To serve the site locally, first install Zola: (takes a couple minutes)
 
 ```sh
 # using a fork because we rely on a few patches that haven't landed yet
-cargo install --locked --git https://github.com/senekor/zola --rev 620bf3c46a39b41db30b1e91756a995bbff84d3a
+cargo install --locked --git https://github.com/senekor/zola --rev 79410eea82f837e4de9b1e4c3905287060b69255
 ```
 
 Now run `zola serve --open`.


### PR DESCRIPTION
The new version contains a workaround for an issue which is temporarily preventing Zola from compiling in some environments.

https://github.com/getzola/zola/compare/v0.20.0...senekor:zola:senekor/remove-dependency-onig

RUN_SNAPSHOT_TESTS