### PR TITLE
Fix the broken links leading to 2025H1 goals in the latest update

### DIFF
--- a/content/Project-Goals-2025-May-Update.md
+++ b/content/Project-Goals-2025-May-Update.md
@@ -8,7 +8,7 @@ team = "the Goals team"
 team_url = "https://www.rust-lang.org/governance/teams/launching-pad#team-goals"
 +++
 
-The Rust project is currently working towards a [slate of 40 project goals](https://rust-lang.github.io/rust-project-goals/2025H1/goals.html), with 3 of them designated as [Flagship Goals](https://rust-lang.github.io/rust-project-goals/2025H1/goals.html#flagship-goals). This post provides selected updates on our progress towards these goals (or, in some cases, lack thereof). The full details for any particular goal are available in its associated [tracking issue on the rust-project-goals repository](https://github.com/rust-lang/rust-project-goals/issues?q=is%3Aissue%20state%3Aopen%20label%3AC-tracking-issue).
+The Rust project is currently working towards a [slate of 40 project goals](https://rust-lang.github.io/rust-project-goals/2025h1/goals.html), with 3 of them designated as [Flagship Goals](https://rust-lang.github.io/rust-project-goals/2025h1/goals.html#flagship-goals). This post provides selected updates on our progress towards these goals (or, in some cases, lack thereof). The full details for any particular goal are available in its associated [tracking issue on the rust-project-goals repository](https://github.com/rust-lang/rust-project-goals/issues?q=is%3Aissue%20state%3Aopen%20label%3AC-tracking-issue).
 
 ## Flagship goals
 


### PR DESCRIPTION
The links are case-sensitive and the post has `2025H1` instead of `2025h1`.

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/master/content/Project-Goals-2025-May-Update.md)