### PR TITLE
Link to edit page directly

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -38,7 +38,7 @@
     </div>
     <div class="attribution">
       Maintained by the Rust Team. See a typo?
-      <a href="https://github.com/rust-lang/blog.rust-lang.org" target="_blank" rel="noopener">Send a fix here</a>!
+      <a href="https://github.com/rust-lang/blog.rust-lang.org{% if page %}/edit/master/content/{{ page.relative_path }}{% endif %}" target="_blank" rel="noopener">Send a fix here</a>!
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Contributors may click on the "fix a typo" link while reading a specific post. When that only leads to the repo, it takes extra effort to find the specific file to edit. Linking to that file directly is more convenient. Even if contributors don't want to use the GitHub editor, it at least tells them the exact path of the file in the repo.