### PR TITLE
Add blog post about our GSoC 2026 participation

### DIFF
--- a/content/Rust-participates-in-GSoC-2026.md
+++ b/content/Rust-participates-in-GSoC-2026.md
@@ -1,5 +1,5 @@
 +++
-path = "2026/02/20/Rust-participates-in-GSoC-2026"
+path = "2026/02/19/Rust-participates-in-GSoC-2026"
 title = "Rust participates in Google Summer of Code 2026"
 authors = ["Jakub Beránek", "Jack Huey"]
 


### PR DESCRIPTION
Mostly a copy-paste of last year's [announcement](https://blog.rust-lang.org/2025/03/03/Rust-participates-in-GSoC-2025/), with some small updates.

Of course this should only be merged *if* we are actually selected by Google :) That being said, once that happens, I don't think we need to wait further, so I set the date to the day following the Google announcement (as it happens relatively late in the day).


[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/Rust-participates-in-GSoC-2026.md)