### PR TITLE
Add blog post about the new Funding page

### DIFF
--- a/content/making-it-easier-to-sponsor-rust-contributors.md
+++ b/content/making-it-easier-to-sponsor-rust-contributors.md
@@ -1,0 +1,29 @@
++++
+path = "2025/12/08/making-it-easier-to-sponsor-rust-contributors"
+title = "Making it easier to sponsor Rust contributors"
+authors = ["Jakub Beránek"]
+
+[extra]
+team = "Leadership Council"
+team_url = "https://rust-lang.org/governance/teams/leadership-council/"
++++
+
+> TLDR: You can now find a list of Rust contributors that you can sponsor on [this page][funding-page].
+
+Same as with many other open-source projects, Rust depends on a large number of contributors, many of whom make Rust better on a volunteer basis or are funded only for a fraction of their open-source contributions.
+
+Supporting these contributors is vital for the long-term health of the Rust language and its toolchain, so that it can keep its current level of quality, but also evolve going forward. Of course, this is nothing new, and there are currently several ongoing efforts to provide stable and sustainable funding for Rust maintainers, such as the [Rust Foundation Maintainer Fund](https://rustfoundation.org/media/announcing-the-rust-foundation-maintainers-fund/) or the [RustNL Maintainers Fund](https://rustnl.org/fund/). We are very happy about that!
+
+That being said, there are multiple ways of supporting the development of Rust. One of them is sponsoring individual Rust contributors directly, through services like GitHub Sponsors. This makes it possible even for individuals or small companies to financially support their favourite contributors. Every bit of funding helps!
+
+Previously, if you wanted to sponsor someone who works on Rust, you had to go on a detective hunt to figure out who are the people contributing to the Rust toolchain, if they are receiving sponsorships and through which service. This was a lot of work that could provide a barrier to sponsorships. So we simplified it!
+
+Now we have a dedicated [Funding page][funding-page] on the Rust website, which helpfully shows members of the Rust Project that are currently accepting funds through sponsoring[^shuffle]. You can click on the name of a contributor to find out what teams they are a part of and what kind of work they do in the Rust Project.
+
+> Note that the list of contributors accepting funding on this page is non-exhaustive. We made it opt in, so that contributors can decide on their own whether they want to be listed there or not.
+
+If you ever wanted to support the development of Rust "in the small", it is now [simpler][funding-page] than ever.
+
+[^shuffle]: The order of people on the funding page is shuffled on every page load to reduce unnecessary ordering bias.
+
+[funding-page]: https://rust-lang.org/funding/


### PR DESCRIPTION
This blog post should promote the new [Funding page](https://rust-lang.org/funding/) a bit.

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/making-it-easier-to-sponsor-rust-contributors.md)