### PR TITLE
Fix claim about Git's default branch name

### DIFF
--- a/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
+++ b/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
@@ -8,7 +8,7 @@ team = "the Infra team"
 team_url = "https://www.rust-lang.org/governance/teams/infra#team-infra"
 +++
 
-We will be renaming the default branch of the [rust-lang/rust repository](https://github.com/rust-lang/rust) from `master` to `main` on 2025-11-10. We've chosen `main` specifically as it's the [new default in git][git-change] and the renaming will leverage the [GitHub tooling][github-tooling] built to make this easier.
+We will be renaming the default branch of the [rust-lang/rust repository](https://github.com/rust-lang/rust) from `master` to `main` on 2025-11-10. We've chosen `main` specifically as it's the default for newly-created repositories [in GitHub][github-change] and the renaming will leverage the [GitHub tooling][github-tooling] built to make this easier.
 
 If you maintain a tool that currently assumes the default branch of `rust-lang/rust` is named `master`, using `HEAD` instead will work both before and after the rename.
 
@@ -26,7 +26,7 @@ git remote prune origin
 
 If you have a fork of the `rust-lang/rust` repository on GitHub and would like to rename your default branch to match, you can follow [GitHub's instructions][github-how-to-rename].
 
-[git-change]: https://lore.kernel.org/git/pull.656.v4.git.1593009996.gitgitgadget@gmail.com/
+[github-change]: https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/
 
 [github-tooling]: https://github.com/github/renaming
 


### PR DESCRIPTION
The blog post about changing the primary branch name of `rust-lang/rust`, as written, claims that the default branch name of *Git*, the open-source version control tool originally written by Linus Torvalds, has changed.  As best I can determine, that's not true, at least as of Git v2.51.  The mailing list thread from 2020, linked in the post, certainly does not support this claim.  That thread discusses making the default branch name for newly-created repositories configurable, and it causes a warning to be shown if this is not configured (indicating that the default may change in the future), but the default when not configured has not been changed.

Conversely, *GitHub*, the service now owned by Microsoft, did change the default branch name for newly-created repositories on 2020-10-01. Probably this is what we mean instead.  Let's change the post to point to that.

cc @shepmaster @Kobzol @carols10cents

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md)