### PR TITLE
Note the nightly version of Rust/Cargo needed

### DIFF
--- a/content/inside-rust/call-for-testing-hint-mostly-unused.md
+++ b/content/inside-rust/call-for-testing-hint-mostly-unused.md
@@ -45,7 +45,12 @@ possible.
 
 Applying this option to key crates you depend on (and use only a small subset
 of) can provide a substantial reduction in compile time, for debug builds and
-especially for release builds.
+especially for release builds. The remainder of this post shows how to apply
+this option selectively using Cargo, when to use it, and how it performs.
+
+(Note that this option should *not* be applied to all crates, e.g. using
+`RUSTFLAGS`. See the rest of this post for guidance on when to apply it, and
+why it shouldn't be applied across the board.)
 
 ## How does this perform?
 

--- a/content/inside-rust/call-for-testing-hint-mostly-unused.md
+++ b/content/inside-rust/call-for-testing-hint-mostly-unused.md
@@ -151,7 +151,7 @@ allow the top-level crate to override.
 
 ## How do I help?
 
-We'd love for you to test out this feature on the latest Rust nightly compiler[^nightly].
+We'd love for you to test out this feature on the latest nightly Rust and Cargo (2025-07-16 or newer)[^nightly].
 
 [^nightly]: Make sure to run `rustup update nightly` (or however you manage your Rust releases).
 


### PR DESCRIPTION
The hint-mostly-unused call for testing got merged before the change in Cargo's
git repo had been synced to `rust-lang/rust`. That sync is happening in
https://github.com/rust-lang/rust/pull/143998 .

As soon as that change goes in and the new nightlies are built, this PR should
go in.


[Rendered](https://github.com/joshtriplett/blog.rust-lang.org/blob/hint-note-nightly-version-needed/content/inside-rust/call-for-testing-hint-mostly-unused.md)