### PR TITLE
add a blog post announcing 2025H2 project goals

### DIFF
--- a/content/inside-rust/project-goals-2025h2-call-for-submissions.md
+++ b/content/inside-rust/project-goals-2025h2-call-for-submissions.md
@@ -5,8 +5,8 @@ authors = ["Niko Matsakis"]
 aliases = ["inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions.html"]
 
 [extra]
-team = "Leadership Council"
-team_url = "https://www.rust-lang.org/governance/teams/leadership-council"
+team = "the Project Goals Team"
+team_url = "https://www.rust-lang.org/governance/teams/goals"
 +++
 
 The Rust Project Goals program for 2025H2 is now open for submissions! If you've been thinking about tackling a significant improvement to Rust, now's the time to propose it. **The deadline for goal submissions is July 18th**.

--- a/content/inside-rust/project-goals-2025h2-call-for-submissions.md
+++ b/content/inside-rust/project-goals-2025h2-call-for-submissions.md
@@ -2,7 +2,6 @@
 path = "inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions"
 title = "Now accepting Project Goal proposals for 2025H2"
 authors = ["Niko Matsakis"]
-aliases = ["inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions.html"]
 
 [extra]
 team = "the Project Goals Team"

--- a/content/inside-rust/project-goals-2025h2-call-for-submissions.md
+++ b/content/inside-rust/project-goals-2025h2-call-for-submissions.md
@@ -1,0 +1,41 @@
++++
+path = "inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions"
+title = "Now accepting Project Goal proposals for 2025H2"
+authors = ["Niko Matsakis"]
+aliases = ["inside-rust/2025/06/23/project-goals-2025h2-call-for-submissions.html"]
+
+[extra]
+team = "Leadership Council"
+team_url = "https://www.rust-lang.org/governance/teams/leadership-council"
++++
+
+The Rust Project Goals program for 2025H2 is now open for submissions! If you've been thinking about tackling a significant improvement to Rust, now's the time to propose it. **The deadline for goal submissions is July 18th**.
+
+## What You Need to Know
+
+We hit some delays getting this round organized (life happens!), so we're adjusting our timeline. The 2025H2 goals will run from September through December instead of our usual schedule. We plan to get back on track with the regular schedule for 2026H1. Here's how 2025H2 is going to work:
+
+* **Now until July 18:** Goal submission period
+* **July 21 to August 1:** Prioritization discussions and flagship goal selection
+* **August 5 to August 8:** Public reviews of the draft RFC
+* **August 12 to August 31:** Final approval process
+* **September 1:** Goals officially begin!
+
+Ready to propose a goal? Here are the resources you need:
+
+* **[How to propose a goal](https://rust-lang.github.io/rust-project-goals/how_to/propose_a_goal.html)** - Step-by-step guide to crafting your proposal
+* **[2025H2 Program Overview](https://rust-lang.github.io/rust-project-goals/2025h2/index.html)** - See what's already been proposed and learn how the program works
+
+## And the survey says...
+
+In preparing to run this round of project goals, we created a survey of Rust contributors and project goal owners to get a sense for what was working and what was not. People felt that drafting goals helped clarify plans, get feedback from the Rust project, and find sponsorship. So, good news: project goals work!
+
+The survey also highlighted areas where we can do better. People want more concrete goals instead of abstract themes, better collaborative priority-setting, and a more sustainable organization that doesn't depend too heavily on any single person. The changes we mentioned in how the program runs are meant to address this feedback.
+
+## How to Get Involved
+
+Ready to propose a goal? [Follow the proposal guide](https://rust-lang.github.io/rust-project-goals/how_to/propose_a_goal.html) and open a PR on the rust-lang/rust-project-goals repository. You can also browse the [current proposals](https://rust-lang.github.io/rust-project-goals/2025h2/index.html) to see what others are working on.
+
+The Rust project goals program gives you a structured way to drive meaningful improvements to Rust with community support and visibility. Whether you're looking to stabilize a language feature, improve tooling, or refactor the compiler, we want to hear your ideas.
+
+**Remember: goal submissions close on July 18th.** Don't wait—start working on your proposal today!


### PR DESCRIPTION
Targeting next Monday, June 23rd. 

cc @rust-lang/goals @rust-lang/goal-owners 

[Rendered](https://github.com/nikomatsakis/blog.rust-lang.org/blob/2025h2-project-goals/content/inside-rust/project-goals-2025h2-call-for-submissions.md)