### PR TITLE
Meta-announce infra announcement zulip channel

### DIFF
--- a/content/inside-rust/infra-announcement-zulip-channel.md
+++ b/content/inside-rust/infra-announcement-zulip-channel.md
@@ -32,22 +32,18 @@ We will subscribe:
 - `gsoc-contributors`, `ospp-contributors` and `cloud-compute` marker team
   members
 
-with registered Zulip IDs[^team-repo] to the dedicated [`#infra/announcements`
-zulip channel][`#infra/announcements`].[^mute]
+with registered Zulip IDs to the dedicated [`#infra/announcements` zulip
+channel][`#infra/announcements`].[^mute]
 
 For project team members without registered Zulip IDs, you are encouraged to do
 so by updating your `people/<handle>.toml` entry in the [rust-lang/team]
 repository so that the Infrastructure Team can consistently announce project
 infrastructure changes that may impact you. 
 
-
-[^team-repo]: In the [rust-lang/team] repo. If your `people/<handle>.toml` entry
-    does not already have a `zulip-id` field, you can send a PR against the
-    [rust-lang/team] repo to update your `people/` entry with your Zulip ID.
 [^mute]: Note that you can mute specific topics that do not concern you
     specifically. We adopted this "blanket" announce approach because in our
     experience, not reaching impacted project team members and [Dev
-    Desktop][dev-desktop] user is significantly more problematic.
+    Desktop][dev-desktop] users is significantly more problematic.
 
 
 [infra-team]: https://rust-lang.org/governance/teams/infra/#team-infra


### PR DESCRIPTION
This is the "Internal Rust blog post" part of meta-announcing the infra announcement channel. Forge doc update and infra-team doc updates have already been merged.

Context is: [#t-infra > Communication method for dev desktops @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Communication.20method.20for.20dev.20desktops/near/536944066)

My current plan is only to _subscribe_ T-all and the gsoc/ospp/cloud-compute marker-teams, not automatically explicitly `@`-ping everyone (but happy to hear feedback for that).

r? @shepmaster

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/inside-rust/infra-announcement-zulip-channel.md)