### PR TITLE
Update footer.html

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -14,7 +14,7 @@
         <ul>
           <li><a href="https://www.rust-lang.org/policies/code-of-conduct">Code of Conduct</a></li>
           <li><a href="https://www.rust-lang.org/policies/licenses">Licenses</a></li>
-          <li><a href="https://www.rust-lang.org/policies/media-guide">Logo Policy and Media Guide</a></li>
+          <li><a href="https://rustfoundation.org/policy/rust-trademark-policy">Logo Policy and Media Guide</a></li>
           <li><a href="https://www.rust-lang.org/policies/security">Security Disclosures</a></li>
           <li><a href="https://www.rust-lang.org/policies">All Policies</a></li>
         </ul>


### PR DESCRIPTION
Currently the "Logo Policy and Media Guide" URL redirects from [1] to [2] where the actual trademark policy document resides. 

[1] https://www.rust-lang.org/policies/media-guide
[2] https://rustfoundation.org/policy/rust-trademark-policy

Instead of the redirection which is visible briefly, lets point to the correct URL where the actual content resides.

I've also verified all the other links here and they point to the correct URLs.