### PR TITLE
Don't default-italicize blockquote text

### DIFF
--- a/sass/styles/app.scss
+++ b/sass/styles/app.scss
@@ -86,7 +86,6 @@ body {
 }
 
 blockquote {
-    font-style: italic;
     position: relative;
     background-color: var(--blockquote-bg-color);
     border-left: 8px solid var(--blockquote-left-border-color);


### PR DESCRIPTION
Default-italicizing blockquote text prevents `*italics*` markdown from having an observable effect.

Fixes rust-lang/blog.rust-lang.org#1617. I was not able to reproduce the extra spacing on the blockquote locally.

### Preview

![Screenshot 2025-05-25 191133](https://github.com/user-attachments/assets/7d7577fb-1cee-4388-9a93-397ba5886e87)

### Testing

You can try out this locally to reproduce the preview above with an example post like

```markdown
+++
path = "9999/12/31/DO_NOT_MERGE_example"
title = "[DO NOT MERGE] Example"
authors = ["Ferris"]
+++

Prior text.

> This is an example blockquote.
>
> Normal text.
>
> *Italicized text*.
>
> Last sentence, does this have excessive whitespace afterwards? Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis ex lacus. Morbi vitae dignissim justo, ac pellentesque felis. Suspendisse at magna in ipsum euismod cursus. Nam sed tristique sem. Quisque efficitur tincidunt tortor, imperdiet interdum sem pharetra sed. Sed dapibus tortor eros, pellentesque auctor augue faucibus vitae.

Trailing text.
```

r? @senekor