### PR TITLE
remove italics from light theme

### DIFF
--- a/night-owl-light.json
+++ b/night-owl-light.json
@@ -172,21 +172,18 @@
         "meta.diff.header.to-file"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#a2bffc"
       }
     },
     {
       "scope": "markup.deleted.diff",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#EF535090"
       }
     },
     {
       "scope": "markup.inserted.diff",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#4876d6ff"
       }
     },
@@ -201,7 +198,6 @@
         "punctuation.definition.comment"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#989fb1"
       }
     },
@@ -288,7 +284,6 @@
         "keyword"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -302,7 +297,6 @@
         "storage.type.property.tsx"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -336,7 +330,6 @@
     {
       "scope": "entity.name.function",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -370,7 +363,6 @@
     {
       "scope": "entity.other.attribute-name",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#4876d6"
       }
     },
@@ -432,7 +424,6 @@
     {
       "scope": "keyword.operator.relational",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -493,7 +484,6 @@
     {
       "scope": "meta.delimiter.period",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -567,7 +557,6 @@
     {
       "scope": "meta.selector",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -589,7 +578,6 @@
         "meta.tag.sgml.doctype"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -629,7 +617,6 @@
         "variable.other.object.property"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#111111"
       }
     },
@@ -646,7 +633,6 @@
         "entity.name.function"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#4876d6"
       }
     },
@@ -673,7 +659,6 @@
         "keyword.operator.expression.instanceof.tsx"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -797,9 +782,7 @@
       }
     },
     {
-      "scope": "italic",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -813,7 +796,6 @@
     {
       "scope": "quote",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#697098"
       }
     },
@@ -942,7 +924,6 @@
     {
       "scope": "source.elixir .punctuation.binary.elixir",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -973,7 +954,6 @@
         "source.go keyword.control.go"
       ],
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -1058,7 +1038,6 @@
     {
       "scope": "meta.tag.sgml.doctype.html",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },
@@ -1190,7 +1169,6 @@
     {
       "scope": "variable.other.object.js",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#0c969b"
       }
     },
@@ -1406,7 +1384,6 @@
     {
       "scope": "keyword.control",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#994cc3"
       }
     },


### PR DESCRIPTION
This was discussed on Zulip: [#t-website > blog syntax highlighting looks weird](https://rust-lang.zulipchat.com/#narrow/channel/542390-t-website/topic/blog.20syntax.20highlighting.20looks.20weird/with/614588842)