### PR TITLE
Add a date the discussed crates.io policy change took effect

### DIFF
--- a/content/crates-io-usage-policy-rfc.md
+++ b/content/crates-io-usage-policy-rfc.md
@@ -9,6 +9,8 @@ team = "the crates.io team"
 team_url = "https://www.rust-lang.org/governance/teams/crates-io"
 +++
 
+> The RFC discussed in this blog post was accepted and became crates.io policy on November 7, 2023.
+
 Around the end of July the crates.io team opened an [RFC](https://github.com/rust-lang/rfcs/pull/3463) to update the current crates.io usage policies. This policy update addresses operational concerns of the crates.io community service that have arisen since the last significant policy update in 2017, particularly related to name squatting and spam. The RFC has caused considerable discussion, and most of the suggested improvements have since been integrated into the proposal.
 
 At the last team meeting the crates.io team decided to move the RFC forward and start the **final comment period** process.


### PR DESCRIPTION
I email people about empty crates and mention that crates.io policy changed, but it was pointed out that this blog post talks about the change potentially happening in the future, and there wasn't really a place that said when the policy went into effect.

[I liked the note added to the branch rename blog post](https://github.com/rust-lang/blog.rust-lang.org/pull/1739), so this PR adds a similar note for [when the RFC was merged](https://github.com/rust-lang/rfcs/pull/3463).

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/crates-io-usage-policy-rfc.md)