### PR TITLE
fix the addition instruction in the naked asm example

### DIFF
--- a/content/Rust-1.88.0.md
+++ b/content/Rust-1.88.0.md
@@ -53,7 +53,7 @@ For example:
 pub unsafe extern "sysv64" fn wrapping_add(a: u64, b: u64) -> u64 {
     // Equivalent to `a.wrapping_add(b)`.
     core::arch::naked_asm!(
-        "add rax, rdi, rsi",
+        "lea rax, [rdi + rsi]",
         "ret"
     );
 }


### PR DESCRIPTION
turns out LLVM does not have your back and will just let you emit an invalid `add` instruction with 3 operands.