### PR TITLE
Added missing mod keywords to blog posts

### DIFF
--- a/content/Rust-1.66.0.md
+++ b/content/Rust-1.66.0.md
@@ -149,7 +149,7 @@ In Rust 1.62.0 we introduced `cargo add`, a command line utility to add dependen
 - [`core::hint::black_box`](https://doc.rust-lang.org/stable/std/hint/fn.black_box.html)
 - [`Duration::try_from_secs_{f32,f64}`](https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.try_from_secs_f32)
 - [`Option::unzip`](https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.unzip)
-- [`std::os::fd`](https://doc.rust-lang.org/stable/std/os/fd/index.html)
+- [`mod std::os::fd`](https://doc.rust-lang.org/stable/std/os/fd/index.html)
 
 ### Other changes
 

--- a/content/Rust-1.77.0.md
+++ b/content/Rust-1.77.0.md
@@ -87,7 +87,7 @@ flag in the relevant Cargo profile.
 
 - [`array::each_ref`](https://doc.rust-lang.org/stable/std/primitive.array.html#method.each_ref)
 - [`array::each_mut`](https://doc.rust-lang.org/stable/std/primitive.array.html#method.each_mut)
-- [`core::net`](https://doc.rust-lang.org/stable/core/net/index.html)
+- [`mod core::net`](https://doc.rust-lang.org/stable/core/net/index.html)
 - [`f32::round_ties_even`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.round_ties_even)
 - [`f64::round_ties_even`](https://doc.rust-lang.org/stable/std/primitive.f64.html#method.round_ties_even)
 - [`mem::offset_of!`](https://doc.rust-lang.org/stable/std/mem/macro.offset_of.html)

--- a/content/Rust-1.81.0.md
+++ b/content/Rust-1.81.0.md
@@ -96,7 +96,7 @@ note: the lint level is defined here
 
 ### Stabilized APIs
 
-- [`core::error`](https://doc.rust-lang.org/stable/core/error/index.html)
+- [`mod core::error`](https://doc.rust-lang.org/stable/core/error/index.html)
 - [`hint::assert_unchecked`](https://doc.rust-lang.org/stable/core/hint/fn.assert_unchecked.html)
 - [`fs::exists`](https://doc.rust-lang.org/stable/std/fs/fn.exists.html)
 - [`AtomicBool::fetch_not`](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicBool.html#method.fetch_not)


### PR DESCRIPTION
As the title says.

I was reading the latest 1.95.0 blog post a few days ago, and for some reason under "Stabilized APIs" the `mod core::range` stood out to me. I thought `mod` was a copy paste mistake.

However, after looking through the other blog posts, I noticed the common denominator was to have the `mod` keyword. So instead of removing it, I added the `mod` keyword the few places it was forgotten.


[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/63059ce98a0785e64f938b63f40ad952c7bb6bee/content/Rust-1.81.0.md)