### PR TITLE
Add `Rust Debugging Survey 2026` blog post

### DIFF
--- a/content/rust-debugging-survey-2026.md
+++ b/content/rust-debugging-survey-2026.md
@@ -26,7 +26,7 @@ We already have some [plans][debug-test-suite-gsoc] to start improving debugging
 
 Filling the survey should take you approximately 5 minutes, and the survey is fully anonymous. We will accept submissions until Friday, March 13th, 2026. After the survey ends, we will evaluate the results and post key insights on this blog.
 
-We would like to thank Sam Kellam [@hashcatHitman](https://github.com/hashcatHitman) who did a lot of great work to prepare this survey.
+We would like to thank Sam Kellam ([@hashcatHitman](https://github.com/hashcatHitman)) who did a lot of great work to prepare this survey.
 
 We invite you to fill the survey, as your responses will help us improve the Rust debugging experience. Thank you!
 


### PR DESCRIPTION
This blog post publishes the Rust Debugging Survey 2026 (https://github.com/rust-lang/surveys/pull/392), which we have been discussing in https://rust-lang.zulipchat.com/#narrow/channel/402479-t-community.2Frust-survey/topic/Debugging.20survey/with/569941399.

I'm planning to merge the blog post on Monday February 23, when I plan to start the survey.

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/rust-debugging-survey-2026.md)