### PR TITLE
feat: add blog article for content team interview with jan david nose of rust infrastructure team

### DIFF
--- a/content/rustconf-2025-interview-with-jan-david-nose.md
+++ b/content/rustconf-2025-interview-with-jan-david-nose.md
@@ -4,7 +4,7 @@ title = "Interview with Jan David Nose"
 authors = ["Pete LeVasseur"]
 
 [extra]
-team = "Content Team"
+team = "the Content Team"
 team_url = "https://rust-lang.org/governance/teams/launching-pad/#team-content"
 +++
 


### PR DESCRIPTION
First blog post containing interview from [Content Team] efforts

[Content Team]: https://rust-lang.org/governance/teams/launching-pad/#team-content

cc: @rust-lang/content, @jdno, @MerrimanInd

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/rustconf-2025-interview-with-jan-david-nose.md)