### PR TITLE
Fix link in `renaming-the-default-branch-of-rust-lang-rust.md`

### DIFF
--- a/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
+++ b/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
@@ -59,4 +59,4 @@ git remote prune upstream
 
 [github-tooling]: https://github.com/github/renaming
 
-[infra-help-zulip]: (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Help.20with.20updating.20rust-lang.2Frust.20default.20branch/with/554127642)
+[infra-help-zulip]: https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Help.20with.20updating.20rust-lang.2Frust.20default.20branch/with/554127642


### PR DESCRIPTION
If the URL contains () it will take you to the address below(404 Not Found)

https://blog.rust-lang.org/inside-rust/2025/10/16/renaming-the-default-branch-of-rust-lang-rust/(https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Help.20with.20updating.20rust-lang.2Frust.20default.20branch/with/554127642)

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md)