### PR TITLE
Forbid migration alias in new posts

### DIFF
--- a/content/Rust-1.87.0/index.md
+++ b/content/Rust-1.87.0/index.md
@@ -2,10 +2,7 @@
 path = "2025/05/15/Rust-1.87.0"
 title = "Announcing Rust 1.87.0 and ten years of Rust!"
 authors = ["The Rust Release Team"]
-aliases = [
-    "2025/05/15/Rust-1.87.0.html",
-    "releases/1.87.0",
-]
+aliases = ["releases/1.87.0"]
 
 [extra]
 release = true

--- a/content/Rustup-1.28.2.md
+++ b/content/Rustup-1.28.2.md
@@ -2,7 +2,6 @@
 path = "2025/05/05/Rustup-1.28.2"
 title = "Announcing rustup 1.28.2"
 authors = ["The Rustup Team"]
-aliases = ["2025/05/05/Rustup-1.28.2.html"]
 +++
 
 The rustup team is happy to announce the release of rustup version 1.28.2.

--- a/content/inside-rust/compiler-team-new-members-may-2025.md
+++ b/content/inside-rust/compiler-team-new-members-may-2025.md
@@ -2,7 +2,6 @@
 path = "inside-rust/2025/05/27/compiler-team-new-members"
 title = "Announcing five new members of the compiler team"
 authors = ["davidtwco and wesleywiser"]
-aliases = ["inside-rust/2025/05/30/compiler-team-new-members.html"]
 
 [extra]
 team = "the compiler team"

--- a/content/inside-rust/project-director-update@4.md
+++ b/content/inside-rust/project-director-update@4.md
@@ -2,7 +2,6 @@
 path = "inside-rust/2025/04/22/project-director-update"
 title = "April 2025 Project Director Update"
 authors = ["Carol Nichols"]
-aliases = ["inside-rust/2025/04/22/project-director-update.html"]
 
 [extra]
 team = "Rust Foundation Project Directors"


### PR DESCRIPTION
The change is explained in a comment, copying it here for convenience:

Make sure that posts created after the migration to Zola don't have
the alias for preserving permalinks.

Blog authors would often copy-paste an old post, reusing the
boilerplate for a new one. In that process, they'd usually preserve
that alias as well, probably not knowing what it's for. Technically
such an alias doesn't hurt much, it's just a redirect that isn't
referenced anywhere. So these aliases were allowed, preferring not to
bother blog authors with such unimportant stuff.

However, there was a situation where a blog post was merged with
the wrong publication date because of this. Shortly before merging,
the date was updated, but it was accidentally changed in the useless
alias instead of the authoritative `path` key. Because of this
footgun, we don't allow creating these new aliases anymore.

Blog authors who copy-paste old boilerplate will run into failed CI
and have to fix it by removing the alias. It's annoying, but better
than publishing a post with the wrong publication date.


[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/master/content/Rust-1.87.0/index.md)