### PR TITLE
Use merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 env:
   # renovate: datasource=github-tags depName=rust lookupName=rust-lang/rust
@@ -53,7 +54,7 @@ jobs:
 
   pub_date:
     name: Check publication date for placeholder
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'merge_group' }}
 
     runs-on: ubuntu-latest
     steps:
@@ -65,9 +66,9 @@ jobs:
       - run: cargo test -p front_matter -- --include-ignored date_is_set
 
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'merge_group' }}
 
-    needs: [pub_date, build]
+    needs: [ pub_date, build ]
 
     permissions:
       pages: write
@@ -81,3 +82,31 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
+  # Summary job for the merge queue.
+  # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+  conclusion:
+    # Keep `name` matching the status check.
+    name: CI
+    needs:
+      - lint
+      - spelling
+      - build
+      - pub_date
+      - deploy
+    # We need to ensure this job does *not* get skipped if its dependencies fail,
+    # because a skipped job is considered a success by GitHub. So we have to
+    # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run
+    # when the workflow is canceled manually.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      # Manually check the status of all dependencies. `if: failure()` does not work.
+      - name: Conclusion
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          # Print the dependent jobs to see them in the CI log
+          jq -C <<< "$NEEDS"
+          # Check if all jobs that we depend on (in the needs array) were successful.
+          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< "$NEEDS"


### PR DESCRIPTION
Requested in https://github.com/rust-lang/blog.rust-lang.org/pull/1892#issuecomment-5002484621.

Note that I left the CI running also on `main`, otherwise we wouldn't get proper caching in the merge queue, due to GitHub limitations.

We could deploy from `main`, but since we have a merge queue now, I think that deploying directly from it is slightly better.
