### PR TITLE
Change branch name from master to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:
@@ -44,7 +44,7 @@ jobs:
 
   pub_date:
     name: Check publication date for placeholder
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
 
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
       - run: cargo test -p front_matter -- --include-ignored date_is_set
 
   deploy:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
 
     needs: [pub_date, build]
 

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -18,8 +18,8 @@ jobs:
         run: cargo install --locked --git https://github.com/getzola/zola --rev 45d3f8d6285f0b47013c5fa31eb405332118af8b
 
       - run: git fetch --depth 2
-      - run: git checkout origin/master
+      - run: git checkout origin/main
       - name: Generate good snapshots
         run: INSTA_OUTPUT=none INSTA_UPDATE=always cargo test -p snapshot -- --include-ignored
-      - run: git checkout $GITHUB_SHA # merge of master+branch
+      - run: git checkout $GITHUB_SHA # merge of main+branch
       - run: INSTA_OUTPUT=none INSTA_UPDATE=no cargo test -p snapshot -- --include-ignored

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can also run these tests locally for a faster feedback cycle:
 
 - Make sure you have [cargo-insta](https://insta.rs/docs/quickstart/) installed.
 
-- Generate the good snapshots to compare against, usually based off the master branch:
+- Generate the good snapshots to compare against, usually based off the main branch:
   ```sh
   cargo insta test -p snapshot --accept --include-ignored
   ```

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -38,7 +38,7 @@
     </div>
     <div class="attribution">
       Maintained by the Rust Team. See a typo?
-      <a href="https://github.com/rust-lang/blog.rust-lang.org{% if page %}/edit/master/content/{{ page.relative_path }}{% endif %}" target="_blank" rel="noopener">Send a fix here</a>!
+      <a href="https://github.com/rust-lang/blog.rust-lang.org{% if page %}/edit/main/content/{{ page.relative_path }}{% endif %}" target="_blank" rel="noopener">Send a fix here</a>!
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Connects to #1687.

This will need someone with the right permissions to actually do the branch rename :)

Fixes: https://github.com/rust-lang/blog.rust-lang.org/issues/1687