### PR TITLE
ci: Fix caching of zola build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
 
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        with:
+          workspaces: ".\nzola" # needed to cache build of zola in ./zola/target
 
       - run: cargo zola build
       - run: cp CNAME ./public/

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -16,6 +16,8 @@ jobs:
           submodules: true
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        with:
+          workspaces: ".\nzola" # needed to cache build of zola in ./zola/target
 
       - run: git fetch --depth 2
       - run: git checkout origin/master


### PR DESCRIPTION
I noticed that CI was taking longer than expected. The problem was that only `./target` is cached by default, but the zola binary is stored in `./zola/target`.