### PR TITLE
Rust 1.98 announcement: add missing semicolon

### DIFF
--- a/content/Rust-1.98.0.md
+++ b/content/Rust-1.98.0.md
@@ -42,7 +42,7 @@ Prior to Rust 1.96.0, there was a bug in the Rust compiler, which made the follo
 
 ```rust
 let mut x = ManuallyDrop::new(Box::new(1));
-unsafe { ManuallyDrop::drop(&mut x) }
+unsafe { ManuallyDrop::drop(&mut x) };
 let x = x; // UB!
 ```
 


### PR DESCRIPTION
Cc @cuviper @Mark-Simulacrum 

[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/Rust-1.98.0.md)