### PR TITLE
fix: a11y issues

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -22,11 +22,11 @@
       <div class="four columns mt3 mt0-l">
         <h4>Social</h4>
         <div class="flex flex-row flex-wrap">
-          <a rel="me" href="https://social.rust-lang.org/@rust" target="_blank" rel="noopener" alt="mastodon link"><img src="{{ config.base_url | safe }}/images/mastodon.svg" alt="mastodon logo" title="Mastodon"/></a>
-          <a rel="me" href="https://bsky.app/profile/rust-lang.org" target="_blank" rel="noopener" alt="Bluesky link"><img src="{{ config.base_url | safe }}/images/bluesky.svg" alt="Bluesky logo" title="Bluesky"/></a>
-          <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" target="_blank" rel="noopener" alt="youtube link"><img style="padding-top: 6px; padding-bottom:6px" src="{{ config.base_url | safe }}/images/youtube.svg" alt="youtube logo" title="YouTube"/></a>
-          <a href="https://discord.gg/rust-lang" target="_blank" rel="noopener" alt="discord link"><img src="{{ config.base_url | safe }}/images/discord.svg" alt="discord logo" title="Discord"/></a>
-          <a href="https://github.com/rust-lang" target="_blank" rel="noopener" alt="github link"><img src="{{ config.base_url | safe }}/images/github.svg" alt="github logo" title="GitHub"/></a>
+          <a rel="me" href="https://social.rust-lang.org/@rust" target="_blank" rel="noopener"><img src="{{ config.base_url | safe }}/images/mastodon.svg" alt="Mastodon"/></a>
+          <a rel="me" href="https://bsky.app/profile/rust-lang.org" target="_blank" rel="noopener"><img src="{{ config.base_url | safe }}/images/bluesky.svg" alt="Bluesky"/></a>
+          <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" target="_blank" rel="noopener"><img style="padding-top: 6px; padding-bottom:6px" src="{{ config.base_url | safe }}/images/youtube.svg" alt="YouTube"/></a>
+          <a href="https://discord.gg/rust-lang" target="_blank" rel="noopener"><img src="{{ config.base_url | safe }}/images/discord.svg" alt="Discord"/></a>
+          <a href="https://github.com/rust-lang" target="_blank" rel="noopener"><img src="{{ config.base_url | safe }}/images/github.svg" alt="GitHub"/></a>
         </div>
         <h4 class="mt4 mb3">RSS</h4>
         <ul>

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -2,7 +2,7 @@
 <nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr4-ns">
   <div class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
     <a href="{{ config.base_url | safe }}{{ section.path | safe }}">
-      <img class="v-mid ml0-l rust-logo" alt="Rust Logo" src="{{ config.base_url | safe }}/images/rust-logo-blk.svg">
+      <img class="v-mid ml0-l rust-logo" alt="" src="{{ config.base_url | safe }}/images/rust-logo-blk.svg">
       <span class="dib ml1 ml0-l">{{ section.title }}</span>
     </a>
   </div>


### PR DESCRIPTION
This PR fixes two issues with the blog templates.

1. Remove the incorrect alt text and titles from the footer social links
2. Remove the redundant "Rust Logo" alt text from the top left blog link