### PR TITLE
Add Leadership Council September 2026 announcement post

### DIFF
--- a/content/inside-rust/leadership-council-repr-selection@9.md
+++ b/content/inside-rust/leadership-council-repr-selection@9.md
@@ -1,0 +1,57 @@
++++
+path = "inside-rust/2026/08/19/leadership-council-repr-selection"
+title = "Leadership Council September 2026 Representative Selections"
+authors = ["Jakub Beránek"]
+
+[extra]
+team = "Leadership Council"
+team_url = "https://www.rust-lang.org/governance/teams/leadership-council"
++++
+
+The selection process for representatives on the [Leadership Council] is starting today.
+
+Every six months, half of the council terms end.
+The following teams are up to choose their representative for the next year:
+
+* [Infra]
+* [Lang]
+* [Mods]
+
+We are aiming to have the teams confirm their choices by September 23, 2026, and for any possible new members to be ready to join the council meetings starting September 25th.
+
+[Infra]: https://www.rust-lang.org/governance/teams/infra
+[Lang]: https://www.rust-lang.org/governance/teams/lang
+[Mods]: https://www.rust-lang.org/governance/teams/moderation
+[Leadership Council]: https://www.rust-lang.org/governance/teams/leadership-council
+
+## Criteria for representatives
+
+Any member of the top-level team or a member of any of their subteams is eligible to be the representative.
+See [candidate criteria] for a description of what makes a good representative.
+
+[candidate criteria]: https://forge.rust-lang.org/governance/council.html#candidate-criteria
+
+There is a limit of at most two people affiliated with the same company or other legal entity being on the council [^affiliates].
+During the selection process, the council will consider the affiliation of candidates to decide if all choices will be compatible with that constraint.
+
+Representatives may serve multiple terms if the team decides to choose the same representative again.
+There is a soft limit of three terms.[^limit]
+It is recommended that teams rotate their representatives if possible to help avoid burnout and to spread the experience to a broader group of people.
+
+[^affiliates]: See [Limits on representatives from a single company/entity](https://forge.rust-lang.org/governance/council.html#limits-on-representatives-from-a-single-companyentity)
+
+[^limit]: See [Term limits](https://forge.rust-lang.org/governance/council.html#term-limits).
+
+## What do Representatives do?
+
+A representative provides a voice on the council to represent the interests of their teams and contribute to the long-term success of the Rust Project.
+A detailed description of the role may be found at the [Representative Role Description][role].
+
+[role]: https://github.com/rust-lang/leadership-council/blob/main/roles/council-representative.md
+
+## How should teams make their selection?
+
+The Leadership Council has put together a [Representative Selection Guide][guide] with recommendations for teams on how to go about choosing a representative.
+It is not a requirement that teams follow this guide; top-level teams may choose their own process.
+
+[guide]: https://github.com/rust-lang/leadership-council/blob/main/guides/representative-selection.md

--- a/content/inside-rust/leadership-council-repr-selection@9.md
+++ b/content/inside-rust/leadership-council-repr-selection@9.md
@@ -22,6 +22,7 @@ We are aiming to have the teams confirm their choices by September 23, 2026, and
 
 [Infra]: https://www.rust-lang.org/governance/teams/infra
 [Lang]: https://www.rust-lang.org/governance/teams/lang
+[Libs]: https://www.rust-lang.org/governance/teams/library
 [Mods]: https://www.rust-lang.org/governance/teams/moderation
 [Leadership Council]: https://www.rust-lang.org/governance/teams/leadership-council
 

--- a/content/inside-rust/leadership-council-repr-selection@9.md
+++ b/content/inside-rust/leadership-council-repr-selection@9.md
@@ -1,5 +1,5 @@
 +++
-path = "inside-rust/2026/08/19/leadership-council-repr-selection"
+path = "inside-rust/2026/08/18/leadership-council-repr-selection"
 title = "Leadership Council September 2026 Representative Selections"
 authors = ["Jakub Beránek"]
 

--- a/content/inside-rust/leadership-council-repr-selection@9.md
+++ b/content/inside-rust/leadership-council-repr-selection@9.md
@@ -15,6 +15,7 @@ The following teams are up to choose their representative for the next year:
 
 * [Infra]
 * [Lang]
+* [Libs]
 * [Mods]
 
 We are aiming to have the teams confirm their choices by September 23, 2026, and for any possible new members to be ready to join the council meetings starting September 25th.


### PR DESCRIPTION
We should start the elections ASAP. I set the publication date to Wednesday 19th, and the finalization date Wednesday 23rd in September, so that the new members can make the following meeting on the 25th.

CC @rust-lang/leadership-council

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/inside-rust/leadership-council-repr-selection@9.md)