### PR TITLE
Update team dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#e61c2109fe6a0b50d9f1870b4773189f29d88bbc"
+source = "git+https://github.com/rust-lang/team#e10bc7a2116cc3155efd7d2bb4b6608f37fee489"
 dependencies = [
  "indexmap",
  "serde",


### PR DESCRIPTION
The team API was not used for `cargo run blog` due to a breaking change.
