### PR TITLE
Add Rust compiler performance 2025 survey blog post

### DIFF
--- a/content/rust-compiler-performance-survey-2025.md
+++ b/content/rust-compiler-performance-survey-2025.md
@@ -1,5 +1,5 @@
 +++
-path = "9999/12/31/rust-compiler-performance-survey-2025"
+path = "2025/06/16/rust-compiler-performance-survey-2025"
 title = "Rust compiler performance survey 2025"
 authors = ["Jakub Beránek"]
 
@@ -16,7 +16,7 @@ In order to better understand these workflows, we have prepared a [Rust Compiler
 
 **You can fill out the survey [here][survey-link].**
 
-Filling the survey will likely take you approximately 10 minutes, and the survey is fully anonymous. We will accept submissions until Monday, June 23rd, 2025. After the survey ends, we will evaluate the results and post key insights on this blog.
+Filling the survey will likely take you approximately 10 minutes, and the survey is fully anonymous. We will accept submissions until Monday, July 7th, 2025. After the survey ends, we will evaluate the results and post key insights on this blog.
 
 We invite you to fill the survey, as your responses will help us improve Rust compilation performance. Thank you!
 

--- a/content/rust-compiler-performance-survey-2025.md
+++ b/content/rust-compiler-performance-survey-2025.md
@@ -8,6 +8,8 @@ team = "the Compiler Performance Working Group"
 team_url = "https://www.rust-lang.org/governance/teams/compiler#team-wg-compiler-performance"
 +++
 
+We're launching a [Rust Compiler Performance Survey][survey-link].
+
 Long compile times of Rust code are frequently being cited as one of the biggest [challenges][annual-survey] limiting the productivity of Rust developers. Rust compiler contributors are of course aware of that, and they are continuously working to improve the situation, by finding [new ways][how-to-speed-up-the-compiler] of speeding up the compiler, [triaging performance regressions][performance-triage] and [measuring][perf-dashboard] our long-term performance improvements. Recently, we also made progress on some [large changes][stabilize-lld] that have been in the making for a long time, which could significantly improve compiler performance by default.
 
 When we talk about compilation performance, it is important to note that it is not always so simple as determining how long does it take `rustc` to compile a crate. There are many diverse development workflows that might have competing trade-offs, and that can be bottlenecked by various factors, such as the integration of the compiler with the used build system.
@@ -16,12 +18,12 @@ In order to better understand these workflows, we have prepared a [Rust Compiler
 
 **You can fill out the survey [here][survey-link].**
 
-Filling the survey will likely take you approximately 10 minutes, and the survey is fully anonymous. We will accept submissions until Monday, July 7th, 2025. After the survey ends, we will evaluate the results and post key insights on this blog.
+Filling the survey should take you approximately 10 minutes, and the survey is fully anonymous. We will accept submissions until Monday, July 7th, 2025. After the survey ends, we will evaluate the results and post key insights on this blog.
 
 We invite you to fill the survey, as your responses will help us improve Rust compilation performance. Thank you!
 
 [annual-survey]: https://blog.rust-lang.org/2025/02/13/2024-State-Of-Rust-Survey-results/#challenges
-[survey-link]: TODO
+[survey-link]: https://www.surveyhero.com/c/rust-compiler-performance-2025
 [how-to-speed-up-the-compiler]: https://nnethercote.github.io/2025/03/19/how-to-speed-up-the-rust-compiler-in-march-2025.html
 [performance-triage]: https://github.com/rust-lang/rustc-perf/blob/master/triage/README.md
 [perf-dashboard]: https://perf.rust-lang.org/dashboard.html

--- a/content/rust-compiler-performance-survey-2025.md
+++ b/content/rust-compiler-performance-survey-2025.md
@@ -1,0 +1,28 @@
++++
+path = "9999/12/31/rust-compiler-performance-survey-2025"
+title = "Rust compiler performance survey 2025"
+authors = ["Jakub Beránek"]
+
+[extra]
+team = "the Compiler Performance Working Group"
+team_url = "https://www.rust-lang.org/governance/teams/compiler#team-wg-compiler-performance"
++++
+
+Long compile times of Rust code are frequently being cited as one of the biggest [challenges][annual-survey] limiting the productivity of Rust developers. Rust compiler contributors are of course aware of that, and they are continuously working to improve the situation, by finding [new ways][how-to-speed-up-the-compiler] of speeding up the compiler, [triaging performance regressions][performance-triage] and [measuring][perf-dashboard] our long-term performance improvements. Recently, we also made progress on some [large changes][stabilize-lld] that have been in the making for a long time, which could significantly improve compiler performance by default.
+
+When we talk about compilation performance, it is important to note that it is not always so simple as determining how long does it take `rustc` to compile a crate. There are many diverse development workflows that might have competing trade-offs, and that can be bottlenecked by various factors, such as the integration of the compiler with the used build system.
+
+In order to better understand these workflows, we have prepared a [Rust Compiler Performance Survey][survey-link]. This survey is focused specifically on compilation performance, which allows us to get more detailed data than what we usually get from the annual State of Rust survey. The data from this survey will help us find areas where we should focus our efforts on improving the productivity of Rust developers.
+
+**You can fill out the survey [here][survey-link].**
+
+Filling the survey will likely take you approximately 10 minutes, and the survey is fully anonymous. We will accept submissions until Monday, June 23rd, 2025. After the survey ends, we will evaluate the results and post key insights on this blog.
+
+We invite you to fill the survey, as your responses will help us improve Rust compilation performance. Thank you!
+
+[annual-survey]: https://blog.rust-lang.org/2025/02/13/2024-State-Of-Rust-Survey-results/#challenges
+[survey-link]: TODO
+[how-to-speed-up-the-compiler]: https://nnethercote.github.io/2025/03/19/how-to-speed-up-the-rust-compiler-in-march-2025.html
+[performance-triage]: https://github.com/rust-lang/rustc-perf/blob/master/triage/README.md
+[perf-dashboard]: https://perf.rust-lang.org/dashboard.html
+[stabilize-lld]: https://github.com/rust-lang/rust/pull/140525


### PR DESCRIPTION
Related to https://github.com/rust-lang/surveys/pull/337. The date of the survey hasn't been determined yet, so opening as a draft.

[Rendered](https://github.com/Kobzol/blog.rust-lang.org/blob/rust-compiler-performance-survey/content/rust-compiler-performance-survey-2025.md)