### PR TITLE
Improve styling of tasklists

### DIFF
--- a/sass/styles/app.scss
+++ b/sass/styles/app.scss
@@ -257,6 +257,25 @@ ul {
   list-style-type: disc;
 }
 
+/* Remove bullet from task lists. */
+/* The checkbox we render afterwards serves that purpose. */
+ul:has(> li > input[type="checkbox"]) {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+/* Add checkbox emoji in front of task list item and hide regular checkbox. */
+/* The regular checkbox is disabled, which is rendered with an unreadable gray color. */
+li > input[type="checkbox"] {
+  display: none
+}
+li:has(> input[type="checkbox"]:checked)::before {
+    content: "✅ ";
+}
+li:has(> input[type="checkbox"]:not(:checked))::before {
+    content: "⬜ ";
+}
+
 .posts {
   background-color: var(--gray);
   color: var(--body-foreground-color);

--- a/sass/styles/app.scss
+++ b/sass/styles/app.scss
@@ -76,7 +76,7 @@ body {
   background-color: var(--body-background-color);
   color: var(--body-color);
 
-  /* Ensure the footer is always at the bottom of the screen */
+  // Ensure the footer is always at the bottom of the screen
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -257,30 +257,30 @@ ul {
   list-style-type: disc;
 }
 
-/* Special handling of item markers for lists that contain task items (checkboxes). */
+// Special handling of item markers for lists that contain task items (checkboxes).
 ul:has(> li > input[type="checkbox"]) {
-  /* Create enough space to the left of the items for custom markers. */
+  // Create enough space to the left of the items for custom markers.
   padding-left: 2cap;
 
   > li:has(> input[type="checkbox"]) {
-    /* Hide default markers from task items. */
+    // Hide default markers from task items.
     list-style-type: none;
-    /* Set position to relative, so we can offset the custom marker relative to this element. */ 
+    // Set position to relative, so we can offset the custom marker relative to this element. 
     position: relative;
 
-    /* Hide default checkbox, which is rendered with an unreadable gray color. */
+    // Hide default checkbox, which is rendered with an unreadable gray color.
     > input[type="checkbox"] {
       display: none
     }
   }
-  /* Add custom emoji markers to task items. */
+  // Add custom emoji markers to task items.
   > li:has(> input[type="checkbox"]:checked)::before {
     content: "✅ ";
   }
   > li:has(> input[type="checkbox"]:not(:checked))::before {
       content: "⬜ ";
   }
-  /* Position custom markers for proper alignment. */
+  // Position custom markers for proper alignment.
   > li:has(> input[type="checkbox"])::before {
     position: absolute;
     left: -1.8em;

--- a/sass/styles/app.scss
+++ b/sass/styles/app.scss
@@ -257,11 +257,15 @@ ul {
   list-style-type: disc;
 }
 
-/* Remove bullet from task lists. */
-/* The checkbox we render afterwards serves that purpose. */
+/* For lists containing task items, create enough space for the custom emoji markers. */
 ul:has(> li > input[type="checkbox"]) {
+  padding-left: 1.8em;
+}
+
+/* Remove marker from task list items. */
+/* The checkbox we render afterwards serves that purpose. */
+ul > li:has(> input[type="checkbox"]) {
   list-style-type: none;
-  padding-left: 0;
 }
 
 /* Add checkbox emoji in front of task list item and hide regular checkbox. */
@@ -276,14 +280,13 @@ li:has(> input[type="checkbox"]:not(:checked))::before {
     content: "⬜ ";
 }
 
-/* Make paragraph next to checkbox aligned as if checkbox was a list bullet. */
+/* Offset custom task item marker by the space we created earlier. */
 li:has(> input[type="checkbox"]) {
   position: relative;
-  padding-left: 1.8em;
 }
 li:has(> input[type="checkbox"])::before {
   position: absolute;
-  left: 0;
+  left: -1.8em;
   top: 0;
 }
 

--- a/sass/styles/app.scss
+++ b/sass/styles/app.scss
@@ -276,6 +276,17 @@ li:has(> input[type="checkbox"]:not(:checked))::before {
     content: "⬜ ";
 }
 
+/* Make paragraph next to checkbox aligned as if checkbox was a list bullet. */
+li:has(> input[type="checkbox"]) {
+  position: relative;
+  padding-left: 1.8em;
+}
+li:has(> input[type="checkbox"])::before {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
 .posts {
   background-color: var(--gray);
   color: var(--body-foreground-color);

--- a/sass/styles/app.scss
+++ b/sass/styles/app.scss
@@ -257,37 +257,36 @@ ul {
   list-style-type: disc;
 }
 
-/* For lists containing task items, create enough space for the custom emoji markers. */
+/* Special handling of item markers for lists that contain task items (checkboxes). */
 ul:has(> li > input[type="checkbox"]) {
-  padding-left: 1.8em;
-}
+  /* Create enough space to the left of the items for custom markers. */
+  padding-left: 2cap;
 
-/* Remove marker from task list items. */
-/* The checkbox we render afterwards serves that purpose. */
-ul > li:has(> input[type="checkbox"]) {
-  list-style-type: none;
-}
+  > li:has(> input[type="checkbox"]) {
+    /* Hide default markers from task items. */
+    list-style-type: none;
+    /* Set position to relative, so we can offset the custom marker relative to this element. */ 
+    position: relative;
 
-/* Add checkbox emoji in front of task list item and hide regular checkbox. */
-/* The regular checkbox is disabled, which is rendered with an unreadable gray color. */
-li > input[type="checkbox"] {
-  display: none
-}
-li:has(> input[type="checkbox"]:checked)::before {
+    /* Hide default checkbox, which is rendered with an unreadable gray color. */
+    > input[type="checkbox"] {
+      display: none
+    }
+  }
+  /* Add custom emoji markers to task items. */
+  > li:has(> input[type="checkbox"]:checked)::before {
     content: "✅ ";
-}
-li:has(> input[type="checkbox"]:not(:checked))::before {
-    content: "⬜ ";
-}
-
-/* Offset custom task item marker by the space we created earlier. */
-li:has(> input[type="checkbox"]) {
-  position: relative;
-}
-li:has(> input[type="checkbox"])::before {
-  position: absolute;
-  left: -1.8em;
-  top: 0;
+  }
+  > li:has(> input[type="checkbox"]:not(:checked))::before {
+      content: "⬜ ";
+  }
+  /* Position custom markers for proper alignment. */
+  > li:has(> input[type="checkbox"])::before {
+    position: absolute;
+    left: -1.8em;
+    top: calc(1em - 1cap);
+    font-size: 1cap;
+  }
 }
 
 .posts {


### PR DESCRIPTION
closes #1904 

Also aligns text next to checkbox, so the checkbox visually serves the purpose of an item bullet.

before:
<img width="1749" height="924" alt="Image" src="https://github.com/user-attachments/assets/cc051c56-0acd-420f-b4fb-530ee5c4934a" />

after:
<img width="2416" height="957" alt="image" src="https://github.com/user-attachments/assets/96e2ff4a-cdf2-4cce-bbaf-6cbdaf6b3d6b" />
