### PR TITLE
Lessons learned from the Rust Vision Doc

### DIFF
--- a/content/lessons-learned-from-the-rust-vision-doc-process.md
+++ b/content/lessons-learned-from-the-rust-vision-doc-process.md
@@ -1,5 +1,5 @@
 +++
-path = "9999/12/31/lessons-learned-from-the-rust-vision-doc-process"
+path = "2025/12/03/lessons-learned-from-the-rust-vision-doc-process"
 title = "Lessons learned from the Rust Vision Doc process"
 authors = ["Niko Matsakis"]
 


### PR DESCRIPTION
The first blog post resulting from the Rust Vision Doc effort. 

cc @rust-lang/project-vision-doc-2025 

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/lessons-learned-from-the-rust-vision-doc-process.md)