### PR TITLE
Post for June 2025 Leadership Council Update

### DIFF
--- a/content/inside-rust/leadership-council-update@7.md
+++ b/content/inside-rust/leadership-council-update@7.md
@@ -29,7 +29,7 @@ We've seen a lot of returns from good Project-directed program management. In su
 
 More than 150 people attended the all-hands event in May at [RustWeek 2025] in the Netherlands. We've received a lot of positive feedback about the event, as it was a great opportunity to get people from across the org to have focused discussions.
 
-The project was able to sponsor this event with $100,000 in funding for the event, with an additional $117,000 for travel and tickets. We are looking to see if we can secure funding to be able to continue these events in the future.
+The project was able to sponsor this event with $100,000 in funding for the event, with an additional $90,000 for travel and tickets. We are looking to see if we can secure funding to be able to continue these events in the future.
 
 Many thanks to [Mara Bos] who was instrumental in organizing this event and making it a success.
 
@@ -72,8 +72,8 @@ One idea for how this might shape up is to re-charter the launching pad to be so
 As part of [Microsoft's donation], the Council has had $650k available to spend at its discretion. There are three recent budget items that the Council has been considering:
 
 - Renewing the Compiler Ops contract for another six months. In the past six months we have spent about $20k out of the initial $30k that we reserved for this position. [leadership-council#181](https://github.com/rust-lang/leadership-council/issues/181)
-- Planning for spending of the [travel budget]. We reserved $75k per year for travel expenses and event tickets. In 2024 we only spent about $16k, but due to the larger all-hands event this year we have spent $117k in the first half of the year. Combining those means there is only about $17k left for the remainder of the year. We'll need to decide if we want to stick to our budgeted cap, or if we want to consider extending it. Additionally we are considering whether or not we want to reserve what remains for 2026. [leadership-council#182](https://github.com/rust-lang/leadership-council/issues/182)
-- Planning for 2026. At present the Council only has about $67k left unreserved. We could consider holding that for the travel budget next year, or to fund other things. We'll be having some discussions with the Foundation about other funding possibilities.
+- Planning for spending of the [travel budget]. We reserved $75k per year for travel expenses and event tickets. In 2024 we only spent about $16k, but due to the larger all-hands event this year we have spent $90k in the first half of the year. Combining those means there is about $44k left for the remainder of the year. We are considering what this means for the rest of the year, and how we can plan for what we can reserve in 2026. [leadership-council#182](https://github.com/rust-lang/leadership-council/issues/182)
+- Planning for 2026. At present the Council only has about $50k left unreserved. We could consider holding that for the travel budget next year, or to fund other things. We'll be having some discussions with the Foundation about other funding possibilities.
 
 [Microsoft's donation]: https://rustfoundation.org/media/1m-microsoft-donation-to-fund-key-rust-foundation-project-priorities/
 [travel budget]: https://github.com/rust-lang/leadership-council/blob/main/policies/spending/travel.md

--- a/content/inside-rust/leadership-council-update@7.md
+++ b/content/inside-rust/leadership-council-update@7.md
@@ -1,0 +1,98 @@
++++
+path = "inside-rust/2025/06/11/leadership-council-update"
+title = "June 2025 Leadership Council Update"
+authors = ["Eric Huss"]
+
+[extra]
+team = "Leadership Council"
+team_url = "https://www.rust-lang.org/governance/teams/leadership-council"
++++
+
+Hello again from the Rust Leadership Council!
+We wanted to share an update on what the Council has been working on since [our last update][update].
+
+[update]: https://blog.rust-lang.org/inside-rust/2025/03/17/leadership-council-update/
+
+## Accomplishments so far
+
+### Welcome Josh Stone to the Council
+
+As [announced in March](https://blog.rust-lang.org/inside-rust/2025/03/26/leadership-council-repr-selection/), Josh Stone joined the Council representing the compiler team.
+
+### Program manager
+
+We've seen a lot of returns from good Project-directed program management. In support of this valuable work — so that we can do more with it while making it more sustainable — we allocated funds to the Edition and Goals teams to hire a program manager. TC and Joel interviewed a large number of candidates, and we're excited to announce that the Project, with logistical support from the Foundation, has brought on [Tomas Sedovic]. He's hit the ground running, joining many team calls in the past week, and supporting the teams with record keeping and communication — which is good for the transparency and effective functioning of our work — and with logistics such as the coordination of meetings and follow-up with contributors. Going forward, we're expecting this work to help us and our teams across the Project better manage the many ongoing initiatives that are of importance to us.
+
+[Tomas Sedovic]: https://github.com/tomassedovic
+
+### All-hands
+
+More than 150 people attended the all-hands event in May at [RustWeek 2025] in the Netherlands. We've received a lot of positive feedback about the event, as it was a great opportunity to get people from across the org to have focused discussions.
+
+The project was able to sponsor this event with $100,000 in funding for the event, with an additional $117,000 for travel and tickets. We are looking to see if we can secure funding to be able to continue these events in the future.
+
+Many thanks to [Mara Bos] who was instrumental in organizing this event and making it a success.
+
+[RustWeek 2025]: https://rustweek.org/
+[Mara Bos]: https://github.com/m-ou-se/
+
+### Additional items
+
+And a few other items:
+- [Josh Stone] has volunteered to be on the RustConf Program Committee to help select talks for [RustConf 2025](https://rustconf.com/). [leadership-council#163](https://github.com/rust-lang/leadership-council/issues/163)
+- [TC] has volunteered to be a substitute for the June Foundation board meeting. [leadership-council#176](https://github.com/rust-lang/leadership-council/issues/176)
+- Approved creating the Vision Doc team, which is working to create a document that identifies key opportunities for Rust over the next 3-5 years. [leadership-council#165](https://github.com/rust-lang/leadership-council/issues/165)
+- Approved placing the Rust logo in the RISC-V landscape page. [leadership-council#164](https://github.com/rust-lang/leadership-council/issues/164)
+- Approved a clarification of the definition of "expatriated crates" as part of our crate publishing policy. [rust-forge#840](https://github.com/rust-lang/rust-forge/pull/840)
+- The social media team set up a [Bluesky account](https://bsky.app/profile/rust-lang.org) for posting official announcements. The Rust Project also has an official [Mastodon account](https://social.rust-lang.org/@rust) as well.
+- Added the Foundation directors as a "team" in the team database. [team#1786](https://github.com/rust-lang/team/pull/1786)
+- Approved the infra team to set it up so that team leads can directly approve modifications to their team files. [leadership-council#171](https://github.com/rust-lang/leadership-council/issues/171)
+- Added some clarification on the approval process for posting on the official Rust blog. [leadership-council#173](https://github.com/rust-lang/leadership-council/issues/173).
+- Added some basic onboarding documentation for the project as a whole. [rust-forge#846](https://github.com/rust-lang/rust-forge/pull/846)
+- Clarified that the council does not need to be involved with transferring the Docker team out of the launching pad and into the infra team. [leadership-council#124](https://github.com/rust-lang/leadership-council/issues/124)
+
+[Josh Stone]: https://github.com/cuviper
+[TC]: https://github.com/traviscross
+
+## Ongoing work
+
+There are various efforts underway on projects that have had significant discussions since the last update, but have not concluded with any decisions, yet.
+They are:
+
+### Shape of Rust
+
+[James Munns] has continued to develop his ideas for a "Rust Society" to find a home for certain kinds of community groups and special interest groups. We've received great feedback during the all-hands to help further refine these ideas, and James is continuing to work on how this might be structured. [leadership-council#159](https://github.com/rust-lang/leadership-council/issues/159)
+
+One idea for how this might shape up is to re-charter the launching pad to be something more permanent for cross-cutting, long-lived teams (like the [Security Response Working Group](https://github.com/rust-lang/leadership-council/issues/141)). [leadership-council#170](https://github.com/rust-lang/leadership-council/issues/170)
+
+[James Munns]: https://github.com/jamesmunns
+
+### Foundation budget
+
+As part of [Microsoft's donation], the Council has had $650k available to spend at its discretion. There are three recent budget items that the Council has been considering:
+
+- Renewing the Compiler Ops contract for another six months. In the past six months we have spent about $20k out of the initial $30k that we reserved for this position. [leadership-council#181](https://github.com/rust-lang/leadership-council/issues/181)
+- Planning for spending of the [travel budget]. We reserved $75k per year for travel expenses and event tickets. In 2024 we only spent about $16k, but due to the larger all-hands event this year we have spent $117k in the first half of the year. Combining those means there is only about $17k left for the remainder of the year. We'll need to decide if we want to stick to our budgeted cap, or if we want to consider extending it. Additionally we are considering whether or not we want to reserve what remains for 2026. [leadership-council#182](https://github.com/rust-lang/leadership-council/issues/182)
+- Planning for 2026. At present the Council only has about $67k left unreserved. We could consider holding that for the travel budget next year, or to fund other things. We'll be having some discussions with the Foundation about other funding possibilities.
+
+[Microsoft's donation]: https://rustfoundation.org/media/1m-microsoft-donation-to-fund-key-rust-foundation-project-priorities/
+[travel budget]: https://github.com/rust-lang/leadership-council/blob/main/policies/spending/travel.md
+
+### Additional items
+
+- We have continued to have discussions on how to have better communication between the Council, Foundation directors, and the Foundation staff.
+- A question came to the Council about the possibility of having explicit team membership durations. This came out of some discussions about how to address burnout, and would have other benefits such as having clearer team structures. [leadership-council#175](https://github.com/rust-lang/leadership-council/issues/175)
+
+## Meeting minutes
+
+We publish minutes from all Council meetings to the [Leadership Council repo][minutes].
+Links to the minutes since our last update are:
+
+* [March 14, 2025](https://github.com/rust-lang/leadership-council/blob/main/minutes/sync-meeting/2025-03-14.md)
+* [March 28, 2025](https://github.com/rust-lang/leadership-council/blob/main/minutes/sync-meeting/2025-03-28.md)
+* [April 11, 2025](https://github.com/rust-lang/leadership-council/blob/main/minutes/sync-meeting/2025-04-11.md)
+* [April 25, 2025](https://github.com/rust-lang/leadership-council/blob/main/minutes/sync-meeting/2025-04-25.md)
+* [May 9, 2025](https://github.com/rust-lang/leadership-council/blob/main/minutes/sync-meeting/2025-05-09.md)
+* [May 23, 2025](https://github.com/rust-lang/leadership-council/blob/main/minutes/sync-meeting/2025-05-23.md)
+
+[minutes]: https://github.com/rust-lang/leadership-council/tree/main/minutes


### PR DESCRIPTION
Opening as draft as there are some unfilled parts.


[Rendered](https://github.com/ehuss/blog.rust-lang.org/blob/council-june-2025/content/inside-rust/leadership-council-update@7.md)