### PR TITLE
announce new compiler team members

### DIFF
--- a/content/inside-rust/compiler-team-new-members-may-2025.md
+++ b/content/inside-rust/compiler-team-new-members-may-2025.md
@@ -1,0 +1,33 @@
++++
+path = "inside-rust/2025/05/27/compiler-team-new-members"
+title = "Announcing five new members of the compiler team"
+authors = ["davidtwco and wesleywiser"]
+aliases = ["inside-rust/2025/05/27/compiler-team-new-members.html"]
+
+[extra]
+team = "the compiler team"
+team_url = "https://www.rust-lang.org/governance/teams/compiler"
++++
+It's been around six months since [we last announced new members of the compiler
+team][blog_prev_addition] and there's already new members to announce:
+
+- [Kobzol](https://github.com/Kobzol), team member
+  - Kobzol is a prolific member of the infrastructure team and has also been making great
+    contributions to the team's performance triaging, our transition to lld as well as many varied
+    improvements to the compiler itself.
+- [ZuseZ4](https://github.com/ZuseZ4), team member
+  - ZuseZ4 is the maintainer of the [Enzyme](https://enzyme.mit.edu/) logic in our LLVM backend and
+    our new automatic differentiation support.
+- [jdonszelmann](https://github.com/jdonszelmann), team member
+  - jdonszelmann has been making significant contributions to how we represent attributes in the HIR
+    and helped organise the Rust All Hands this year, enabling the team to meet in person.
+- [madsmtm](https://github.com/madsmtm), team member
+  - madsmtm is our Apple and iOS target maintainer and expert on the issues and regressions that
+    come up with these targets.
+- [mati865](https://github.com/mati865), team member
+  - mati865 is likewise our maintainer of the Windows GNULLVM targets and has been instrumental in
+    doing reviews and fixes in support of these targets.
+
+Thanks to all of our new members for their contributions!
+
+[blog_prev_addition]: https://blog.rust-lang.org/inside-rust/2024/11/12/compiler-team-new-members/

--- a/content/inside-rust/compiler-team-new-members-may-2025.md
+++ b/content/inside-rust/compiler-team-new-members-may-2025.md
@@ -2,7 +2,7 @@
 path = "inside-rust/2025/05/27/compiler-team-new-members"
 title = "Announcing five new members of the compiler team"
 authors = ["davidtwco and wesleywiser"]
-aliases = ["inside-rust/2025/05/27/compiler-team-new-members.html"]
+aliases = ["inside-rust/2025/05/30/compiler-team-new-members.html"]
 
 [extra]
 team = "the compiler team"


### PR DESCRIPTION
Waiting on rust-lang/team#1849

[Rendered](https://github.com/davidtwco/blog.rust-lang.org/blob/compiler-new-team-member-may-25/content/inside-rust/compiler-team-new-members-may-2025.md)