### PR TITLE
Fix placeholder date validation for Inside Rust posts

### DIFF
--- a/crates/front_matter/src/lib.rs
+++ b/crates/front_matter/src/lib.rs
@@ -282,7 +282,7 @@ The post {post} has abnormal front matter.
             let content = fs::read_to_string(&post).unwrap();
             let (front_matter, _) = parse(&content).unwrap();
 
-            if front_matter.path.starts_with("9999/12/31") {
+            if front_matter.path.contains("9999/12/31") {
                 let post = std::fs::canonicalize(post).unwrap().to_path_buf();
                 panic!(
                     "\n\

--- a/crates/front_matter/src/lib.rs
+++ b/crates/front_matter/src/lib.rs
@@ -283,12 +283,12 @@ The post {post} has abnormal front matter.
             let (front_matter, _) = parse(&content).unwrap();
 
             if front_matter.path.starts_with("9999/12/31") {
+                let post = std::fs::canonicalize(post).unwrap().to_path_buf();
                 panic!(
                     "\n\
-                    The post {slug} has a placeholder publication date.\n\
+                    The post {post:?} has a placeholder publication date.\n\
                     If you're about to publish it, please set it to today.\n\
                     ",
-                    slug = post.file_stem().unwrap().to_str().unwrap(),
                 );
             }
         }


### PR DESCRIPTION
https://github.com/rust-lang/blog.rust-lang.org/pull/1928 got through with a placeholder date, because it was an Inside Rust post, and the current test was not correctly validating those.
