### PR TITLE
Add a note that the rust-lang/rust default branch has happened

### DIFF
--- a/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
+++ b/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md
@@ -9,6 +9,8 @@ team = "the Infra team"
 team_url = "https://www.rust-lang.org/governance/teams/infra#team-infra"
 +++
 
+> The rename happened on November 10, 2025. The default branch of `rust-lang/rust` is now named `main`. 
+
 We will be renaming the default branch of the [rust-lang/rust repository](https://github.com/rust-lang/rust) from `master` to `main` on 2025-11-10. We've chosen `main` specifically as it's the default for newly-created repositories [in GitHub][github-change] and the renaming will leverage the [GitHub tooling][github-tooling] built to make this easier.
 
 If you maintain a tool that currently assumes the default branch of `rust-lang/rust` is named `master`, using `HEAD` instead will work both before and after the rename.


### PR DESCRIPTION
Should only be merged once this is actually true :)


[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/inside-rust/renaming-the-default-branch-of-rust-lang-rust.md)