### PR TITLE
Fix CI caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 env:
   # renovate: datasource=github-tags depName=rust lookupName=rust-lang/rust
   RUST_VERSION: 1.95.0
+  ZOLA_VERSION: 29540e9897dbe8aca388b13f7bdf615985f6ca2c
 
 jobs:
   lint:
@@ -37,8 +38,10 @@ jobs:
 
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          env-vars: CARGO RUST ZOLA_VERSION
       - name: Install Zola
-        run: cargo install --locked --git https://github.com/getzola/zola --rev 29540e9897dbe8aca388b13f7bdf615985f6ca2c
+        run: cargo install --locked --git https://github.com/getzola/zola --rev ${{ env.ZOLA_VERSION }}
 
       - run: zola build
       - run: cp CNAME ./public/

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -5,6 +5,7 @@ on:
 env:
   # renovate: datasource=github-tags depName=rust lookupName=rust-lang/rust
   RUST_VERSION: 1.95.0
+  ZOLA_VERSION: 29540e9897dbe8aca388b13f7bdf615985f6ca2c
 
 jobs:
   snapshot-tests:
@@ -14,8 +15,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: rustup override set ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          env-vars: CARGO RUST ZOLA_VERSION
       - name: Install Zola
-        run: cargo install --locked --git https://github.com/getzola/zola --rev 29540e9897dbe8aca388b13f7bdf615985f6ca2c
+        run: cargo install --locked --git https://github.com/getzola/zola --rev ${{ env.ZOLA_VERSION }}
 
       - run: git fetch --depth 2
       - run: git checkout origin/main


### PR DESCRIPTION
Whenever the Zola version is updated, this breaks the CI cache. The Swatinem/rust-cache action doesn't know anything about installed versions. This means that the cache won't get updated, but every time CI runs, cargo will install the new version.

This fixes it by including the version of Zola installed in the cache key.

Note that I think the caching in the `snapshot_tests.yml` file is broken. IIRC, PR jobs cannot share a cache between PR jobs. The only way to fix this is to have the job also run on `main`. Since this job is almost never run, I would recommend just removing the caching from it. I will leave that up to @senekor.
