### PR TITLE
Update instructions for renaming rust-lang/rust default branch

### DIFF
--- a/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
+++ b/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
@@ -15,7 +15,7 @@ If you maintain a tool that currently assumes the default branch of `rust-lang/r
 
 After the rename, contributors will need to run a few git commands in their local checkout of the repository to update. Note that the specific commands that should be executed might differ based on the way you use git and how your local checkout is configured. We provide a guide below that we think should work for most use-cases, but your mileage may vary.
 
-Please try to follow the guide step-by-step, and if you run into any problems, feel free to ask in the [t-infra Zulip channel][infra-zulip].
+Please try to follow the guide step-by-step, and if you run into any problems, feel free to ask in this [Zulip channel][infra-help-zulip].
 
 ## Renaming your fork's default branch
 
@@ -31,10 +31,10 @@ Here is how you can update your fork's default branch:
 Execute the following git commands in your local checkout of the `rust` repository.
 
 Note that the instructions below make two assumptions:
-- They assume that you have a git remote called `upstream` that points to the `rust-lang/rust` repository and a remote called `origin` that points to your `<username>/rust` fork. Please update the commands accordingly if you use a different setup.
+- You have a git remote called `upstream` that points to the `rust-lang/rust` repository and a remote called `origin` that points to your `<username>/rust` fork. Please update the commands accordingly if you use a different setup.
   - You can find out which remotes you have configured using the `git remote -v` command.
-- They assume that your local `master` branch tracks the default branch of your *fork*, not the default branch of the *upstream* `rust-lang/rust` repository. If that is not the case, execute the commented `git branch` command instead.
-  - You can find which remote is your local branch tracking e.g. using `git branch -vv --contains master`.
+- Your local `master` branch tracks the default branch of your *fork*, not the default branch of the *upstream* `rust-lang/rust` repository. If that is not the case, execute the commented `git branch` command instead.
+  - You can find which remote your local `master` branch tracks by using `git branch -vv --contains master` (the tracked branch should be shown in square brackets).
 
 ```bash
 # Update the local branch name
@@ -59,4 +59,4 @@ git remote prune upstream
 
 [github-tooling]: https://github.com/github/renaming
 
-[infra-zulip]: (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Renaming.20the.20master.20branch.20for.20rust-lang.2Frust/with/554094625)
+[infra-help-zulip]: (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Help.20with.20updating.20rust-lang.2Frust.20default.20branch/with/554127642)


### PR DESCRIPTION
Discussed at https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Renaming.20the.20master.20branch.20for.20rust-lang.2Frust/with/554094625.


[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md)