### PR TITLE
Switch to upstream Zola

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 blog = ["run", "--package", "generate_blog"]
+zola = ["run", "--manifest-path", "zola/Cargo.toml", "--"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          submodules: true
 
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
-      - name: Install Zola
-        run: cargo install --locked --git https://github.com/senekor/zola --rev 79410eea82f837e4de9b1e4c3905287060b69255
-      - run: zola build
+      - run: cargo zola build
       - run: cp CNAME ./public/
       - run: touch public/.nojekyll
 

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -12,10 +12,10 @@ jobs:
     if: contains(github.event.pull_request.body, 'RUN_SNAPSHOT_TESTS')
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          submodules: true
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-      - name: Install Zola
-        run: cargo install --locked --git https://github.com/senekor/zola --rev 79410eea82f837e4de9b1e4c3905287060b69255
 
       - run: git fetch --depth 2
       - run: git checkout origin/master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "zola"]
+	path = zola
+	url = https://github.com/getzola/zola

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ It uses [Zola](https://www.getzola.org/) and is deployed to GitHub Pages via Git
 
 ## Building
 
-To serve the site locally, first install Zola: (takes a couple minutes)
+To serve the site locally, first make sure the zola submodule is initialized:
 
 ```sh
-# using a fork because we rely on a few patches that haven't landed yet
-cargo install --locked --git https://github.com/senekor/zola --rev 79410eea82f837e4de9b1e4c3905287060b69255
+git submodule update --init --recursive
 ```
 
-Now run `zola serve --open`.
+Now run `cargo zola serve --open`.
+(The first run takes a while to compile Zola.)
 The site will be reloaded automatically when you make any changes.
 
 ## Contributing

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "Rust Blog"
 description = "Empowering everyone to build reliable and efficient software."
+sort_by = "permalink"
 generate_feeds = true
 [extra]
 index_title = "The Rust Programming Language Blog"

--- a/content/inside-rust/_index.md
+++ b/content/inside-rust/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "Inside Rust Blog"
 description = "Want to follow along with Rust development? Curious how you might get involved? Take a look!"
+sort_by = "permalink"
 generate_feeds = true
 [extra]
 index_title = 'The "Inside Rust" Blog'

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -2,8 +2,8 @@
 fn snapshot() {
     std::env::set_current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/../..")).unwrap();
     let _ = std::fs::remove_dir_all("public");
-    let status = std::process::Command::new("zola")
-        .arg("build")
+    let status = std::process::Command::new("cargo")
+        .args(["zola", "build"])
         .status()
         .unwrap();
     assert!(status.success(), "failed to build site");


### PR DESCRIPTION
All of the patches we needed for the migration have been merged upstream (with some modifications, hence the `sort_by = "permalink"` diff).

We don't know how long it will take for Zola to cut a new release, so let's provide our own binaries to blog authors in the meantime.

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/senekor-qonutkpxlntw/content/_index.md)