### PR TITLE
add blog post about docs.rs changed default targets

### DIFF
--- a/content/docs-rs-changed-default-targets.md
+++ b/content/docs-rs-changed-default-targets.md
@@ -1,5 +1,5 @@
 +++
-path = "2025/10/15/docsrs-changed-default-targets"
+path = "2025/10/16/docsrs-changed-default-targets"
 title = "docs.rs: changed default targets"
 authors = ["Denis Cornehl"]
 
@@ -8,36 +8,49 @@ team = "the docs.rs team"
 team_url = "https://rust-lang.org/governance/teams/dev-tools/#team-docs-rs"
 +++
 
-With Apple's transition from x86_64 to its own silicon (ARM64), the Rust project
-has updated its platform support tiers.
+# Changes to default build targets on docs.rs
 
-Consequently, the `aarch64-apple-darwin` target has been promoted to Tier 1,
-while the `x86_64-apple-darwin` target has been demoted to Tier 2. You can read
-more about this change in
-[RFC 3671](https://github.com/rust-lang/rfcs/pull/3671) and
-[RFC 3841](https://github.com/rust-lang/rfcs/pull/3841).
+This post announces two changes to the list of default targets used to build
+documentation on docs.rs.
 
-To align with this ecosystem shift, docs.rs is updating its default build
-targets.
+Crate authors can specify a custom list of targets using
+[docs.rs metadata in `Cargo.toml`](https://docs.rs/about/metadata). If this
+metadata is not provided, docs.rs falls back to a default list. We are updating
+this list to better reflect the current state of the Rust ecosystem.
 
-Crates can provide [docs.rs metadata](https://docs.rs/about/metadata) to specify
-which targets to build for. If this metadata is not provided, docs.rs uses a
-default list of targets. We are now switching the default macOS target in this
-list from `x86_64-apple-darwin` to `aarch64-apple-darwin`.
+## Apple silicon (ARM64) replaces x86_64
 
-The new default target list is:
+Reflecting Apple's transition from x86_64 to its own ARM64 silicon, the Rust
+project has updated its platform support tiers. The `aarch64-apple-darwin`
+target is now Tier 1, while `x86_64-apple-darwin` has moved to Tier 2. You can
+read more about this in [RFC 3671](https://github.com/rust-lang/rfcs/pull/3671)
+and [RFC 3841](https://github.com/rust-lang/rfcs/pull/3841).
+
+To align with this, docs.rs will now use `aarch64-apple-darwin` as the default
+target for Apple platforms instead of `x86_64-apple-darwin`.
+
+## Linux ARM64 replaces 32-bit x86
+
+Support for 32-bit `i686` architectures is declining, and major Linux
+distributions have begun to phase it out.
+
+Consequently, we are replacing the `i686-unknown-linux-gnu` target with
+`aarch64-unknown-linux-gnu` in our default set.
+
+## New default target list
+
+The updated list of default targets is:
 
 - `x86_64-unknown-linux-gnu`
-- `aarch64-apple-darwin` (previously: `x86_64-apple-darwin`)
+- `aarch64-apple-darwin` (replaces `x86_64-apple-darwin`)
 - `x86_64-pc-windows-msvc`
-- `i686-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu` (replaces `i686-unknown-linux-gnu`)
 - `i686-pc-windows-msvc`
 
-## If your crate requires the old target list
+## Opting out
 
-If your crate needs to be built for the previous default target list, you can
-explicitly define it using [docs.rs metadata](https://docs.rs/about/metadata) in
-your `Cargo.toml`:
+If your crate requires the previous default target list, you can explicitly
+define it in your `Cargo.toml`:
 
 ```toml
 [package.metadata.docs.rs]
@@ -49,3 +62,6 @@ targets = [
     "i686-pc-windows-msvc"
 ]
 ```
+
+Note that docs.rs continues to support any target available in the Rust
+toolchain; only the _default_ list has changed.


### PR DESCRIPTION
coming from the promotion & demotion for the apple targets, we will change the list of default targets we build for crates, if they don't provide a list of targets. 

See https://github.com/rust-lang/docs.rs/issues/2926 and https://github.com/rust-lang/docs.rs/pull/2927 

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/docs-rs-changed-default-targets.md)