### PR TITLE
Adjust blockquote list styles

### DIFF
--- a/sass/styles/app.scss
+++ b/sass/styles/app.scss
@@ -104,6 +104,11 @@ blockquote {
     p:last-of-type {
         margin-bottom: 0;
     }
+
+    ol, ul {
+        margin-block-start: 1em;
+        margin-block-end: 0em;
+    }
 }
 
 details > summary {


### PR DESCRIPTION
To avoid strange extraneous bottom margins. Follow-up to https://github.com/rust-lang/blog.rust-lang.org/pull/1618.

I was confused why I couldn't reproduce https://github.com/rust-lang/blog.rust-lang.org/issues/1617#issuecomment-2907015819, it turns out you need (ordered, unordered) list within blockquote to repro.

### Preview

<details>
<summary>Click to expand</summary>

![Screenshot 2025-05-30 090425](https://github.com/user-attachments/assets/f6da0aca-fc5b-447a-a638-218479fdc001)
</details>

### Sample markdown to test

<details>
<summary>Click to expand</summary>

```md
Text before

> How about full paragraphs?

Text in-between.

> Revision:
>
> - (2025-05-30) This blog post was edited to clarify the lack of impact for distribution packagers (i.e. distribution packages will still be able to build `N + 1` version of Rust using version `N` of Rust), as this change affects the contributor workflow.
> - Another `<li>`.

This blog post accompanies an [upcoming major change to the `rust-lang/rust` build system][stage0-redesign-pr] (see also [Major Change Proposal 619][redesign-stage0-mcp]). This will have no impact on the distributed artifacts from [rust-lang/rust], but the way we build those artifacts is changing.

> Revision:
>
> 1. (2025-05-30) This blog post was edited to clarify the lack of impact for distribution packagers (i.e. distribution packages will still be able to build `N + 1` version of Rust using version `N` of Rust), as this change affects the contributor workflow.
> 2. Another `<li>`.
```
</details>

r? @senekor