### PR TITLE
1.97.0: Detail that CARGO_BUILD_WARNINGS doesn't apply to MIRI

### DIFF
--- a/content/Rust-1.97.0.md
+++ b/content/Rust-1.97.0.md
@@ -48,7 +48,7 @@ See the previous [blog post](https://blog.rust-lang.org/2025/11/20/switching-to-
 ### Cargo support for denying warnings
 
 It's common practice to deny warnings in CI. Historically, doing so is
-typically done through `RUSTFLAGS=-Dwarnings`. With Rust 1.97, Cargo controls
+typically done through `RUSTFLAGS=-Dwarnings`. With Rust 1.97, Cargo (except for MIRI) controls
 how warnings interact with build success: either silencing them (via `allow`
 level), rendering without failing (default, `warn`), or denying them (via `deny`).
 


### PR DESCRIPTION
As per https://github.com/rust-lang/miri/issues/5202. Of course, feel free to re-word/edit... as you seem fit.

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/ba7f2035b3da5adaf939e5f3d8c579ed51f403cd/content/Rust-1.97.0.md)