### PR TITLE
Rust-1.89.0.md: split sentence into 2, for readability

### DIFF
--- a/content/Rust-1.89.0.md
+++ b/content/Rust-1.89.0.md
@@ -134,7 +134,7 @@ pub fn cool_simd_code(/* .. */) -> /* ... */ {
 
 ### Cross-compiled doctests
 
-Doctests will now be tested when running `cargo test --doc --target other_target`, this may result in some amount of breakage due to would-be-failing doctests now being tested.
+Doctests will now be tested when running `cargo test --doc --target other_target`. This may result in some amount of breakage due to would-be-failing doctests now being tested.
 
 Failing tests can be disabled by annotating the doctest with `ignore-<target>` ([docs](https://doc.rust-lang.org/stable/rustdoc/write-documentation/documentation-tests.html#ignoring-targets)):
 ```rust


### PR DESCRIPTION


[Rendered](https://github.com/tshepang/blog.rust-lang.org/blob/patch-1/content/Rust-1.89.0.md)