### PR TITLE
Post about a change to the crates.io malware notification policy

### DIFF
--- a/content/crates.io-malicious-crate-update.md
+++ b/content/crates.io-malicious-crate-update.md
@@ -1,5 +1,5 @@
 +++
-path = "2026/02/12/crates.io-malicious-crate-update"
+path = "2026/02/13/crates.io-malicious-crate-update"
 title = "crates.io: an update to the malicious crate notification policy"
 authors = ["Adam Harvey"]
 
@@ -20,17 +20,19 @@ Since we are announcing this policy change now, here is a retrospective summary 
 
 - `finch_cli_rust`, `finch-rst`, and `sha-rst`: the Rust security response working group was notified on December 9th, 2025 by Matthias Zepper of [National Genomics Infrastructure Sweden][ngi-sweden] that these crates were attempting to exfiltrate credentials by impersonating the `finch` and `finch_cli` crates. Advisories: [RUSTSEC-2025-0150][advisory-finch-rst], [RUSTSEC-2025-0151][advisory-sha-rst], [RUSTSEC-2025-0152][advisory-finch-cli-rust].
 - `polymarket-clients-sdk`: we were notified on February 6th by [Socket][socket] that this crate was attempting to exfiltrate credentials by impersonating the `polymarket-client-sdk` crate. Advisory: [RUSTSEC-2026-0010][advisory-polymarket].
+- `polymarket-client-sdks`: we were notified on February 13th that this crate was attempting to exfiltrate credentials by impersonating the `polymarket-client-sdk` crate. Advisory: [RUSTSEC-2026-0011][advisory-polymarket-deux].
 
 In all cases, the crates were deleted, the user accounts that published them were immediately disabled, and reports were made to upstream providers as appropriate.
 
 ## Thanks
 
-Once again, our thanks go to Matthias and Socket for their reports. We also want to thank Dirkjan Ochtman from the secure code working group, Emily Albini from the security response working group, and Walter Pearce from the [Rust Foundation][foundation] for aiding in the response.
+Once again, our thanks go to Matthias, Socket, and the reporter of `polymarket-client-sdks` for their reports. We also want to thank Dirkjan Ochtman from the secure code working group, Emily Albini from the security response working group, and Walter Pearce from the [Rust Foundation][foundation] for aiding in the response.
 
 [advisory-finch-cli-rust]: https://rustsec.org/advisories/RUSTSEC-2025-0152.html
 [advisory-finch-rst]: https://rustsec.org/advisories/RUSTSEC-2025-0150.html
 [advisory-sha-rst]: https://rustsec.org/advisories/RUSTSEC-2025-0151.html
 [advisory-polymarket]: https://rustsec.org/advisories/RUSTSEC-2026-0010.html
+[advisory-polymarket-deux]: https://rustsec.org/advisories/RUSTSEC-2026-0011.html
 [foundation]: https://foundation.rust-lang.org/
 [last-post]: https://blog.rust-lang.org/2025/12/05/crates.io-malicious-crates-finch-rust-and-sha-rust/
 [ngi-sweden]: https://ngisweden.scilifelab.se/


### PR DESCRIPTION
We can't publish this until https://github.com/rustsec/advisory-db/pull/2638 is merged and we have advisory numbers for three of the crates, so I'm opening this as a draft for now.

This also rolls in notifications about the last few malicious crates before the policy change.

More context: https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/how.20to.20announce.20takedowns.3F/near/563504478

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/crates.io-malicious-crate-update.md)