### PR TITLE
inside-rust: cargo team membership change

### DIFF
--- a/content/inside-rust/welcome-dongpo-and-ross-to-the-cargo-team.md
+++ b/content/inside-rust/welcome-dongpo-and-ross-to-the-cargo-team.md
@@ -1,0 +1,65 @@
++++
+path = "inside-rust/2026/09/08/welcome-dongpo-and-ross-to-the-cargo-team"
+title = "Welcome Dongpo and Ross to the Cargo team"
+authors = ["Weihang Lo"]
+
+[extra]
+team = "the Cargo team"
+team_url = "https://www.rust-lang.org/governance/teams/dev-tools#team-cargo"
++++
+
+We are excited to welcome
+[Dongpo Liu](https://github.com/0xPoe) and
+[Ross Sullivan](https://github.com/ranger-ross)
+to the Cargo team!
+
+Dongpo has contributed to the Rust Project for years across different teams.
+He has been an important bridge between Cargo and other Rust teams
+and has brought insights and fresh ideas from across the Project.
+Dongpo also [integrated `cargo info`](https://github.com/rust-lang/cargo/pull/14141)
+from an external experiment into Cargo as a built-in command.
+That fulfilled a feature request that was nearly ten years old!
+He is also a kind and thoughtful reviewer.
+He always gives careful feedback
+and takes the time to help contributors.
+Fun fact: Dongpo joined the team in December 2024,
+but we never publicly announced it!
+
+Ross is brave and a deep thinker.
+In his first Cargo contributions,
+he jumped straight into one of Cargo's hardest topics:
+build artifact management and caching.
+He has shepherded the [new build directory layout](https://github.com/rust-lang/cargo/pull/17354)
+through design, implementation, and extensive community testing.
+This work lays a great foundation for cross-workspace caching
+and many other future optimizations.
+He is now leading the
+[2026 Project Goal for cross-workspace caching](https://goals.rust-lang.org/2026/cargo-cross-workspace-cache.html)!
+Ross also always takes responsibility for his work.
+He responds quickly in discussions,
+fixes regressions,
+and helps unblock other teams.
+We are very glad to have him on the team.
+
+At the same time,
+[Eric Huss](https://github.com/ehuss)
+has stepped down from the Cargo team.
+He contributed to the Rust Project for nearly a decade
+and served as a Cargo team lead for more than seven years.
+Eric's fingerprints can be found across basically every part of Cargo.
+He was our go-to person whenever we needed to understand the history of Cargo.
+In fact, his work reached far beyond Cargo.
+He maintained mdBook and books such as
+the Rust Reference and the Rustonomicon.
+He also helped lead the Edition work
+and represented the Dev tools team on the Leadership Council.
+Cargo and the Rust Project are much better because of him.
+Thank you, Eric!
+
+With Eric stepping down,
+the Cargo team has selected
+[Jacob Finkelman](https://github.com/Eh2406) and
+[Weihang Lo](https://github.com/weihanglo)
+as its new co-leads.
+Together, they will coordinate the team and support Cargo contributors.
+We look forward to this next chapter for the Cargo team.


### PR DESCRIPTION
cc @rust-lang/cargo @ehuss 

<img width="622" height="907" alt="Screenshot 2026-09-06 at 10 50 21" src="https://github.com/user-attachments/assets/33e53130-52c4-4af2-9087-6670019b408e" />


[Rendered](https://github.com/rust-lang/blog.rust-lang.org/blob/main/content/inside-rust/welcome-dongpo-and-ross-to-the-cargo-team.md)