### PR TITLE
this-development-cycle-in-cargo-1.90.md: fix typo

### DIFF
--- a/content/inside-rust/this-development-cycle-in-cargo-1.90.md
+++ b/content/inside-rust/this-development-cycle-in-cargo-1.90.md
@@ -353,7 +353,7 @@ This runs counter to the way the rest of Cargo works which creates warts in beha
 Some examples of problems with doctests are:
 - inability to run `cargo check` or `cargo clippy` on them
 - `cargo test --workspace` rebuilding doctests when there was no change
-- cargo can't collect "unused depednency" messages from rustc to identify which dependencies are unused across all dev-dependencies
+- cargo can't collect "unused dependency" messages from rustc to identify which dependencies are unused across all dev-dependencies
 
 This also affects future plans including:
 - Coverage reporting ([#13040](https://github.com/rust-lang/cargo/issues/13040))


### PR DESCRIPTION
"depednency" should be "dependency"

[Rendered](https://github.com/DanielEScherzer/blog.rust-lang.org/blob/patch-1/content/inside-rust/this-development-cycle-in-cargo-1.90.md)