### PR TITLE
Announce Rust 1.92 stable release

### DIFF
--- a/content/Rust-1.92.0.md
+++ b/content/Rust-1.92.0.md
@@ -30,7 +30,7 @@ It's worth noting that while this can result in compilation errors, it is still 
 
 These lints detect code which is likely to be broken by the never type stabilization. It is highly advised to fix them if they are reported in your crate graph.
 
-We believe there to be approximately 500 crates affected by this lint. Despite that, we believe this to be acceptable, as lints are not a breaking change and it will allow for stabilizing the never type in the future. For more in-depth justification, the Language Team's assessment can be read here: [rust-lang/rust#146167#issuecomment-3363795006](https://github.com/rust-lang/rust/pull/146167#issuecomment-3363795006).
+We believe there to be approximately 500 crates affected by this lint. Despite that, we believe this to be acceptable, as lints are not a breaking change and it will allow for stabilizing the never type in the future. For more in-depth justification, see the [Language Team's assessment](https://github.com/rust-lang/rust/pull/146167#issuecomment-3363795006).
 
 ### `unused_must_use` no longer warns about `Result<(), UninhabitedType>`
 


### PR DESCRIPTION
Draft release notes - https://github.com/rust-lang/rust/issues/149161

@rustbot ping relnotes-interest-group

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/Rust-1.92.0.md)