### PR TITLE
typo: "not" -> "now"

### DIFF
--- a/content/Rust-1.89.0.md
+++ b/content/Rust-1.89.0.md
@@ -32,7 +32,7 @@ pub fn all_false<const LEN: usize>() -> [bool; LEN] {
 }
 ```
 
-Similar to the rules for when `_` is permitted as a type, `_` is not permitted as an argument to const generics when in a signature:
+Similar to the rules for when `_` is permitted as a type, `_` is now permitted as an argument to const generics when in a signature:
 
 ```rust
 // This is not allowed


### PR DESCRIPTION
typo: "not" -> "now"

[Rendered](https://github.com/CarlKCarlK/blog.rust-lang.org/blob/patch-1/content/Rust-1.89.0.md)