### PR TITLE
Build Zola in debug mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,9 @@ jobs:
         with:
           env-vars: CARGO RUST ZOLA_VERSION
       - name: Install Zola
-        run: cargo install --locked --git https://github.com/getzola/zola --rev ${{ env.ZOLA_VERSION }}
+        # Installing in release can take >5 minutes (in case the GitHub cache is not primed).
+        # We don't really need the performance, so we prefer faster compilation.
+        run: cargo install --locked --git https://github.com/getzola/zola --rev ${{ env.ZOLA_VERSION }} --debug
 
       - run: zola build
       - run: cp CNAME ./public/

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           env-vars: CARGO RUST ZOLA_VERSION
       - name: Install Zola
-        run: cargo install --locked --git https://github.com/getzola/zola --rev ${{ env.ZOLA_VERSION }}
+        run: cargo install --locked --git https://github.com/getzola/zola --rev ${{ env.ZOLA_VERSION }} --debug
 
       - run: git fetch --depth 2
       - run: git checkout origin/main


### PR DESCRIPTION
I just waited >5 minutes for Zola to be built, and almost missed a deadline to publish a blog post that was synchronized with other Rust Foundation blog posts :sweat_smile: I think that we can make Zola's uncached compilation a bit faster.
